### PR TITLE
Stop the batcher from repeating failed txs in a loop

### DIFF
--- a/batcher/batched-transaction-poster/src/index.ts
+++ b/batcher/batched-transaction-poster/src/index.ts
@@ -125,6 +125,7 @@ class BatchedTransactionPoster {
         transactionHash = postedMessage[1];
       } catch (postError) {
         await this.rejectPostedStates(hashes);
+        await this.deletePostedInputs(ids);
         return ids.length;
       }
 


### PR DESCRIPTION
The batcher works by calling `postingRound` in a loop, constantly checking for txs that haven't been set yet.

Normally this is fine, but if `this.postMessage(batchedTransaction)` fails (ex: due to the transaction reverting), then the transaction never gets updated in the DB and will just be retried constantly as the batcher doesn't know it's processed already.

This PR properly marks the transactions as rejected, and shuts down the process if marking transactions as failed doesn't work