### PR TITLE
Updated MW endpoint address lowercasing

### DIFF
--- a/paima-mw-core/src/endpoints/accounts.ts
+++ b/paima-mw-core/src/endpoints/accounts.ts
@@ -45,7 +45,7 @@ async function userWalletLogin(loginType: string): Promise<Result<Wallet>> {
     ...response,
     result: {
       ...response.result,
-      walletAddress: response.result.walletAddress.toLowerCase(),
+      walletAddress: response.result.walletAddress,
     },
   };
 }

--- a/paima-mw-core/src/wallets/cardano.ts
+++ b/paima-mw-core/src/wallets/cardano.ts
@@ -177,7 +177,7 @@ export async function cardanoLoginWrapper(walletMode: WalletMode): Promise<Resul
   return {
     success: true,
     result: {
-      walletAddress: getCardanoAddress(),
+      walletAddress: getCardanoAddress().toLocaleLowerCase(),
     },
   };
 }

--- a/paima-mw-core/src/wallets/metamask.ts
+++ b/paima-mw-core/src/wallets/metamask.ts
@@ -185,7 +185,7 @@ export async function metamaskLoginWrapper(): Promise<Result<Wallet>> {
   return {
     success: true,
     result: {
-      walletAddress: getEthAddress(),
+      walletAddress: getEthAddress().toLocaleLowerCase(),
     },
   };
 }


### PR DESCRIPTION
Originally, all addresses were lowercased; Now, only EVM and Cardano are.