### PR TITLE
Update paima-tx documentation

### DIFF
--- a/paima-tx/README.md
+++ b/paima-tx/README.md
@@ -9,11 +9,11 @@ Both Paima-tx and the Paima Contract are currently implemented to be usable on t
 Currently the library is in development, unpublished, and to be
 imported and used locally.
 
-The exported function `getStoreDataTxTemplate` can be used as follows to help build store data transaction structures to be sent using Metamask:
+The exported function `getTxTemplate` can be used as follows to help build store data transaction structures to be sent using Metamask:
 
 ```ts
 import { utf8ToHex, numberToHex } from "web3-utils";
-import { getStoreDataTxTemplate } from "paima-tx";
+import { getTxTemplate } from "paima-tx";
 
 ...
 
@@ -22,8 +22,9 @@ const storageContractAddress = "0x76b...882";
 const data = utf8ToHex("Hello!");
 const value = 123456;
 
-const txTemplate = getStoreDataTxTemplate(
+const txTemplate = getTxTemplate(
   storageContractAddress,
+  'paimaSubmitGameInput',
   data
 );
 


### PR DESCRIPTION
The documentation for paima-tx got out of this.

This PR updates the documentation to match https://github.com/PaimaStudios/catapult/blob/0e2a2e874f0a2719ff7b3e48185159b15fcafd40/middleware/src/helpers/posting.ts#L60