### PR TITLE
Implemented CDE Access Objects

### DIFF
--- a/paima-utils-backend/README.md
+++ b/paima-utils-backend/README.md
@@ -23,6 +23,23 @@ async function getUserNfts(readonlyDBConn: Pool, userAddress: string): Promise<s
 }
 ```
 
+### CDE Access Objects
+
+Similar results are achieved here, using CDE Access objects rather than using the CDE Access functions directly. Unfortunately, in the current implementation, TypeScript cannot predict the exact type of the abstractly constructed object.
+
+```ts
+const cdeAccess = await CdeAccessObject.fromTypeAndContractAddress(
+  pool,
+  ChainDataExtensionType.ERC721,
+  GameENV.NFT_CONTRACT
+);
+if (!cdeAccess) {
+  throw new Error('Unable to find registered CDE!');
+}
+const nftAccess = cdeAccess as Erc721AccessObject;
+const ownerNfts = await nftAccess.getOwnedNfts(userAddress);
+```
+
 ## Development
 
 Install dependencies:

--- a/paima-utils-backend/src/cde-access-objects.ts
+++ b/paima-utils-backend/src/cde-access-objects.ts
@@ -1,0 +1,100 @@
+import type { Pool } from 'pg';
+
+import { ChainDataExtensionType } from '@paima/utils';
+import { getSpecificChainDataExtension } from '@paima/db';
+
+import {
+  getCdeIdByAddress,
+  getCdeIdByTypeAndAddress,
+  getNftOwner,
+  getOwnedNfts,
+  getTokenBalance,
+} from './cde-access';
+
+export class CdeAccessObject {
+  protected readonlyDBConn: Pool;
+  protected cdeId: number;
+  protected cdeType: ChainDataExtensionType;
+
+  constructor(readonlyDBConn: Pool, cdeId: number, cdeType: ChainDataExtensionType) {
+    this.readonlyDBConn = readonlyDBConn;
+    this.cdeId = cdeId;
+    this.cdeType = cdeType;
+  }
+
+  static fromCdeIdAndType = async (
+    readonlyDBConn: Pool,
+    cdeId: number,
+    cdeType: ChainDataExtensionType
+  ): Promise<CdeAccessObject | null> => {
+    switch (cdeType) {
+      case ChainDataExtensionType.ERC20:
+        return new Erc20AccessObject(readonlyDBConn, cdeId);
+      case ChainDataExtensionType.ERC721:
+        return new Erc721AccessObject(readonlyDBConn, cdeId);
+      default:
+        return null;
+    }
+  };
+
+  static fromCdeId = async (
+    readonlyDBConn: Pool,
+    cdeId: number
+  ): Promise<CdeAccessObject | null> => {
+    const cdeConfigs = await getSpecificChainDataExtension.run({ cde_id: cdeId }, readonlyDBConn);
+    if (cdeConfigs.length !== 1) {
+      return null;
+    }
+    const cdeConfig = cdeConfigs[0];
+    return await this.fromCdeIdAndType(readonlyDBConn, cdeId, cdeConfig.cde_type);
+  };
+
+  static fromContractAddress = async (
+    readonlyDBConn: Pool,
+    contractAddress: string
+  ): Promise<CdeAccessObject | null> => {
+    const cdeIds = await getCdeIdByAddress(readonlyDBConn, contractAddress);
+    if (cdeIds.length !== 1) {
+      return null;
+    }
+    const cdeId = cdeIds[0];
+    return await this.fromCdeId(readonlyDBConn, cdeId);
+  };
+
+  static fromTypeAndContractAddress = async (
+    readonlyDBConn: Pool,
+    cdeType: ChainDataExtensionType,
+    contractAddress: string
+  ): Promise<CdeAccessObject | null> => {
+    const cdeIds = await getCdeIdByTypeAndAddress(readonlyDBConn, cdeType, contractAddress);
+    if (cdeIds.length !== 1) {
+      return null;
+    }
+    const cdeId = cdeIds[0];
+    return await this.fromCdeIdAndType(readonlyDBConn, cdeId, cdeType);
+  };
+}
+
+export class Erc20AccessObject extends CdeAccessObject {
+  constructor(readonlyDBConn: Pool, cdeId: number) {
+    super(readonlyDBConn, cdeId, ChainDataExtensionType.ERC20);
+  }
+
+  public getTokenBalance = async (walletAddress: string): Promise<string | null> => {
+    return await getTokenBalance(this.readonlyDBConn, this.cdeId, walletAddress);
+  };
+}
+
+export class Erc721AccessObject extends CdeAccessObject {
+  constructor(readonlyDBConn: Pool, cdeId: number) {
+    super(readonlyDBConn, cdeId, ChainDataExtensionType.ERC721);
+  }
+
+  public getNftOwner = async (tokenId: string): Promise<string | null> => {
+    return await getNftOwner(this.readonlyDBConn, this.cdeId, tokenId);
+  };
+
+  public getOwnedNfts = async (ownerAddress: string): Promise<string[]> => {
+    return await getOwnedNfts(this.readonlyDBConn, this.cdeId, ownerAddress);
+  };
+}

--- a/paima-utils-backend/src/index.ts
+++ b/paima-utils-backend/src/index.ts
@@ -3,5 +3,6 @@ export * from './cde-config/loading';
 export * from './cde-config/validation';
 export * from './cde-config/utils';
 export * from './cde-access';
+export * from './cde-access-objects';
 
 export * from './types';


### PR DESCRIPTION
A possible alternative to CDE Access functions. See README in `paima-utils-backen`d for example of use. Unfortunately, in the current implementation, TypeScript cannot seem to predict the exact type of the constructed CDE Access Object from the parameters of the static abstract constructors.