### PR TITLE
Misc fixes for EVM wallet connection

### DIFF
--- a/packages/paima-sdk/paima-mw-core/src/endpoints/internal.ts
+++ b/packages/paima-sdk/paima-mw-core/src/endpoints/internal.ts
@@ -13,6 +13,9 @@ import { TruffleConnector } from '@paima/providers';
 import HDWalletProvider from '@truffle/hdwallet-provider';
 import type { LoginInfo } from '../wallets/wallet-modes.js';
 
+/**
+ * @deprecated use specificWalletLogin instead
+ */
 export async function userWalletLoginWithoutChecks(
   loginInfo: LoginInfo,
   setDefault: boolean = true

--- a/packages/paima-sdk/paima-mw-core/src/wallets/evm/injected.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/evm/injected.ts
@@ -117,9 +117,11 @@ export async function evmLoginWrapper(
     // If the fee has increased beyond the default value, posting won't work.
   }
   try {
-    if (!(await verifyWalletChain())) {
-      if (!(await switchChain())) {
-        return errorFxn(PaimaMiddlewareErrorCode.EVM_CHAIN_SWITCH);
+    if (loginInfo.checkChainId !== false) {
+      if (!(await verifyWalletChain())) {
+        if (!(await switchChain())) {
+          return errorFxn(PaimaMiddlewareErrorCode.EVM_CHAIN_SWITCH);
+        }
       }
     }
   } catch (err) {

--- a/packages/paima-sdk/paima-mw-core/src/wallets/wallet-modes.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/wallet-modes.ts
@@ -21,7 +21,10 @@ export type BaseLoginInfo<Api> = {
   preference?: InjectionPreference<Api>;
 };
 export type LoginInfoMap = {
-  [WalletMode.EvmInjected]: BaseLoginInfo<EvmApi> & { preferBatchedMode: boolean };
+  [WalletMode.EvmInjected]: BaseLoginInfo<EvmApi> & {
+    preferBatchedMode: boolean;
+    checkChainId?: boolean;
+  };
   [WalletMode.EvmEthers]: { connection: ActiveConnection<EthersApi>; preferBatchedMode: boolean };
   [WalletMode.Cardano]: BaseLoginInfo<CardanoApi>;
   [WalletMode.Polkadot]: BaseLoginInfo<PolkadotApi>;

--- a/packages/paima-sdk/paima-providers/src/evm/injected.ts
+++ b/packages/paima-sdk/paima-providers/src/evm/injected.ts
@@ -132,7 +132,7 @@ export class EvmInjectedConnector implements IConnector<EvmApi> {
       allWallets.push({
         metadata: {
           name: 'metamask',
-          displayName: 'Metamask',
+          displayName: 'MetaMask',
         },
         api: () => Promise.resolve(ethereum),
       });
@@ -153,11 +153,15 @@ export class EvmInjectedConnector implements IConnector<EvmApi> {
   static getWalletOptions(): ConnectionOption<EvmApi>[] {
     const withDuplicates = EvmInjectedConnector.getPossiblyDuplicateWalletOptions();
     const seenNames: Set<string> = new Set();
+    const seenDisplayNames: Set<string> = new Set();
 
     const result: ConnectionOption<EvmApi>[] = [];
     for (const option of withDuplicates) {
+      const lowerCaseName = option.metadata.displayName.toLowerCase();
       if (seenNames.has(option.metadata.name)) continue;
+      if (seenDisplayNames.has(lowerCaseName)) continue;
       seenNames.add(option.metadata.name);
+      seenDisplayNames.add(lowerCaseName);
       result.push(option);
     }
 


### PR DESCRIPTION
This PR makes 3 changes:
- Marks `userWalletLoginWithoutChecks` as deprecated. Its function signature is exactly the same as `specificWalletLogin` which should be use instead
- Allows optionally passing `checkChainId: false` when connecting to an EVM wallet. This is useful when you only care about message signing so it doesn't matter which chain the user has selected (esp for wallets like Metamask and Flint which don't support arbitrary network switching)
- Fix deduplicating logic when multiple EVM wallets have the same display name