### PR TITLE
Flexible providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,5 @@
     "./packages/*/*"
   ],
   "dependencies": {
-    "assert-never": "^1.2.1"
   }
 }

--- a/packages/batcher/address-validator/package.json
+++ b/packages/batcher/address-validator/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "pg": "^8.7.3",
-    "web3": "1.10.0"
+    "web3": "1.10.0",
+    "assert-never": "^1.2.1"
   },
   "devDependencies": {
     "@types/pg": "^8.6.5"

--- a/packages/batcher/utils/package.json
+++ b/packages/batcher/utils/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@truffle/hdwallet-provider": "^2.1.15",
-    "web3": "1.10.0"
+    "web3": "1.10.0",
+    "assert-never": "^1.2.1"
   }
 }

--- a/packages/engine/paima-funnel/package.json
+++ b/packages/engine/paima-funnel/package.json
@@ -17,5 +17,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "assert-never": "^1.2.1"
   }
 }

--- a/packages/engine/paima-funnel/src/cde/erc20Deposit.ts
+++ b/packages/engine/paima-funnel/src/cde/erc20Deposit.ts
@@ -12,7 +12,7 @@ export default async function getCdeData(
   // https://github.com/dethcrypto/TypeChain/issues/767
   const events = (await timeout(
     extension.contract.getPastEvents('Transfer', {
-      filter: { to: extension.depositAddress.toLocaleLowerCase() },
+      filter: { to: extension.depositAddress.toLowerCase() },
       fromBlock: fromBlock,
       toBlock: toBlock,
     }),

--- a/packages/engine/paima-runtime/package.json
+++ b/packages/engine/paima-runtime/package.json
@@ -17,7 +17,8 @@
     "express": "^4.18.1",
     "fnv-plus": "^1.3.1",
     "json-stable-stringify": "^1.0.2",
-    "yaml": "^2.3.1"
+    "yaml": "^2.3.1",
+    "assert-never": "^1.2.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/packages/engine/paima-sm/package.json
+++ b/packages/engine/paima-sm/package.json
@@ -14,5 +14,6 @@
   },
   "author": "Paima Studios",
   "dependencies": {
+    "assert-never": "^1.2.1"
   }
 }

--- a/packages/paima-sdk/paima-mw-core/package.json
+++ b/packages/paima-sdk/paima-mw-core/package.json
@@ -40,6 +40,7 @@
     "@paima/utils": "1.1.5",
     "@paima/providers": "1.1.5",
     "@paima/concise": "1.1.5",
-    "@paima/prando": "1.1.5"
+    "@paima/prando": "1.1.5",
+    "assert-never": "^1.2.1"
   }
 }

--- a/packages/paima-sdk/paima-mw-core/src/endpoints/accounts.ts
+++ b/packages/paima-sdk/paima-mw-core/src/endpoints/accounts.ts
@@ -5,7 +5,7 @@ import {
 } from '../helpers/auxiliary-queries';
 import { checkCardanoWalletStatus } from '../wallets/cardano';
 import { checkEthWalletStatus } from '../wallets/evm';
-import { specificWalletLogin, stringToWalletMode } from '../wallets/wallets';
+import { specificWalletLogin } from '../wallets/wallets';
 import {
   getEmulatedBlocksActive,
   getPostingMode,
@@ -14,6 +14,7 @@ import {
   setEmulatedBlocksInactive,
 } from '../state';
 import type { Result, OldResult, Wallet } from '../types';
+import type { LoginInfo } from '../wallets/wallet-modes';
 
 /**
  * Wrapper function for all wallet status checking functions
@@ -39,15 +40,10 @@ async function checkWalletStatus(): Promise<OldResult> {
  * thus allowing the game to get past the login screen.
  * @param preferBatchedMode - If true (or truthy value) even EVM wallet inputs will be batched.
  */
-async function userWalletLogin(
-  loginType: string,
-  preferBatchedMode: boolean = false
-): Promise<Result<Wallet>> {
+async function userWalletLogin(loginInfo: LoginInfo): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('userWalletLogin');
 
-  const walletMode = stringToWalletMode(loginType);
-  // Unity bridge uses 0|1 instead of booleans
-  const response = await specificWalletLogin(walletMode, !!preferBatchedMode);
+  const response = await specificWalletLogin(loginInfo);
   if (!response.success) {
     return response;
   }

--- a/packages/paima-sdk/paima-mw-core/src/endpoints/internal.ts
+++ b/packages/paima-sdk/paima-mw-core/src/endpoints/internal.ts
@@ -3,7 +3,6 @@ import { buildEndpointErrorFxn, PaimaMiddlewareErrorCode } from '../errors';
 import {
   getActiveAddress,
   getChainUri,
-  getGameName,
   getPostingInfo,
   setAutomaticMode,
   setBackendUri,
@@ -15,17 +14,14 @@ import {
   setUnbatchedMode,
 } from '../state';
 import type { PostingInfo, PostingModeSwitchResult, Result, Wallet } from '../types';
-import { specificWalletLogin, stringToWalletMode } from '../wallets/wallets';
+import { specificWalletLogin } from '../wallets/wallets';
 import { emulatedBlocksActiveOnBackend } from '../helpers/auxiliary-queries';
 import { TruffleConnector } from '@paima/providers';
 import HDWalletProvider from '@truffle/hdwallet-provider';
+import type { LoginInfo } from '../wallets/wallet-modes';
 
-export async function userWalletLoginWithoutChecks(
-  loginType: string,
-  preferBatchedMode = false
-): Promise<Result<Wallet>> {
-  const walletMode = stringToWalletMode(loginType);
-  return await specificWalletLogin(walletMode, preferBatchedMode);
+export async function userWalletLoginWithoutChecks(loginInfo: LoginInfo): Promise<Result<Wallet>> {
+  return await specificWalletLogin(loginInfo);
 }
 
 export async function automaticWalletLogin(privateKey: string): Promise<Result<Wallet>> {

--- a/packages/paima-sdk/paima-mw-core/src/endpoints/internal.ts
+++ b/packages/paima-sdk/paima-mw-core/src/endpoints/internal.ts
@@ -17,7 +17,7 @@ import {
 import type { PostingInfo, PostingModeSwitchResult, Result, Wallet } from '../types';
 import { specificWalletLogin, stringToWalletMode } from '../wallets/wallets';
 import { emulatedBlocksActiveOnBackend } from '../helpers/auxiliary-queries';
-import { CardanoConnector, TruffleConnector } from '@paima/providers';
+import { TruffleConnector } from '@paima/providers';
 import HDWalletProvider from '@truffle/hdwallet-provider';
 
 export async function userWalletLoginWithoutChecks(
@@ -26,24 +26,6 @@ export async function userWalletLoginWithoutChecks(
 ): Promise<Result<Wallet>> {
   const walletMode = stringToWalletMode(loginType);
   return await specificWalletLogin(walletMode, preferBatchedMode);
-}
-
-export async function cardanoWalletLoginEndpoint(): Promise<Result<Wallet>> {
-  const errorFxn = buildEndpointErrorFxn('cardanoWalletLoginEndpoint');
-  try {
-    const provider = await CardanoConnector.instance().connectSimple({
-      gameName: getGameName(),
-      gameChainId: undefined,
-    });
-    return {
-      success: true,
-      result: {
-        walletAddress: provider.getAddress(),
-      },
-    };
-  } catch (err) {
-    return errorFxn(PaimaMiddlewareErrorCode.CARDANO_LOGIN, err);
-  }
 }
 
 export async function automaticWalletLogin(privateKey: string): Promise<Result<Wallet>> {

--- a/packages/paima-sdk/paima-mw-core/src/index.ts
+++ b/packages/paima-sdk/paima-mw-core/src/index.ts
@@ -58,6 +58,7 @@ export type * from './errors';
 // Only for use in game-specific middleware:
 export * from './types';
 export type * from './types';
+export { WalletMode } from './wallets/wallet-modes';
 export {
   paimaEndpoints,
   getBlockNumber,

--- a/packages/paima-sdk/paima-mw-core/src/index.ts
+++ b/packages/paima-sdk/paima-mw-core/src/index.ts
@@ -5,7 +5,6 @@ import { queryEndpoints } from './endpoints/queries';
 import { utilityEndpoints } from './endpoints/utility';
 
 import {
-  cardanoWalletLoginEndpoint,
   retrievePostingInfo,
   switchToBatchedCardanoMode,
   switchToBatchedEthMode,
@@ -83,7 +82,6 @@ export {
 
 // NOT FOR USE IN PRODUCTION, just internal endpoints and helper functions for easier testing and debugging:
 export {
-  cardanoWalletLoginEndpoint,
   retrievePostingInfo,
   switchToBatchedCardanoMode,
   switchToBatchedEthMode,

--- a/packages/paima-sdk/paima-mw-core/src/types.ts
+++ b/packages/paima-sdk/paima-mw-core/src/types.ts
@@ -1,4 +1,5 @@
 import type { Hash, WalletAddress, UserSignature } from '@paima/utils';
+export type * from './wallets/wallet-modes';
 
 export interface PostingInfo {
   address: WalletAddress;

--- a/packages/paima-sdk/paima-mw-core/src/wallets/algorand.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/algorand.ts
@@ -28,7 +28,7 @@ export async function algorandLoginWrapper(
   return {
     success: true,
     result: {
-      walletAddress: loginResult.result.getAddress().toLocaleLowerCase(),
+      walletAddress: loginResult.result.getAddress(),
     },
   };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/algorand.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/algorand.ts
@@ -1,44 +1,34 @@
-import type { Result, Wallet } from '../types';
+import type { LoginInfoMap, Result, Wallet } from '../types';
 import { PaimaMiddlewareErrorCode, buildEndpointErrorFxn } from '../errors';
 import { AlgorandConnector } from '@paima/providers';
 import { getGameName } from '../state';
-import { WalletMode } from './wallet-modes';
+import type { WalletMode } from './wallet-modes';
+import { connectWallet } from './wallet-modes';
 
-// TODO: the whole concept of converting wallet mode to names should be removed
-function algorandWalletModeToName(walletMode: WalletMode): string {
-  switch (walletMode) {
-    case WalletMode.ALGORAND_PERA:
-      return 'pera';
-    default:
-      return '';
-  }
-}
-
-export async function algorandLoginWrapper(walletMode: WalletMode): Promise<Result<Wallet>> {
+export async function algorandLoginWrapper(
+  loginInfo: LoginInfoMap[WalletMode.ALGORAND]
+): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('algorandLoginWrapper');
 
-  const walletName = algorandWalletModeToName(walletMode);
-  try {
-    const provider =
-      walletMode === WalletMode.ALGORAND
-        ? await AlgorandConnector.instance().connectSimple({
-            gameName: getGameName(),
-            gameChainId: undefined, // Not needed because of batcher
-          })
-        : await AlgorandConnector.instance().connectNamed(
-            {
-              gameName: getGameName(),
-              gameChainId: undefined, // Not needed because of batcher
-            },
-            walletName
-          );
-    return {
-      success: true,
-      result: {
-        walletAddress: provider.getAddress(),
-      },
-    };
-  } catch (err) {
-    return errorFxn(PaimaMiddlewareErrorCode.ALGORAND_LOGIN, err);
+  const gameInfo = {
+    gameName: getGameName(),
+    gameChainId: undefined, // Not needed because of batcher
+  };
+  const loginResult = await connectWallet(
+    'algorandLoginWrapper',
+    errorFxn,
+    PaimaMiddlewareErrorCode.ALGORAND_LOGIN,
+    loginInfo,
+    AlgorandConnector.instance(),
+    gameInfo
+  );
+  if (loginResult.success === false) {
+    return loginResult;
   }
+  return {
+    success: true,
+    result: {
+      walletAddress: loginResult.result.getAddress().toLocaleLowerCase(),
+    },
+  };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/algorand.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/algorand.ts
@@ -2,15 +2,36 @@ import type { Result, Wallet } from '../types';
 import { PaimaMiddlewareErrorCode, buildEndpointErrorFxn } from '../errors';
 import { AlgorandConnector } from '@paima/providers';
 import { getGameName } from '../state';
+import { WalletMode } from './wallet-modes';
 
-export async function algorandLoginWrapper(): Promise<Result<Wallet>> {
+// TODO: the whole concept of converting wallet mode to names should be removed
+function algorandWalletModeToName(walletMode: WalletMode): string {
+  switch (walletMode) {
+    case WalletMode.ALGORAND_PERA:
+      return 'pera';
+    default:
+      return '';
+  }
+}
+
+export async function algorandLoginWrapper(walletMode: WalletMode): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('algorandLoginWrapper');
 
+  const walletName = algorandWalletModeToName(walletMode);
   try {
-    const provider = await AlgorandConnector.instance().connectSimple({
-      gameName: getGameName(),
-      gameChainId: undefined,
-    });
+    const provider =
+      walletMode === WalletMode.ALGORAND
+        ? await AlgorandConnector.instance().connectSimple({
+            gameName: getGameName(),
+            gameChainId: undefined, // Not needed because of batcher
+          })
+        : await AlgorandConnector.instance().connectNamed(
+            {
+              gameName: getGameName(),
+              gameChainId: undefined, // Not needed because of batcher
+            },
+            walletName
+          );
     return {
       success: true,
       result: {

--- a/packages/paima-sdk/paima-mw-core/src/wallets/cardano.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/cardano.ts
@@ -41,7 +41,7 @@ export async function cardanoLoginWrapper(
   return {
     success: true,
     result: {
-      walletAddress: loginResult.result.getAddress().toLocaleLowerCase(),
+      walletAddress: loginResult.result.getAddress(),
     },
   };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/cardano.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/cardano.ts
@@ -1,11 +1,8 @@
-import type { OldResult, Result, Wallet } from '../types';
-import {
-  buildEndpointErrorFxn,
-  PaimaMiddlewareErrorCode,
-  FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED,
-} from '../errors';
-import { WalletMode } from './wallet-modes';
-import { CardanoConnector, UnsupportedWallet, WalletNotFound } from '@paima/providers';
+import type { LoginInfoMap, OldResult, Result, Wallet } from '../types';
+import { buildEndpointErrorFxn, PaimaMiddlewareErrorCode } from '../errors';
+import type { WalletMode } from './wallet-modes';
+import { connectWallet } from './wallet-modes';
+import { CardanoConnector } from '@paima/providers';
 import { getGameName } from '../state';
 
 export async function checkCardanoWalletStatus(): Promise<OldResult> {
@@ -21,63 +18,30 @@ export async function checkCardanoWalletStatus(): Promise<OldResult> {
   return { success: true, message: '' };
 }
 
-function cardanoWalletModeToName(walletMode: WalletMode): string {
-  switch (walletMode) {
-    case WalletMode.CARDANO_FLINT:
-      return 'flint';
-    case WalletMode.CARDANO_NUFI:
-      return 'nufi';
-    case WalletMode.CARDANO_NAMI:
-      return 'nami';
-    case WalletMode.CARDANO_ETERNL:
-      return 'eternl';
-    default:
-      return '';
-  }
-}
-
-export async function cardanoLoginWrapper(walletMode: WalletMode): Promise<Result<Wallet>> {
+export async function cardanoLoginWrapper(
+  loginInfo: LoginInfoMap[WalletMode.CARDANO]
+): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('cardanoLoginWrapper');
-  console.log('[cardanoLoginWrapper] window.cardano:', (window as any).cardano);
 
-  let specificWalletName: string | undefined = undefined;
-  if (walletMode !== WalletMode.CARDANO) {
-    console.log(`[cardanoLoginWrapper] Attempting to log into ${specificWalletName}`);
-    specificWalletName = cardanoWalletModeToName(walletMode);
-    if (!specificWalletName) {
-      return errorFxn(PaimaMiddlewareErrorCode.CARDANO_WALLET_NOT_INSTALLED);
-    }
-  } else {
-    console.log(`[cardanoLoginWrapper] Attempting to log into any Cardano wallet`);
+  const gameInfo = {
+    gameName: getGameName(),
+    gameChainId: undefined, // Not needed because of batcher
+  };
+  const loginResult = await connectWallet(
+    'cardanoLoginWrapper',
+    errorFxn,
+    PaimaMiddlewareErrorCode.CARDANO_LOGIN,
+    loginInfo,
+    CardanoConnector.instance(),
+    gameInfo
+  );
+  if (loginResult.success === false) {
+    return loginResult;
   }
-
-  try {
-    const gameInfo = {
-      gameName: getGameName(),
-      gameChainId: undefined,
-    };
-    const provider =
-      specificWalletName == null
-        ? await CardanoConnector.instance().connectSimple(gameInfo)
-        : await CardanoConnector.instance().connectNamed(gameInfo, specificWalletName);
-    return {
-      success: true,
-      result: {
-        walletAddress: provider.getAddress().toLocaleLowerCase(),
-      },
-    };
-  } catch (err) {
-    if (err instanceof WalletNotFound || err instanceof UnsupportedWallet) {
-      return errorFxn(
-        PaimaMiddlewareErrorCode.CARDANO_WALLET_NOT_INSTALLED,
-        undefined,
-        FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED
-      );
-    }
-    console.log(
-      `[cardanoLoginWrapper] Error while logging into wallet ${specificWalletName ?? 'Cardano'}`
-    );
-    return errorFxn(PaimaMiddlewareErrorCode.CARDANO_LOGIN, err);
-    // TODO: improve error differentiation
-  }
+  return {
+    success: true,
+    result: {
+      walletAddress: loginResult.result.getAddress().toLocaleLowerCase(),
+    },
+  };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/evm.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/evm.ts
@@ -124,7 +124,7 @@ export async function evmLoginWrapper(
   return {
     success: true,
     result: {
-      walletAddress: EvmConnector.instance().getOrThrowProvider().getAddress().toLocaleLowerCase(),
+      walletAddress: EvmConnector.instance().getOrThrowProvider().getAddress(),
     },
   };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/polkadot.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/polkadot.ts
@@ -1,55 +1,34 @@
-import {
-  buildEndpointErrorFxn,
-  PaimaMiddlewareErrorCode,
-  FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED,
-} from '../errors';
+import { buildEndpointErrorFxn, PaimaMiddlewareErrorCode } from '../errors';
 import { getGameName } from '../state';
-import type { Result, Wallet } from '../types';
-import { UnsupportedWallet, WalletNotFound } from '@paima/providers';
+import type { LoginInfoMap, Result, Wallet } from '../types';
 import { PolkadotConnector } from '@paima/providers';
-import { WalletMode } from './wallet-modes';
+import type { WalletMode } from './wallet-modes';
+import { connectWallet } from './wallet-modes';
 
-// TODO: the whole concept of converting wallet mode to names should be removed
-function polkadotWalletModeToName(walletMode: WalletMode): string {
-  switch (walletMode) {
-    default:
-      return '';
-  }
-}
-
-export async function polkadotLoginWrapper(walletMode: WalletMode): Promise<Result<Wallet>> {
+export async function polkadotLoginWrapper(
+  loginInfo: LoginInfoMap[WalletMode.POLKADOT]
+): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('polkadotLoginWrapper');
 
-  const walletName = polkadotWalletModeToName(walletMode);
-  try {
-    const provider =
-      walletMode === WalletMode.POLKADOT
-        ? await PolkadotConnector.instance().connectSimple({
-            gameName: getGameName(),
-            gameChainId: undefined, // Not needed because of batcher
-          })
-        : await PolkadotConnector.instance().connectNamed(
-            {
-              gameName: getGameName(),
-              gameChainId: undefined, // Not needed because of batcher
-            },
-            walletName
-          );
-    return {
-      success: true,
-      result: {
-        walletAddress: provider.getAddress(),
-      },
-    };
-  } catch (err) {
-    if (err instanceof WalletNotFound || err instanceof UnsupportedWallet) {
-      return errorFxn(
-        PaimaMiddlewareErrorCode.POLKADOT_WALLET_NOT_INSTALLED,
-        undefined,
-        FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED
-      );
-    }
-    console.log(`[polkadotLoginWrapper] Error while logging into wallet`);
-    return errorFxn(PaimaMiddlewareErrorCode.POLKADOT_LOGIN, err);
+  const gameInfo = {
+    gameName: getGameName(),
+    gameChainId: undefined, // Not needed because of batcher
+  };
+  const loginResult = await connectWallet(
+    'polkadotLoginWrapper',
+    errorFxn,
+    PaimaMiddlewareErrorCode.POLKADOT_LOGIN,
+    loginInfo,
+    PolkadotConnector.instance(),
+    gameInfo
+  );
+  if (loginResult.success === false) {
+    return loginResult;
   }
+  return {
+    success: true,
+    result: {
+      walletAddress: loginResult.result.getAddress().toLocaleLowerCase(),
+    },
+  };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/polkadot.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/polkadot.ts
@@ -7,15 +7,34 @@ import { getGameName } from '../state';
 import type { Result, Wallet } from '../types';
 import { UnsupportedWallet, WalletNotFound } from '@paima/providers';
 import { PolkadotConnector } from '@paima/providers';
+import { WalletMode } from './wallet-modes';
 
-export async function polkadotLoginWrapper(): Promise<Result<Wallet>> {
+// TODO: the whole concept of converting wallet mode to names should be removed
+function polkadotWalletModeToName(walletMode: WalletMode): string {
+  switch (walletMode) {
+    default:
+      return '';
+  }
+}
+
+export async function polkadotLoginWrapper(walletMode: WalletMode): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('polkadotLoginWrapper');
 
+  const walletName = polkadotWalletModeToName(walletMode);
   try {
-    const provider = await PolkadotConnector.instance().connectSimple({
-      gameName: getGameName(),
-      gameChainId: undefined,
-    });
+    const provider =
+      walletMode === WalletMode.POLKADOT
+        ? await PolkadotConnector.instance().connectSimple({
+            gameName: getGameName(),
+            gameChainId: undefined, // Not needed because of batcher
+          })
+        : await PolkadotConnector.instance().connectNamed(
+            {
+              gameName: getGameName(),
+              gameChainId: undefined, // Not needed because of batcher
+            },
+            walletName
+          );
     return {
       success: true,
       result: {

--- a/packages/paima-sdk/paima-mw-core/src/wallets/polkadot.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/polkadot.ts
@@ -28,7 +28,7 @@ export async function polkadotLoginWrapper(
   return {
     success: true,
     result: {
-      walletAddress: loginResult.result.getAddress().toLocaleLowerCase(),
+      walletAddress: loginResult.result.getAddress(),
     },
   };
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/wallet-modes.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/wallet-modes.ts
@@ -1,14 +1,103 @@
-export enum WalletMode {
+import type {
+  ActiveConnection,
+  EvmApi,
+  CardanoApi,
+  AlgorandApi,
+  PolkadotApi,
+  IConnector,
+  IProvider,
+  GameInfo,
+} from '@paima/providers';
+import { WalletNotFound, UnsupportedWallet } from '@paima/providers';
+import type { EndpointErrorFxn } from '../errors';
+import type { Result } from '../types';
+import type { PaimaMiddlewareErrorCode } from '../errors';
+import { FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED } from '../errors';
+import assertNever from 'assert-never';
+
+export const enum WalletMode {
   NO_WALLET,
   EVM,
-  METAMASK,
-  EVM_FLINT,
   CARDANO,
-  CARDANO_FLINT,
-  CARDANO_NUFI,
-  CARDANO_NAMI,
-  CARDANO_ETERNL,
   POLKADOT,
   ALGORAND,
-  ALGORAND_PERA,
+}
+
+export type Preference<T> =
+  | {
+      name: string;
+    }
+  | {
+      connection: ActiveConnection<T>;
+    };
+
+export type BaseLoginInfo<Api> = {
+  preference?: Preference<Api>;
+};
+export type LoginInfoMap = {
+  [WalletMode.EVM]: BaseLoginInfo<EvmApi> & { preferBatchedMode: boolean };
+  [WalletMode.CARDANO]: BaseLoginInfo<CardanoApi>;
+  [WalletMode.POLKADOT]: BaseLoginInfo<PolkadotApi>;
+  [WalletMode.ALGORAND]: BaseLoginInfo<AlgorandApi>;
+  [WalletMode.NO_WALLET]: void;
+};
+
+type ToUnion<T> = {
+  [K in keyof T]: { mode: K } & T[K];
+}[keyof T];
+
+export type LoginInfo = ToUnion<LoginInfoMap>;
+
+function getWalletName(info: BaseLoginInfo<unknown>): undefined | string {
+  if (info.preference == null) return undefined;
+  if ('name' in info.preference) {
+    return info.preference.name;
+  }
+  return info.preference.connection.metadata.name;
+}
+export async function connectWallet<Api>(
+  typeName: string,
+  errorFxn: EndpointErrorFxn,
+  errorCode: PaimaMiddlewareErrorCode,
+  loginInfo: BaseLoginInfo<Api>,
+  connector: IConnector<Api>,
+  gameInfo: GameInfo
+): Promise<Result<IProvider<Api>>> {
+  try {
+    if (loginInfo.preference == null) {
+      console.log(`${typeName} Attempting simple login`);
+      const provider = await connector.connectSimple(gameInfo);
+      return {
+        success: true,
+        result: provider,
+      };
+    } else if ('name' in loginInfo.preference) {
+      const walletName = loginInfo.preference.name;
+      console.log(`${typeName} Attempting to log into ${walletName}`);
+      const provider = await connector.connectNamed(gameInfo, walletName);
+      return {
+        success: true,
+        result: provider,
+      };
+    } else if ('connection' in loginInfo.preference) {
+      const walletName = loginInfo.preference.connection.metadata.name;
+      console.log(`${typeName} Attempting to log into ${walletName}`);
+      const provider = await connector.connectExternal(gameInfo, loginInfo.preference.connection);
+      return {
+        success: true,
+        result: provider,
+      };
+    } else {
+      assertNever(loginInfo.preference);
+    }
+  } catch (err) {
+    if (err instanceof WalletNotFound || err instanceof UnsupportedWallet) {
+      return errorFxn(errorCode, undefined, FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED);
+    }
+    console.log(
+      `${typeName} Error while logging into wallet ${getWalletName(loginInfo) ?? 'simple'}`
+    );
+
+    return errorFxn(errorCode, err);
+  }
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/wallet-modes.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/wallet-modes.ts
@@ -1,5 +1,6 @@
 export enum WalletMode {
   NO_WALLET,
+  EVM,
   METAMASK,
   EVM_FLINT,
   CARDANO,
@@ -8,5 +9,6 @@ export enum WalletMode {
   CARDANO_NAMI,
   CARDANO_ETERNL,
   POLKADOT,
+  ALGORAND,
   ALGORAND_PERA,
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/wallets.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/wallets.ts
@@ -7,78 +7,37 @@ import {
   setBatchedPolkadotMode,
   setUnbatchedMode,
 } from '../state';
-import type { Result, Wallet } from '../types';
+import type { LoginInfo, Result, Wallet } from '../types';
 import { algorandLoginWrapper } from './algorand';
 import { cardanoLoginWrapper } from './cardano';
 import { evmLoginWrapper } from './evm';
 import { polkadotLoginWrapper } from './polkadot';
 import { WalletMode } from './wallet-modes';
 
-export function stringToWalletMode(loginType: string): WalletMode {
-  // TODO: this function has a bunch of magic strings in it which is not great
-  // some of these are also repeated in other places (ex: evmWalletModeToName)
-  switch (loginType) {
-    case 'evm':
-      return WalletMode.EVM;
-    case 'metamask':
-      return WalletMode.METAMASK;
-    case 'evm-flint':
-      return WalletMode.EVM_FLINT;
-    case 'cardano':
-      return WalletMode.CARDANO;
-    case 'flint':
-      return WalletMode.CARDANO_FLINT;
-    case 'nufi':
-      return WalletMode.CARDANO_NUFI;
-    case 'nami':
-      return WalletMode.CARDANO_NAMI;
-    case 'eternl':
-      return WalletMode.CARDANO_ETERNL;
-    case 'polkadot':
-      return WalletMode.POLKADOT;
-    case 'pera':
-      return WalletMode.ALGORAND_PERA;
-    case 'algorand':
-      return WalletMode.ALGORAND;
-    default:
-      return WalletMode.NO_WALLET;
-  }
-}
-
-export async function specificWalletLogin(
-  walletMode: WalletMode,
-  preferBatchedMode: boolean
-): Promise<Result<Wallet>> {
+export async function specificWalletLogin(loginInfo: LoginInfo): Promise<Result<Wallet>> {
   const errorFxn = buildEndpointErrorFxn('specificWalletLogin');
 
-  switch (walletMode) {
+  switch (loginInfo.mode) {
     case WalletMode.EVM:
-    case WalletMode.METAMASK:
-    case WalletMode.EVM_FLINT:
-      if (preferBatchedMode) {
+      if (loginInfo.preferBatchedMode) {
         setBatchedEthMode();
       } else {
         setUnbatchedMode();
       }
-      return await evmLoginWrapper(walletMode);
+      return await evmLoginWrapper(loginInfo);
     case WalletMode.CARDANO:
-    case WalletMode.CARDANO_FLINT:
-    case WalletMode.CARDANO_NUFI:
-    case WalletMode.CARDANO_NAMI:
-    case WalletMode.CARDANO_ETERNL:
       setBatchedCardanoMode();
-      return await cardanoLoginWrapper(walletMode);
+      return await cardanoLoginWrapper(loginInfo);
     case WalletMode.POLKADOT:
       setBatchedPolkadotMode();
-      return await polkadotLoginWrapper(walletMode);
+      return await polkadotLoginWrapper(loginInfo);
     case WalletMode.ALGORAND:
-    case WalletMode.ALGORAND_PERA:
       setBatchedAlgorandMode();
-      return await algorandLoginWrapper(walletMode);
+      return await algorandLoginWrapper(loginInfo);
     case WalletMode.NO_WALLET:
       return errorFxn(FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED);
     default:
-      assertNever(walletMode, true);
+      assertNever(loginInfo, true);
       return errorFxn(FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED);
   }
 }

--- a/packages/paima-sdk/paima-mw-core/src/wallets/wallets.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/wallets.ts
@@ -18,6 +18,8 @@ export function stringToWalletMode(loginType: string): WalletMode {
   // TODO: this function has a bunch of magic strings in it which is not great
   // some of these are also repeated in other places (ex: evmWalletModeToName)
   switch (loginType) {
+    case 'evm':
+      return WalletMode.EVM;
     case 'metamask':
       return WalletMode.METAMASK;
     case 'evm-flint':
@@ -36,6 +38,8 @@ export function stringToWalletMode(loginType: string): WalletMode {
       return WalletMode.POLKADOT;
     case 'pera':
       return WalletMode.ALGORAND_PERA;
+    case 'algorand':
+      return WalletMode.ALGORAND;
     default:
       return WalletMode.NO_WALLET;
   }
@@ -48,6 +52,7 @@ export async function specificWalletLogin(
   const errorFxn = buildEndpointErrorFxn('specificWalletLogin');
 
   switch (walletMode) {
+    case WalletMode.EVM:
     case WalletMode.METAMASK:
     case WalletMode.EVM_FLINT:
       if (preferBatchedMode) {
@@ -65,10 +70,11 @@ export async function specificWalletLogin(
       return await cardanoLoginWrapper(walletMode);
     case WalletMode.POLKADOT:
       setBatchedPolkadotMode();
-      return await polkadotLoginWrapper();
+      return await polkadotLoginWrapper(walletMode);
+    case WalletMode.ALGORAND:
     case WalletMode.ALGORAND_PERA:
       setBatchedAlgorandMode();
-      return await algorandLoginWrapper();
+      return await algorandLoginWrapper(walletMode);
     case WalletMode.NO_WALLET:
       return errorFxn(FE_ERR_SPECIFIC_WALLET_NOT_INSTALLED);
     default:

--- a/packages/paima-sdk/paima-providers/src/IProvider.ts
+++ b/packages/paima-sdk/paima-providers/src/IProvider.ts
@@ -1,12 +1,35 @@
 export type UserSignature = string;
 
+export type WalletOption = {
+  name: string; // name of the wallet used in APIs (as opposed to a human-friendly string)
+  displayName: string;
+  /**
+   * URI-encoded image
+   * DANGER: SVGs can contain Javascript, so these should only be rendered with <img> tags
+   *
+   * Note: not every wallet type has an image (ex: locally generated keypairs)
+   * Example values:
+   * data:image/svg+xml,...
+   * data:image/png;base64,...
+   */
+  icon?: undefined | string;
+};
+
 export type ActiveConnection<T> = {
-  metadata: {
-    // TODO: should also expose the icon for the wallet
-    name: string;
-  };
+  metadata: WalletOption;
   api: T;
 };
+export type ConnectionOption<T> = {
+  metadata: WalletOption;
+  api: () => Promise<T>;
+};
+export async function optionToActive<T>(option: ConnectionOption<T>): Promise<ActiveConnection<T>> {
+  const connection = {
+    metadata: option.metadata,
+    api: await option.api(),
+  };
+  return connection;
+}
 
 export type GameInfo = {
   gameName: string;

--- a/packages/paima-sdk/paima-providers/src/algorand.ts
+++ b/packages/paima-sdk/paima-providers/src/algorand.ts
@@ -30,6 +30,10 @@ export class AlgorandConnector implements IConnector<AlgorandApi> {
     // but it doesn't give any information about which wallet is injected
     // and, similar to window.ethereum, has wallets overriding each other
     // and Pera wallet doesn't even use this standard
+    // instead, the best we can do is check if Pera injected its UI component in the window
+    if (window.customElements.get('pera-wallet-connect-modal') == null) {
+      return [];
+    }
     return [
       {
         metadata: {

--- a/packages/paima-sdk/paima-providers/src/algorand.ts
+++ b/packages/paima-sdk/paima-providers/src/algorand.ts
@@ -1,20 +1,49 @@
 import type { PeraWalletConnect } from '@perawallet/connect';
-import type { ActiveConnection, GameInfo, IConnector, IProvider, UserSignature } from './IProvider';
+import {
+  optionToActive,
+  type ActiveConnection,
+  type ConnectionOption,
+  type GameInfo,
+  type IConnector,
+  type IProvider,
+  type UserSignature,
+} from './IProvider';
 import { CryptoManager } from '@paima/crypto';
 import { uint8ArrayToHexString } from '@paima/utils';
-import { ProviderApiError, ProviderNotInitialized, UnsupportedWallet } from './errors';
+import {
+  ProviderApiError,
+  ProviderNotInitialized,
+  UnsupportedWallet,
+  WalletNotFound,
+} from './errors';
 
 export type AlgorandApi = PeraWalletConnect;
 export type AlgorandAddress = string;
 
-// TODO: this should probably be dynamically detected
-enum SupportedAlgorandWallets {
-  PERA = 'pera',
-}
-
 export class AlgorandConnector implements IConnector<AlgorandApi> {
   private provider: AlgorandProvider | undefined;
   private static INSTANCE: undefined | AlgorandConnector = undefined;
+
+  static getWalletOptions(): ConnectionOption<AlgorandApi>[] {
+    // Algorand has no standard for wallet discovery
+    // The closest that exists is ARC11 (https://arc.algorand.foundation/ARCs/arc-0011)
+    // but it doesn't give any information about which wallet is injected
+    // and, similar to window.ethereum, has wallets overriding each other
+    // and Pera wallet doesn't even use this standard
+    return [
+      {
+        metadata: {
+          name: 'pera',
+          displayName: 'Pera Wallet',
+        },
+        api: async (): Promise<AlgorandApi> => {
+          const { PeraWalletConnect } = await import('@perawallet/connect');
+          const peraWallet = new PeraWalletConnect();
+          return peraWallet;
+        },
+      },
+    ];
+  }
 
   static instance(): AlgorandConnector {
     if (AlgorandConnector.INSTANCE == null) {
@@ -27,7 +56,11 @@ export class AlgorandConnector implements IConnector<AlgorandApi> {
     if (this.provider != null) {
       return this.provider;
     }
-    return await this.connectNamed(gameInfo, SupportedAlgorandWallets.PERA);
+    const options = AlgorandConnector.getWalletOptions();
+    if (options.length === 0) {
+      throw new WalletNotFound(`No Algorand wallet found`);
+    }
+    return await this.connectExternal(gameInfo, await optionToActive(options[0]));
   };
   connectExternal = async (
     gameInfo: GameInfo,
@@ -43,18 +76,13 @@ export class AlgorandConnector implements IConnector<AlgorandApi> {
     if (this.provider?.getConnection().metadata?.name === name) {
       return this.provider;
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    if (name !== SupportedAlgorandWallets.PERA) {
-      throw new UnsupportedWallet(`AlgorandProvider: unknown connection type ${name}`);
+    const provider = AlgorandConnector.getWalletOptions().find(
+      entry => entry.metadata.name === name
+    );
+    if (provider == null) {
+      throw new UnsupportedWallet(`AlgorandProvider: unsupported connection type ${name}`);
     }
-    const { PeraWalletConnect } = await import('@perawallet/connect');
-    const peraWallet = new PeraWalletConnect();
-    return await this.connectExternal(gameInfo, {
-      metadata: {
-        name: SupportedAlgorandWallets.PERA,
-      },
-      api: peraWallet,
-    });
+    return await this.connectExternal(gameInfo, await optionToActive(provider));
   };
   getProvider = (): undefined | AlgorandProvider => {
     return this.provider;

--- a/packages/paima-sdk/paima-providers/src/evm-truffle.ts
+++ b/packages/paima-sdk/paima-providers/src/evm-truffle.ts
@@ -55,6 +55,7 @@ export class TruffleEvmProvider implements IProvider<TruffleApi> {
       api: hdWalletProvider,
       metadata: {
         name: 'truffle',
+        displayName: 'truffle',
       },
     };
     return new TruffleEvmProvider(conn, web3, address);

--- a/packages/paima-sdk/paima-providers/src/evm.ts
+++ b/packages/paima-sdk/paima-providers/src/evm.ts
@@ -52,7 +52,7 @@ window?.addEventListener('eip6963:announceProvider', (event: EIP6963AnnounceProv
 window?.dispatchEvent(new Event('eip6963:requestProvider'));
 declare global {
   interface Window {
-    ethereum: EIP1193Provider;
+    ethereum?: EIP1193Provider;
     evmproviders?: EIP5749EVMProviders;
   }
   interface WindowEventMap {
@@ -125,14 +125,15 @@ export class EvmConnector implements IConnector<EvmApi> {
     }
 
     // Metamask doesn't support EIP6963 yet, but it plans to. In the meantime, we add it manually
-    if (window.ethereum.isMetaMask) {
+    if (window.ethereum != null && window.ethereum.isMetaMask) {
+      const ethereum = window.ethereum;
       addOptions([
         {
           metadata: {
             name: 'metamask',
             displayName: 'Metamask',
           },
-          api: () => Promise.resolve(window.ethereum),
+          api: () => Promise.resolve(ethereum),
         },
       ]);
     }
@@ -166,7 +167,7 @@ export class EvmConnector implements IConnector<EvmApi> {
 
     // Update the selected Eth address if the user changes after logging in.
     // warning: not supported by all wallets (ex: Flint)
-    window.ethereum.on('accountsChanged', newAccounts => {
+    window.ethereum?.on('accountsChanged', newAccounts => {
       const accounts = newAccounts as string[];
       if (!accounts || !accounts[0] || accounts[0] !== this.provider?.address) {
         this.provider = undefined;

--- a/packages/paima-sdk/paima-providers/src/evm.ts
+++ b/packages/paima-sdk/paima-providers/src/evm.ts
@@ -1,13 +1,62 @@
 import type { MetaMaskInpageProvider } from '@metamask/providers';
-import type { ActiveConnection, GameInfo, IConnector, IProvider, UserSignature } from './IProvider';
+import {
+  optionToActive,
+  type ActiveConnection,
+  type ConnectionOption,
+  type GameInfo,
+  type IConnector,
+  type IProvider,
+  type UserSignature,
+} from './IProvider';
 import { utf8ToHex } from 'web3-utils';
 import { ProviderApiError, ProviderNotInitialized, WalletNotFound } from './errors';
 
+type EIP1193Provider = MetaMaskInpageProvider;
+
+interface EIP5749ProviderInfo {
+  uuid: string;
+  name: string;
+  icon: `data:image/svg+xml;base64,${string}`;
+  description: string;
+}
+interface EIP5749ProviderWithInfo extends EIP1193Provider {
+  info: EIP5749ProviderInfo;
+}
+interface EIP5749EVMProviders {
+  /**
+   * The key is RECOMMENDED to be the name of the extension in snake_case. It MUST contain only lowercase letters, numbers, and underscores.
+   */
+  [index: string]: EIP5749ProviderWithInfo;
+}
+
+interface EIP6963ProviderInfo {
+  uuid: string;
+  name: string;
+  icon: string;
+  rdns: string;
+}
+interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: EIP1193Provider;
+}
+interface EIP6963AnnounceProviderEvent extends CustomEvent {
+  type: 'eip6963:announceProvider';
+  detail: EIP6963ProviderDetail;
+}
+
+const eip5953Providers: EIP6963ProviderDetail[] = [];
+
+window?.addEventListener('eip6963:announceProvider', (event: EIP6963AnnounceProviderEvent) => {
+  eip5953Providers.push(event.detail);
+});
+window?.dispatchEvent(new Event('eip6963:requestProvider'));
 declare global {
   interface Window {
-    ethereum: MetaMaskInpageProvider;
-    // API should be the same as MetaMask
-    evmproviders?: Record<string, MetaMaskInpageProvider>;
+    ethereum: EIP1193Provider;
+    evmproviders?: EIP5749EVMProviders;
+  }
+  interface WindowEventMap {
+    'eip6963:announceProvider': EIP6963AnnounceProviderEvent;
   }
 }
 
@@ -28,36 +77,67 @@ interface AddEthereumChainParameter {
   rpcUrls?: string[];
 }
 
-export type EvmApi = MetaMaskInpageProvider;
+export type EvmApi = EIP1193Provider;
 export type EvmAddress = string;
-
-/**
- * NOTE: https://eips.ethereum.org/EIPS/eip-5749
- */
-
-// TODO: this should probably be dynamically detected
-enum SupportedEvmWallets {
-  Metamask = 'metamask',
-  Flint = 'flint',
-}
-
-const getProvider = (name: string): MetaMaskInpageProvider => {
-  switch (name) {
-    case 'metamask':
-      return window.ethereum;
-    default: {
-      if (window.evmproviders != null && name in window.evmproviders) {
-        return window.evmproviders[name];
-      }
-      throw new WalletNotFound(`EVM wallet ${name} not found`);
-    }
-  }
-};
 
 export class EvmConnector implements IConnector<EvmApi> {
   private provider: EvmProvider | undefined;
   private static INSTANCE: undefined | EvmConnector = undefined;
 
+  static getWalletOptions(): ConnectionOption<EvmApi>[] {
+    const seenNames: Set<string> = new Set();
+    const allWallets: ConnectionOption<EvmApi>[] = [];
+
+    // add options and de-duplicate based off the display name
+    // we can't duplicate on other keys because they have a different formats for different EIPs
+    const addOptions: (options: ConnectionOption<EvmApi>[]) => void = options => {
+      for (const option of options) {
+        if (seenNames.has(option.metadata.name)) continue;
+        seenNames.add(option.metadata.name);
+        allWallets.push(option);
+      }
+    };
+
+    // 1) Add EIP6963 and prioritize it for deduplicating
+    {
+      const eip6963Options = eip5953Providers.map(({ info, provider }) => ({
+        metadata: {
+          name: info.rdns,
+          displayName: info.name,
+          icon: info.icon,
+        },
+        api: () => Promise.resolve(provider),
+      }));
+      addOptions(eip6963Options);
+    }
+
+    // 2) Add EIP5749
+    {
+      const eip5749Options = Object.entries(window.evmproviders ?? {}).map(([key, provider]) => ({
+        metadata: {
+          name: key,
+          displayName: provider.info.name,
+          icon: provider.info.icon,
+        },
+        api: () => Promise.resolve(provider),
+      }));
+      addOptions(eip5749Options);
+    }
+
+    // Metamask doesn't support EIP6963 yet, but it plans to. In the meantime, we add it manually
+    if (window.ethereum.isMetaMask) {
+      addOptions([
+        {
+          metadata: {
+            name: 'metamask',
+            displayName: 'Metamask',
+          },
+          api: () => Promise.resolve(window.ethereum),
+        },
+      ]);
+    }
+    return allWallets;
+  }
   static instance(): EvmConnector {
     if (EvmConnector.INSTANCE == null) {
       const newInstance = new EvmConnector();
@@ -69,8 +149,11 @@ export class EvmConnector implements IConnector<EvmApi> {
     if (this.provider != null) {
       return this.provider;
     }
-    // TODO: probably this should be better
-    return await this.connectNamed(gameInfo, SupportedEvmWallets.Metamask);
+    const options = EvmConnector.getWalletOptions();
+    if (options.length === 0) {
+      throw new WalletNotFound(`No EVM wallet found`);
+    }
+    return await this.connectExternal(gameInfo, await optionToActive(options[0]));
   };
   connectExternal = async (
     gameInfo: GameInfo,
@@ -96,12 +179,11 @@ export class EvmConnector implements IConnector<EvmApi> {
       return this.provider;
     }
 
-    return await this.connectExternal(gameInfo, {
-      metadata: {
-        name,
-      },
-      api: getProvider(name),
-    });
+    const provider = EvmConnector.getWalletOptions().find(entry => entry.metadata.name === name);
+    if (provider == null) {
+      throw new WalletNotFound(`EVM wallet ${name} not found`);
+    }
+    return await this.connectExternal(gameInfo, await optionToActive(provider));
   };
   getProvider = (): undefined | EvmProvider => {
     return this.provider;

--- a/packages/paima-sdk/paima-providers/src/polkadot.ts
+++ b/packages/paima-sdk/paima-providers/src/polkadot.ts
@@ -1,19 +1,45 @@
-import type { ActiveConnection, GameInfo, IConnector, IProvider, UserSignature } from './IProvider';
 import {
-  ProviderApiError,
-  ProviderNotInitialized,
-  UnsupportedWallet,
-  WalletNotFound,
-} from './errors';
-import type { InjectedExtension } from '@polkadot/extension-inject/types';
+  optionToActive,
+  type ActiveConnection,
+  type ConnectionOption,
+  type GameInfo,
+  type IConnector,
+  type IProvider,
+  type UserSignature,
+} from './IProvider';
+import { ProviderApiError, ProviderNotInitialized, WalletNotFound } from './errors';
+import type { InjectedExtension, InjectedWindowProvider } from '@polkadot/extension-inject/types';
 import { utf8ToHex } from 'web3-utils';
 
 export type PolkadotAddress = string;
 export type PolkadotApi = InjectedExtension;
 
+declare global {
+  interface Window {
+    injectedWeb3: Record<string, InjectedWindowProvider>;
+  }
+}
+
 export class PolkadotConnector implements IConnector<PolkadotApi> {
   private provider: PolkadotProvider | undefined;
   private static INSTANCE: undefined | PolkadotConnector = undefined;
+
+  static async getWalletOptions(gameName: string): Promise<ConnectionOption<PolkadotApi>[]> {
+    return Object.keys(window.injectedWeb3).map(wallet => ({
+      metadata: {
+        name: wallet,
+        // polkadot provides no way to get a human-friendly name or icon for wallets
+        displayName: wallet,
+      },
+      api: async (): Promise<PolkadotApi> => {
+        const { web3Enable, web3FromSource } = await import('@polkadot/extension-dapp');
+
+        await web3Enable(gameName);
+        const injector = await web3FromSource(wallet);
+        return injector;
+      },
+    }));
+  }
 
   static instance(): PolkadotConnector {
     if (PolkadotConnector.INSTANCE == null) {
@@ -31,6 +57,9 @@ export class PolkadotConnector implements IConnector<PolkadotApi> {
     if (extensions.length === 0) {
       throw new WalletNotFound(`[polkadot] no extension detected`);
     }
+
+    // we get all accounts instead of picking a specific extension
+    // because some extensions could have no accounts in them
     const allAccounts = await web3Accounts();
     for (const account of allAccounts) {
       const injector = await web3FromAddress(account.address);
@@ -38,6 +67,8 @@ export class PolkadotConnector implements IConnector<PolkadotApi> {
       return await this.connectExternal(gameInfo, {
         metadata: {
           name: account.meta.source,
+          // polkadot provides no way to get a human-friendly name or icon for wallets
+          displayName: account.meta.source,
         },
         api: injector,
       });
@@ -58,21 +89,13 @@ export class PolkadotConnector implements IConnector<PolkadotApi> {
     if (this.provider?.getConnection().metadata?.name === name) {
       return this.provider;
     }
-
-    const { web3Enable, web3FromSource } = await import('@polkadot/extension-dapp');
-
-    await web3Enable(gameInfo.gameName);
-    try {
-      const injector = await web3FromSource(name);
-      return await this.connectExternal(gameInfo, {
-        metadata: {
-          name,
-        },
-        api: injector,
-      });
-    } catch (e) {
-      throw new UnsupportedWallet(`[polkadot] no account found for extension ${name}`);
+    const provider = (await PolkadotConnector.getWalletOptions(gameInfo.gameName)).find(
+      entry => entry.metadata.name === name
+    );
+    if (provider == null) {
+      throw new WalletNotFound(`Polkadot wallet ${name} not found`);
     }
+    return await this.connectExternal(gameInfo, await optionToActive(provider));
   };
   getProvider = (): undefined | PolkadotProvider => {
     return this.provider;

--- a/packages/paima-sdk/paima-providers/src/polkadot.ts
+++ b/packages/paima-sdk/paima-providers/src/polkadot.ts
@@ -16,7 +16,7 @@ export type PolkadotApi = InjectedExtension;
 
 declare global {
   interface Window {
-    injectedWeb3: Record<string, InjectedWindowProvider>;
+    injectedWeb3?: Record<string, InjectedWindowProvider>;
   }
 }
 
@@ -25,6 +25,7 @@ export class PolkadotConnector implements IConnector<PolkadotApi> {
   private static INSTANCE: undefined | PolkadotConnector = undefined;
 
   static async getWalletOptions(gameName: string): Promise<ConnectionOption<PolkadotApi>[]> {
+    if (window.injectedWeb3 == null) return [];
     return Object.keys(window.injectedWeb3).map(wallet => ({
       metadata: {
         name: wallet,


### PR DESCRIPTION
# New features
- EIP6963 and EIP5749 implemented for wallet detection (no longer only Metamask)
- Providers now expose a `getWalletOptions` function to fetch all wallets available. This makes it easier to know which wallets to show in your dApp as option
- **(breaking change)** Support for games specifying which wallets they want to connect to by name or injecting their own wallet (previously, you had to pass in the wallet name from a pre-specified list of wallets Paima accepted)