### PR TITLE
SubmittedData now contains suppliedValue and funnel sets it

### DIFF
--- a/paima-funnel/src/batch-processing.ts
+++ b/paima-funnel/src/batch-processing.ts
@@ -87,13 +87,15 @@ async function verifySignatureCardano(
 
 async function processBatchedSubunit(
   web3: Web3,
-  input: string
+  input: string,
+  suppliedValue: string
 ): Promise<ValidatedSubmittedChainData> {
   const INNER_DIVIDER = '/';
   const INVALID_INPUT: ValidatedSubmittedChainData = {
     inputData: '',
     userAddress: '',
     inputNonce: '',
+    suppliedValue: '0',
     validated: false,
   };
 
@@ -118,6 +120,7 @@ async function processBatchedSubunit(
     inputData,
     userAddress,
     inputNonce,
+    suppliedValue,
     validated,
   };
 }
@@ -147,10 +150,15 @@ export async function processDataUnit(
     const afterLastIndex = elems.length - (hasClosingTilde ? 1 : 0);
 
     const prefix = elems[0];
+    const subunitCount = elems.length - 1;
+    const subunitValue = web3.utils
+      .toBN(unit.suppliedValue)
+      .div(web3.utils.toBN(subunitCount))
+      .toString(10);
 
     if (prefix === 'B') {
       const validatedSubUnits = await Promise.all(
-        elems.slice(1, afterLastIndex).map(elem => processBatchedSubunit(web3, elem))
+        elems.slice(1, afterLastIndex).map(elem => processBatchedSubunit(web3, elem, subunitValue))
       );
       return validatedSubUnits.filter(item => item.validated).map(unpackValidatedData);
     } else {

--- a/paima-funnel/src/reading.ts
+++ b/paima-funnel/src/reading.ts
@@ -30,6 +30,7 @@ async function getSubmittedData(
         userAddress: e.returnValues.userAddress,
         inputData: decodedData,
         inputNonce: '',
+        suppliedValue: e.returnValues.value,
       },
       block.number
     );

--- a/paima-sm/src/index.ts
+++ b/paima-sm/src/index.ts
@@ -56,6 +56,7 @@ const SM: GameStateMachineInitializer = {
             userAddress: '0x0',
             inputData: data.input_data,
             inputNonce: '',
+            suppliedValue: '0',
           };
           // Trigger STF
           const sqlQueries = await gameStateTransition(

--- a/paima-utils/src/types.ts
+++ b/paima-utils/src/types.ts
@@ -34,6 +34,7 @@ export interface SubmittedChainData {
   userAddress: ETHAddress;
   inputData: EncodedGameDataString;
   inputNonce: NonceString;
+  suppliedValue: string;
 }
 export interface ChainData {
   timestamp: number | string;


### PR DESCRIPTION
The supplied value from the storage contract even is now included with `SubmittedData` and can in principle be used e.g. in SM to control access.

Ideally, we should also consider a better way of storing large numbers than strings, e.g.:

- JS's `BigInt` (_may_ limit our targets, but probably won't?)
- `BN` which is e.g. included with `web3.js` (Extra `web3.js` dependency even in places where we might not need it)