### PR TITLE
Emulated blocks: fix potentially skipping blocks on a crash

### DIFF
--- a/engine/paima-funnel/src/funnels/FunnelCache.ts
+++ b/engine/paima-funnel/src/funnels/FunnelCache.ts
@@ -16,8 +16,10 @@ export class FunnelCacheManager {
   public cacheEntries: CacheMapType = {};
 
   public clear(): void {
-    for (const entry of Object.values<FunnelCacheEntry>(this.cacheEntries)) {
-      entry.clear();
+    for (const entry of Object.getOwnPropertySymbols(this.cacheEntries) as Array<
+      keyof CacheMapType
+    >) {
+      this.cacheEntries[entry]?.clear();
     }
   }
 }

--- a/engine/paima-funnel/src/funnels/emulated/funnel.ts
+++ b/engine/paima-funnel/src/funnels/emulated/funnel.ts
@@ -98,10 +98,7 @@ export class EmulatedBlocksFunnel extends BaseFunnel {
         const latestAvailableBlockNumber = this.sharedData.cacheManager.cacheEntries[
           RpcCacheEntry.SYMBOL
         ]?.getState(ENV.CHAIN_ID);
-        if (
-          latestAvailableBlockNumber == null ||
-          latestAvailableBlockNumber.state === RpcRequestState.NotRequested
-        )
+        if (latestAvailableBlockNumber?.state !== RpcRequestState.HasResult)
           throw new Error(`latestAvailableBlockNumber missing from cache for ${ENV.CHAIN_ID}`);
 
         // check if the chunk we read matches the latest block known by the RPC endpoint
@@ -334,9 +331,6 @@ export class EmulatedBlocksFunnel extends BaseFunnel {
 
     // we only want to pop off the queue the entries that correspond for the next ChainData
     // for the rest, we leave them in the queue to be fetched in the next readData call
-    if (this.processingQueue.length === 0) {
-    } else if (this.processingQueue[0].timestamp >= nextBlockEndTimestamp) {
-    }
     const mergedBlocks: ChainData[] = [];
     while (
       this.processingQueue.length > 0 &&

--- a/engine/paima-runtime/src/runtime-loops.ts
+++ b/engine/paima-runtime/src/runtime-loops.ts
@@ -277,7 +277,7 @@ async function processSyncBlockData(
   exitIfStopped(run);
 
   // note: every state machine update is its own SQL transaction
-  // this is to ensure things like shutting down and taking snapshots properly sees SM updats
+  // this is to ensure things like shutting down and taking snapshots properly sees SM updates
   const success = await tx<boolean>(gameStateMachine.getReadWriteDbConn(), async dbTx => {
     // Before processing -- sanity check of block height:
     if (!(await blockPreProcess(dbTx, gameStateMachine, chainData.blockNumber, pollingPeriod))) {


### PR DESCRIPTION
When an error gets thrown while fetching/processing a new block in Paima, the funnel cache is cleared so the funnel can cleanly restart

There was a bug though where clearing the cache would fail as symbols were not iterated properly