### PR TITLE
Misc small fixes

### DIFF
--- a/executors/src/match_executor.ts
+++ b/executors/src/match_executor.ts
@@ -45,19 +45,19 @@ const matchExecutorInitializer: MatchExecutorInitializer = {
         if (this.currentRound > maxRound) return null // null if reached end of the match
         if (!this.roundExecutor) { // Set round executor if null
           this.currentRound++
-          const states = (roundStates as any).filter((rs: any) => rs.round == this.currentRound)
+          const states = roundStates.filter((rs: any) => rs.round == this.currentRound)
           if (states.length === 0) return null // This shouldn't happen but good to check nonetheless
           const stateObj = stateMutator(states);
           const seed = seeds.find(s => s.round === this.currentRound);
           if (!seed) {
             return null;
           }
-          const randomnessGenerator = new Prando((seed as Seed).seed);
+          const randomnessGenerator = new Prando(seed.seed);
           const inputs = (userInputs).filter((ui: any) => ui.round == this.currentRound)
           const executor = roundExecutor.initialize(matchEnvironment, stateObj, inputs, randomnessGenerator, processTick)
           this.roundExecutor = executor;
         }
-        const event = (this.roundExecutor as any).tick()
+        const event = this.roundExecutor.tick()
 
         // If no event, it means that the previous round executor finished, so we recurse this function to increment the round and try again
         if (!event) {

--- a/executors/src/round_executor.ts
+++ b/executors/src/round_executor.ts
@@ -31,7 +31,7 @@ const roundExecutor: RoundExecutorInitializer = {
         return event
       },
       endState() {
-        for (let move of userInputs) this.tick()
+        for (const _ of userInputs) this.tick()
         return this.currentState
       },
     };

--- a/funnel/src/reading.ts
+++ b/funnel/src/reading.ts
@@ -93,5 +93,5 @@ export async function internalReadDataSingle(
 }
 
 // Timeout function for promises
-export const timeout = (prom: Promise<any>, time: number) =>
-    Promise.race([prom, new Promise((_r, rej) => setTimeout(rej, time))]);
+export const timeout = <T>(prom: Promise<T>, time: number) =>
+    Promise.race([prom, new Promise<T>((_r, rej) => setTimeout(rej, time))]);

--- a/paima-utils/src/types.ts
+++ b/paima-utils/src/types.ts
@@ -42,7 +42,7 @@ export type GameStateTransitionFunction = (
 export interface GameStateMachineInitializer {
   initialize: (
     databaseInfo: PoolConfig,
-    randomessProtocolEnum: any,
+    randomnessProtocolEnum: any,
     gameStateTransitionRouter: GameStateTransitionFunctionRouter,
     startBlockheight: number
   ) => GameStateMachine


### PR DESCRIPTION
Just a few small fixes that shouldn't affect runtime behavior

The one I didn't understand is why match_executor had multiple unnecessary casts to `any` 🤔 