### PR TITLE
Dynamically import crypto-specific packages

### DIFF
--- a/packages/paima-sdk/paima-crypto/src/cardano.ts
+++ b/packages/paima-sdk/paima-crypto/src/cardano.ts
@@ -1,4 +1,3 @@
-import verifyCardanoDataSignature from '@cardano-foundation/cardano-verify-datasignature';
 import { doLog } from '@paima/utils';
 import type { IVerify } from './IVerify';
 
@@ -17,6 +16,9 @@ export class CardanoCrypto implements IVerify {
       if (!signature || !key || remainder.length > 0) {
         return false;
       }
+      const { default: verifyCardanoDataSignature } = await import(
+        '@cardano-foundation/cardano-verify-datasignature'
+      );
       return verifyCardanoDataSignature(signature, key, message, userAddress);
     } catch (err) {
       doLog('[address-validator] error verifying cardano signature:', err);

--- a/packages/paima-sdk/paima-crypto/src/polkadot.ts
+++ b/packages/paima-sdk/paima-crypto/src/polkadot.ts
@@ -1,5 +1,3 @@
-import { cryptoWaitReady, decodeAddress, signatureVerify } from '@polkadot/util-crypto';
-import { u8aToHex } from '@polkadot/util';
 import { doLog } from '@paima/utils';
 import type { IVerify } from './IVerify';
 
@@ -14,6 +12,10 @@ export class PolkadotCrypto implements IVerify {
     signature: string
   ): Promise<boolean> => {
     try {
+      const { cryptoWaitReady, decodeAddress, signatureVerify } = await import(
+        '@polkadot/util-crypto'
+      );
+      const { u8aToHex } = await import('@polkadot/util');
       await cryptoWaitReady();
       const publicKey = decodeAddress(userAddress);
       const hexPublicKey = u8aToHex(publicKey);

--- a/packages/paima-sdk/paima-providers/src/algorand.ts
+++ b/packages/paima-sdk/paima-providers/src/algorand.ts
@@ -1,4 +1,4 @@
-import { PeraWalletConnect } from '@perawallet/connect';
+import type { PeraWalletConnect } from '@perawallet/connect';
 import type { ActiveConnection, GameInfo, IConnector, IProvider, UserSignature } from './IProvider';
 import { CryptoManager } from '@paima/crypto';
 import { uint8ArrayToHexString } from '@paima/utils';
@@ -44,6 +44,7 @@ export class AlgorandConnector implements IConnector<AlgorandApi> {
     if (name !== SupportedAlgorandWallets.PERA) {
       throw new UnsupportedWallet(`AlgorandProvider: unknown connection type ${name}`);
     }
+    const { PeraWalletConnect } = await import('@perawallet/connect');
     const peraWallet = new PeraWalletConnect();
     return await this.connectExternal(gameInfo, {
       metadata: {
@@ -89,7 +90,7 @@ export class AlgorandProvider implements IProvider<AlgorandApi> {
     return this.address;
   };
   signMessage = async (message: string): Promise<UserSignature> => {
-    const txn = CryptoManager.Algorand().buildAlgorandTransaction(this.getAddress(), message);
+    const txn = await CryptoManager.Algorand().buildAlgorandTransaction(this.getAddress(), message);
     const signerTx = {
       txn,
       signers: [this.getAddress()],
@@ -101,7 +102,7 @@ export class AlgorandProvider implements IProvider<AlgorandApi> {
         `[signMessageAlgorand] invalid number of signatures returned: ${signedTxs.length}`
       );
     }
-    const signedTx = CryptoManager.Algorand().decodeSignedTransaction(signedTxs[0]);
+    const signedTx = await CryptoManager.Algorand().decodeSignedTransaction(signedTxs[0]);
     const signature = signedTx.sig;
     if (!signature) {
       throw new ProviderApiError(`[signMessageAlgorand] signature missing in signed Tx`);

--- a/packages/paima-sdk/paima-providers/src/polkadot.ts
+++ b/packages/paima-sdk/paima-providers/src/polkadot.ts
@@ -1,9 +1,3 @@
-import {
-  web3Accounts,
-  web3Enable,
-  web3FromAddress,
-  web3FromSource,
-} from '@polkadot/extension-dapp';
 import type { ActiveConnection, GameInfo, IConnector, IProvider, UserSignature } from './IProvider';
 import {
   ProviderApiError,
@@ -32,6 +26,7 @@ export class PolkadotConnector implements IConnector<PolkadotApi> {
     if (this.provider != null) {
       return this.provider;
     }
+    const { web3Accounts, web3Enable, web3FromAddress } = await import('@polkadot/extension-dapp');
     const extensions = await web3Enable(gameInfo.gameName);
     if (extensions.length === 0) {
       throw new WalletNotFound(`[polkadot] no extension detected`);
@@ -60,6 +55,8 @@ export class PolkadotConnector implements IConnector<PolkadotApi> {
     if (this.provider?.getConnection().metadata?.name === name) {
       return this.provider;
     }
+
+    const { web3Enable, web3FromSource } = await import('@polkadot/extension-dapp');
 
     await web3Enable(gameInfo.gameName);
     try {


### PR DESCRIPTION
Previously, packages for cryptocurrencies were loaded by default when you setup paima-sdk. This is wasteful since you don't actually care about initializing these potentially expensive packages unless you actually intend to use them for your game

To tackle this, all of these packages were moved to dynamic imports. 

This should also, at the same time, minimize the impact of https://github.com/PaimaStudios/paima-game-templates/issues/46