### PR TITLE
Remove catapult naming

### DIFF
--- a/paima-runtime/src/server.ts
+++ b/paima-runtime/src/server.ts
@@ -6,7 +6,7 @@ import { doLog } from '@paima/utils';
 
 const server: Express = express();
 const bodyParser = express.json();
-const port = process.env.CATAPULT_WEBSERVER_PORT || 3333; // default port to listen
+const port = process.env.WEBSERVER_PORT || 3333; // default port to listen
 
 server.use(cors());
 server.use(bodyParser);


### PR DESCRIPTION
Just a naming change I've noticed while adding the generic template repo.

Could be merged right away since the fallback was always the value we used (AFAIK) but would be better to adjust dependant repositories at the same time)