### PR TITLE
Add missing global prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "scripts": {
     "lint": "npm run prettier && npm run eslint",
     "cilint": "npm run cprettier && npm run eslint",
-    "build": "npm run prepare --workspaces --if-present && npx tsc --build tsconfig.build.json",
+    "prebuild": "npm run prebuild --workspaces --if-present",
+    "build": "npx tsc --build tsconfig.build.json",
     "cprettier": "prettier --check '**/*.{ts,tsx}'",
     "eslint": "eslint '**/*.{ts,tsx}' --ignore-path .gitignore",
     "prettier": "prettier --write '**/*.{ts,tsx}'",
-    "prepare": "husky install"
+    "prepare": "husky install && npm run prepare --workspaces --if-present"
   },
   "workspaces": [
     "./paima-utils",

--- a/paima-utils/package.json
+++ b/paima-utils/package.json
@@ -15,7 +15,8 @@
     ],
     "scripts": {
         "prepare": "npm run generate-types",
-        "build": "npm run generate-types && tsc",
+        "prebuild": "npm run generate-types",
+        "build": "tsc",
         "generate-types": "npx typechain --target=web3-v1 'src/artifacts/*.json' --out-dir src/contract-types",
         "test": "echo \"Error: no test specified\" && exit 1",
         "lint": "prettier --write '**/*.ts'"


### PR DESCRIPTION
Before this PR, running `npm run build` would not regenerate the solidity contract types which could cause unexpected build errors.

This PR fixes it by setting up the regeneration as a prebuild command and running the prebuild commands from the global `npm run build`

Note: `prebuild` is special npm syntax that is guaranteed to run before any `npm run build`