### PR TITLE
Fixed process block not properly reporting error on failure

### DIFF
--- a/funnel/src/reading.ts
+++ b/funnel/src/reading.ts
@@ -53,12 +53,7 @@ async function processBlock(
         };
     } catch (err) {
         doLog(`[funnel::processBlock] caught ${err}`)
-        return {
-            timestamp: 0,
-            blockHash: "",
-            blockNumber: 0,
-            submittedData: [],
-        };
+        throw err;
     }
 }
 


### PR DESCRIPTION
Before, on error, `processBlock` would return an empty, but valid looking block, so the funnel as a whole would consider it the true result.

Now, it throws an exception, which will make this particular promise unresolved and removed by `internalReadDataMulti`.