### PR TITLE
Fix for dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "eslint": "eslint '**/*.{ts,tsx}' --ignore-path .eslintignore",
     "prettier": "prettier --write '**/*.{ts,tsx}'",
     "prepare": "husky install && npm run prepare --workspaces --if-present",
-    "patch-standalone-dev": "sed -i 's/\"Paima Studios\",/\"Paima Studios\", \"license\": \"ISC\",/' paima-standalone/package.json ",
-    "unpatch-standalone-dev": "sed -i 's/\"Paima Studios\",.*/\"Paima Studios\",/' paima-standalone/package.json "
+    "patch-standalone-dev": "./paima-standalone/scripts/sed.sh patch",
+    "unpatch-standalone-dev": "./paima-standalone/scripts/sed.sh unpatch"
   },
   "workspaces": [
     "./paima-utils",

--- a/paima-standalone/scripts/sed.sh
+++ b/paima-standalone/scripts/sed.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+sedi () {
+    sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" -e "$@"
+}
+
+if [ "$1" == "patch" ]; then
+  sedi 's/"Paima Studios",/"Paima Studios", "license": "ISC",/' paima-standalone/package.json
+fi
+
+if [ "$1" == "unpatch" ]; then
+  sedi 's/"Paima Studios",.*/"Paima Studios",/' paima-standalone/package.json
+fi
+


### PR DESCRIPTION
pkg will not work without a public license found in: https://github.com/vercel/pkg/blob/e51efbe14ffd6d649420419cbd835146d1a7a612/lib/walker.ts#L119

--public-packages is not working as expected to bypass the error
```
If you do require building pkg binaries for other architectures and/or depend on a package with a broken
`license` in its `package.json`, you can override this behavior by either explicitly whitelisting packages to be public
using `--public-packages "packageA,packageB"` or setting all packages to public using `--public-packages "*"`
```

Neight --config flag can be removed due to the need for the asset setup.