### PR TITLE
Fixed match executor of lobby in progress bug

### DIFF
--- a/executors/src/match_executor.ts
+++ b/executors/src/match_executor.ts
@@ -49,6 +49,9 @@ const matchExecutorInitializer: MatchExecutorInitializer = {
           if (states.length === 0) return null // This shouldn't happen but good to check nonetheless
           const stateObj = stateMutator(states);
           const seed = seeds.find(s => s.round === this.currentRound);
+          if (!seed) {
+            return null;
+          }
           const randomnessGenerator = new Prando((seed as Seed).seed);
           const inputs = (userInputs).filter((ui: any) => ui.round == this.currentRound)
           const executor = roundExecutor.initialize(matchEnvironment, stateObj, inputs, randomnessGenerator, processTick)


### PR DESCRIPTION
Once reaching the current round (which does not yet have a valid round executor), the match executor would throw an unhandled exception due to not having a seed for that round