### PR TITLE
Improve parsing type safety

### DIFF
--- a/paima-utils-backend/src/parser/PaimaParser.ts
+++ b/paima-utils-backend/src/parser/PaimaParser.ts
@@ -99,7 +99,15 @@ import { Grammars } from 'ebnf';
 type ParserValues = string | boolean | number | null;
 type ParserCommandExec = (keyName: string, input: string) => ParserValues;
 
-export type ParserCommands = Record<string, Record<string, ParserValues | ParserCommandExec>>;
+type InputKeys<T> = keyof Omit<T, 'input'>;
+export type ParserRecord<T = { input: string }> = Record<
+  InputKeys<T>,
+  ParserValues | ParserCommandExec
+> & {
+  renameCommand?: string;
+};
+
+export type ParserCommands = Record<string, ParserRecord>;
 
 export class PaimaParser {
   private readonly grammar: string;


### PR DESCRIPTION
Our parser was previously disconnected from type definitions of our inputs. This PR just adds a new type that can be used in games.

Combined with broken test setup tjos meant that eg. scheduled inputs were not really working in templates with this new parser (chess, RPS).