### PR TITLE
Keep batcher rejection errors in responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paima/engine",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@paima/engine",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "workspaces": [
         "./paima-utils",
         "./paima-utils-backend",
@@ -15997,7 +15997,7 @@
         "@paima/utils": "1.0.0",
         "@polkadot/util": "^10.4.2",
         "@polkadot/util-crypto": "^10.4.2",
-        "algosdk": "*",
+        "algosdk": "^2.3.0",
         "prettier": "^2.6.2",
         "prettier-plugin-organize-imports": "^2.3.4",
         "tweetnacl": "^1.0.3",

--- a/paima-mw-core/src/errors.ts
+++ b/paima-mw-core/src/errors.ts
@@ -9,13 +9,17 @@ export type EndpointErrorFxn = (
   errorCode?: number
 ) => FailedResult;
 
-type PaimaErrorMessageMapping = Record<PaimaMiddlewareErrorCode, string>;
+// specific batcher error codes
+export const enum BatcherRejectionCode {
+  ADDRESS_NOT_ALLOWED = 4,
+}
 
 export const FE_ERR_OK = 0;
 export const FE_ERR_GENERIC = 1;
 export const FE_ERR_METAMASK_NOT_INSTALLED = 2;
 export const FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED = 3;
 export const FE_ERR_BATCHER_REJECTED_INPUT = 4;
+export const FE_ERR_BATCHER_LIMIT_REACHED = 5;
 
 export const enum PaimaMiddlewareErrorCode {
   OK,
@@ -55,7 +59,7 @@ export const enum PaimaMiddlewareErrorCode {
   FINAL_PAIMA_GENERIC_ERROR, // only to be used as a counter
 }
 
-export const PAIMA_MIDDLEWARE_ERROR_MESSAGES: PaimaErrorMessageMapping = {
+export const PAIMA_MIDDLEWARE_ERROR_MESSAGES: Record<PaimaMiddlewareErrorCode, string> = {
   [PaimaMiddlewareErrorCode.OK]: '',
   [PaimaMiddlewareErrorCode.UNKNOWN]: 'Unknown error',
   [PaimaMiddlewareErrorCode.EVM_WALLET_NOT_INSTALLED]: 'Selected EVM wallet not installed',

--- a/paima-mw-core/src/types.ts
+++ b/paima-mw-core/src/types.ts
@@ -77,6 +77,7 @@ interface BatcherPostResponseSuccessful {
 interface BatcherPostResponseUnsuccessful {
   success: false;
   message: string;
+  code?: number;
 }
 
 export type BatcherPostResponse = BatcherPostResponseSuccessful | BatcherPostResponseUnsuccessful;


### PR DESCRIPTION
`postConciseData` now forwards batcher error codes and batcher rejection is sent from `verifyBatcherSubmission` too (not just `submitToBatcher`)

disclaimer:
- most likely not compatible with JW (priority for updating?)