### PR TITLE
Remove husky from paima standalone sdk

### DIFF
--- a/paima-standalone/scripts/prepare_standalone_folders.sh
+++ b/paima-standalone/scripts/prepare_standalone_folders.sh
@@ -65,7 +65,8 @@ cp $module/README.md $SDK_PATH/$module/README.md
 cp $module/package.json $SDK_PATH/$module/package.json
 
 # Prepare SDK root folder files
-cp package.json $SDK_PATH/package.json
+# remove husky from "SDK" package.json to avoid using it in user templates
+sed 's/husky install && //g' package.json > $SDK_PATH/package.json
 cp package-lock.json $SDK_PATH/package-lock.json
 
 


### PR DESCRIPTION
Adding & removing .git folder was a bit of a hack and to keep `npm install` functionality the `.git` folder would have to remain.

So instead sdk `package.json` now doesn't use husky at all (as it shouldn't). We can later consider removing even more things (renaming, removing workspaces that are not present, packages that are not utilized etc. - but that's fine for now)