### PR TITLE
Move blockheight endpoint to paima engine

### DIFF
--- a/paima-runtime/src/index.ts
+++ b/paima-runtime/src/index.ts
@@ -46,6 +46,12 @@ const paimaEngine: PaimaRuntimeInitializer = {
         this.addGET('/backend_version', (req, res): void => {
           res.status(200).json(gameBackendVersion);
         });
+        this.addGET('/latest_processed_blockheight', (req, res): void => {
+          gameStateMachine
+            .latestBlockHeight()
+            .then(blockHeight => res.json({ block_height: blockHeight }))
+            .catch(_error => res.status(500));
+        });
 
         // initialize snapshot folder
         await initSnapshots();


### PR DESCRIPTION
Since we're removing internal paima DB tables from individual games and mw is abstracted to paima-engine as well, this endpoint should no longer be present on the game side. So I moved it over to `paima-engine`.

AFAIK this was the only endpoint called from `mw-core` but defined on the game side. (right?)
