### PR TITLE
carp funnel stake delegation cde epoch tracking

### DIFF
--- a/packages/engine/paima-funnel/src/cde/cardanoPool.ts
+++ b/packages/engine/paima-funnel/src/cde/cardanoPool.ts
@@ -6,6 +6,7 @@ import type {
 import { ChainDataExtensionDatumType, DEFAULT_FUNNEL_TIMEOUT, timeout } from '@paima/utils';
 import { Routes, query } from '@dcspark/carp-client/client/src';
 import type { DelegationForPoolResponse } from '@dcspark/carp-client/shared/models/DelegationForPool';
+import { absoluteSlotToEpoch } from '../funnels/carp/funnel.js';
 
 export default async function getCdeData(
   url: string,
@@ -22,13 +23,16 @@ export default async function getCdeData(
     DEFAULT_FUNNEL_TIMEOUT
   );
 
-  return events.map(e => eventToCdeDatum(e, extension, getBlockNumber(e.slot)));
+  return events.map(e =>
+    eventToCdeDatum(e, extension, getBlockNumber(e.slot), absoluteSlotToEpoch(e.slot))
+  );
 }
 
 function eventToCdeDatum(
   event: DelegationForPoolResponse[0],
   extension: ChainDataExtensionCardanoDelegation,
-  blockNumber: number
+  blockNumber: number,
+  epoch: number
 ): CdeCardanoPoolDatum {
   return {
     cdeId: extension.cdeId,
@@ -37,6 +41,7 @@ function eventToCdeDatum(
     payload: {
       address: event.credential,
       pool: event.pool || undefined,
+      epoch,
     },
     scheduledPrefix: extension.scheduledPrefix,
   };

--- a/packages/engine/paima-funnel/src/cde/cardanoPool.ts
+++ b/packages/engine/paima-funnel/src/cde/cardanoPool.ts
@@ -6,14 +6,14 @@ import type {
 import { ChainDataExtensionDatumType, DEFAULT_FUNNEL_TIMEOUT, timeout } from '@paima/utils';
 import { Routes, query } from '@dcspark/carp-client/client/src';
 import type { DelegationForPoolResponse } from '@dcspark/carp-client/shared/models/DelegationForPool';
-import { absoluteSlotToEpoch } from '../funnels/carp/funnel.js';
 
 export default async function getCdeData(
   url: string,
   extension: ChainDataExtensionCardanoDelegation,
   fromAbsoluteSlot: number,
   toAbsoluteSlot: number,
-  getBlockNumber: (slot: number) => number
+  getBlockNumber: (slot: number) => number,
+  absoluteSlotToEpoch: (slot: number) => number
 ): Promise<ChainDataExtensionDatum[]> {
   const events = await timeout(
     query(url, Routes.delegationForPool, {

--- a/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
+++ b/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
@@ -76,6 +76,7 @@ export class RpcCacheEntry implements FunnelCacheEntry {
 export type CarpFunnelCacheEntryState = {
   startingSlot: number;
   lastPoint: { blockHeight: number; timestamp: number } | undefined;
+  epoch: number | undefined;
 };
 
 export class CarpFunnelCacheEntry implements FunnelCacheEntry {
@@ -83,12 +84,18 @@ export class CarpFunnelCacheEntry implements FunnelCacheEntry {
   public static readonly SYMBOL = Symbol('CarpFunnelStartingSlot');
 
   public updateStartingSlot(startingSlot: number): void {
-    this.state = { startingSlot, lastPoint: this.state?.lastPoint };
+    this.state = { startingSlot, lastPoint: this.state?.lastPoint, epoch: this.state?.epoch };
   }
 
   public updateLastPoint(blockHeight: number, timestamp: number): void {
     if (this.state) {
       this.state.lastPoint = { blockHeight, timestamp };
+    }
+  }
+
+  public updateEpoch(epoch: number): void {
+    if (this.state) {
+      this.state.epoch = epoch;
     }
   }
 

--- a/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
@@ -30,36 +30,42 @@ import { getCardanoEpoch } from '@paima/db';
 
 const delayForWaitingForFinalityLoop = 1000;
 
-// This returns the unix timestamp of the first block in the Shelley era of the
-// configured network, and the slot of the corresponding block.
-function knownShelleyTime(): { timestamp: number; absoluteSlot: number } {
+type Era = {
+  firstSlot: number;
+  startEpoch: number;
+  slotsPerEpoch: number;
+  timestamp: number;
+};
+
+function shelleyEra(): Era {
   switch (ENV.CARDANO_NETWORK) {
     case 'preview':
-      return { timestamp: 1666656000, absoluteSlot: 0 };
+      return {
+        firstSlot: 0,
+        startEpoch: 0,
+        slotsPerEpoch: 86400,
+        timestamp: 1666656000,
+      };
     case 'preprod':
-      return { timestamp: 1655769600, absoluteSlot: 86400 };
+      return {
+        firstSlot: 86400,
+        startEpoch: 4,
+        slotsPerEpoch: 432000,
+        timestamp: 1655769600,
+      };
     case 'mainnet':
-      return { timestamp: 1596059091, absoluteSlot: 4492800 };
+      return {
+        firstSlot: 4492800,
+        startEpoch: 208,
+        slotsPerEpoch: 432000,
+        timestamp: 1596059091,
+      };
     default:
       throw new Error('unknown cardano network');
   }
 }
 
-function shelleyEra(): { firstSlot: number; startEpoch: number; slotsPerEpoch: number } {
-  switch (ENV.CARDANO_NETWORK) {
-    case 'preview':
-      return { firstSlot: 0, startEpoch: 0, slotsPerEpoch: 86400 };
-    case 'preprod':
-      return { firstSlot: 86400, startEpoch: 4, slotsPerEpoch: 432000 };
-    case 'mainnet':
-      return { firstSlot: 4492800, startEpoch: 208, slotsPerEpoch: 432000 };
-    default:
-      throw new Error('unknown cardano network');
-  }
-}
-
-export function absoluteSlotToEpoch(slot: number): number {
-  const era = shelleyEra();
+function absoluteSlotToEpoch(era: Era, slot: number): number {
   const slotRelativeToEra = slot - era.firstSlot;
 
   if (slotRelativeToEra >= 0) {
@@ -87,14 +93,12 @@ Note: The state pairing only matters after the presync stage is done, so as
 long as the timestamp of the block specified in START_BLOCKHEIGHT happens after
 the first Shelley block, we don't need to consider the previous Cardano era (if any).
 */
-function timestampToAbsoluteSlot(timestamp: number, confirmationDepth: number): number {
+function timestampToAbsoluteSlot(era: Era, timestamp: number, confirmationDepth: number): number {
   const cardanoAvgBlockPeriod = 20;
   // map timestamps with a delta, since we are waiting for blocks.
   const confirmationTimeDelta = cardanoAvgBlockPeriod * confirmationDepth;
 
-  const era = knownShelleyTime();
-
-  return timestamp - confirmationTimeDelta - era.timestamp + era.absoluteSlot;
+  return timestamp - confirmationTimeDelta - era.timestamp + era.firstSlot;
 }
 
 export class CarpFunnel extends BaseFunnel implements ChainFunnel {
@@ -112,9 +116,11 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
     this.readPresyncData.bind(this);
     this.getDbTx.bind(this);
     this.bufferedData = null;
+    this.era = shelleyEra();
   }
 
   private bufferedData: ChainData[] | null;
+  private era: Era;
 
   public override async readData(blockHeight: number): Promise<ChainData[]> {
     if (!this.bufferedData || this.bufferedData[0].blockNumber != blockHeight) {
@@ -151,7 +157,8 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
       this.sharedData.extensions,
       lastTimestamp,
       this.cache,
-      this.confirmationDepth
+      this.confirmationDepth,
+      this.era
     );
 
     const composed = composeChainData(this.bufferedData, grouped);
@@ -161,7 +168,8 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
         data.internalEvents = [] as InternalEvent[];
 
         const epoch = absoluteSlotToEpoch(
-          timestampToAbsoluteSlot(data.timestamp, this.confirmationDepth)
+          this.era,
+          timestampToAbsoluteSlot(this.era, data.timestamp, this.confirmationDepth)
         );
 
         const prevEpoch = this.cache.getState().epoch;
@@ -207,7 +215,8 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                   Math.min(arg.to, this.cache.getState().startingSlot - 1),
                   slot => {
                     return slot;
-                  }
+                  },
+                  slot => absoluteSlotToEpoch(this.era, slot)
                 );
                 return data;
               } else {
@@ -268,6 +277,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
 
       newEntry.updateStartingSlot(
         timestampToAbsoluteSlot(
+          shelleyEra(),
           (await sharedData.web3.eth.getBlock(startingBlockHeight)).timestamp as number,
           confirmationDepth
         )
@@ -299,14 +309,15 @@ async function readDataInternal(
   extensions: ChainDataExtension[],
   lastTimestamp: number,
   cache: CarpFunnelCacheEntry,
-  confirmationDepth: number
+  confirmationDepth: number,
+  era: Era
 ): Promise<PresyncChainData[]> {
   // the lower range is exclusive
-  const min = timestampToAbsoluteSlot(lastTimestamp, confirmationDepth);
+  const min = timestampToAbsoluteSlot(era, lastTimestamp, confirmationDepth);
   // the upper range is inclusive
   const maxElement = data[data.length - 1];
 
-  const max = timestampToAbsoluteSlot(maxElement.timestamp, confirmationDepth);
+  const max = timestampToAbsoluteSlot(era, maxElement.timestamp, confirmationDepth);
 
   cache.updateLastPoint(maxElement.blockNumber, maxElement.timestamp);
 
@@ -331,7 +342,7 @@ async function readDataInternal(
 
   const blockNumbers = data.reduce(
     (dict, data) => {
-      dict[timestampToAbsoluteSlot(data.timestamp, confirmationDepth)] = data.blockNumber;
+      dict[timestampToAbsoluteSlot(era, data.timestamp, confirmationDepth)] = data.blockNumber;
       return dict;
     },
     {} as { [slot: number]: number }
@@ -362,7 +373,8 @@ async function readDataInternal(
             extension,
             min,
             Math.min(max, extension.stopSlot || max),
-            mapSlotToBlockNumber
+            mapSlotToBlockNumber,
+            slot => absoluteSlotToEpoch(era, slot)
           );
 
           return poolData;

--- a/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
@@ -175,13 +175,16 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
         const prevEpoch = this.cache.getState().epoch;
 
         if (!prevEpoch || epoch !== prevEpoch) {
-          data.internalEvents?.push({
+          data.internalEvents.push({
             type: InternalEventType.CardanoBestEpoch,
             epoch: epoch,
           });
-        }
 
-        this.cache.updateEpoch(epoch);
+          // The execution of the event that we just pushed should set the
+          // `cardano_last_epoch` table to `epoch`. This cache entry mirrors the
+          // value of that table, so we need to update it here too.
+          this.cache.updateEpoch(epoch);
+        }
       }
     }
 

--- a/packages/engine/paima-sm/src/cde-cardano-pool.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-pool.ts
@@ -1,5 +1,5 @@
 import { ENV } from '@paima/utils';
-import { createScheduledData, cdeCardanoPoolInsertData } from '@paima/db';
+import { createScheduledData, cdeCardanoPoolInsertData, removeOldEntries } from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
 import type { CdeCardanoPoolDatum } from './types.js';
 
@@ -16,7 +16,18 @@ export default async function processDatum(cdeDatum: CdeCardanoPoolDatum): Promi
     createScheduledData(scheduledInputData, scheduledBlockHeight),
     [
       cdeCardanoPoolInsertData,
-      { cde_id: cdeId, address: cdeDatum.payload.address, pool: cdeDatum.payload.pool },
+      {
+        cde_id: cdeId,
+        address: cdeDatum.payload.address,
+        pool: cdeDatum.payload.pool,
+        epoch: cdeDatum.payload.epoch,
+      },
+    ],
+    [
+      removeOldEntries,
+      {
+        address: cdeDatum.payload.address,
+      },
     ],
   ];
   return updateList;

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -13,6 +13,7 @@ import type {
   OldERC6551RegistryContract,
   ERC6551RegistryContract,
   Network,
+  InternalEventType,
 } from '@paima/utils';
 import { Type } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
@@ -25,7 +26,11 @@ export interface ChainData {
   blockNumber: number;
   submittedData: SubmittedData[];
   extensionDatums?: ChainDataExtensionDatum[];
+  internalEvents?: InternalEvent[];
 }
+
+export type InternalEvent = CardanoEpochEvent;
+export type CardanoEpochEvent = { type: InternalEventType.CardanoBestEpoch; epoch: number };
 
 export interface PresyncChainData {
   network: Network;
@@ -69,6 +74,7 @@ interface CdeDatumErc6551RegistryPayload {
 interface CdeDatumCardanoPoolPayload {
   address: string;
   pool: string | undefined;
+  epoch: number;
 }
 
 interface CdeDatumCardanoProjectedNFTPayload {

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -89,9 +89,15 @@ CREATE TABLE emulated_block_heights (
 
 CREATE TABLE cde_cardano_pool_delegation (
   cde_id INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
   address TEXT NOT NULL,
   pool TEXT,
-  PRIMARY KEY (cde_id, address)
+  PRIMARY KEY (cde_id, epoch, address)
+);
+
+CREATE TABLE cardano_last_epoch (
+  id INTEGER PRIMARY KEY,
+  epoch INTEGER NOT NULL
 );
 
 CREATE TABLE cde_cardano_projected_nft (

--- a/packages/node-sdk/paima-db/src/index.ts
+++ b/packages/node-sdk/paima-db/src/index.ts
@@ -35,6 +35,8 @@ export * from './sql/cde-cardano-projected-nft.queries.js';
 export type * from './sql/cde-cardano-projected-nft.queries.js';
 export * from './sql/cde-tracking-cardano.queries.js';
 export type * from './sql/cde-tracking-cardano.queries.js';
+export * from './sql/cardano-last-epoch.queries.js';
+export type * from './sql/cardano-last-epoch.queries.js';
 
 export {
   tx,

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -259,17 +259,19 @@ const TABLE_DATA_CDE_ERC6551_REGISTRY: TableData = {
 const QUERY_CREATE_TABLE_CDE_CARDANO_POOL = `
 CREATE TABLE cde_cardano_pool_delegation (
   cde_id INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
   address TEXT NOT NULL,
   pool TEXT,
-  PRIMARY KEY (cde_id, address)
+  PRIMARY KEY (cde_id, epoch, address)
 );
 `;
 
 const TABLE_DATA_CDE_CARDANO_POOL: TableData = {
   tableName: 'cde_cardano_pool_delegation',
-  primaryKeyColumns: ['cde_id', 'address'],
+  primaryKeyColumns: ['cde_id', 'epoch', 'address'],
   columnData: packTuples([
     ['cde_id', 'integer', 'NO', ''],
+    ['epoch', 'integer', 'NO', ''],
     ['address', 'text', 'NO', ''],
     ['pool', 'text', 'YES', ''],
   ]),
@@ -318,6 +320,24 @@ const TABLE_DATA_CDE_CARDANO_PROJECTED_NFT: TableData = {
   creationQuery: QUERY_CREATE_TABLE_CDE_CARDANO_PROJECTED_NFT,
 };
 
+const QUERY_CREATE_TABLE_CARDANO_LAST_EPOCH = `
+CREATE TABLE cardano_last_epoch (
+  id INTEGER PRIMARY KEY,
+  epoch INTEGER NOT NULL
+);
+`;
+
+const TABLE_DATA_CARDANO_LAST_EPOCH: TableData = {
+  tableName: 'cardano_last_epoch',
+  primaryKeyColumns: ['id'],
+  columnData: packTuples([
+    ['id', 'integer', 'NO', ''],
+    ['epoch', 'integer', 'NO', ''],
+  ]),
+  serialColumns: [],
+  creationQuery: QUERY_CREATE_TABLE_CARDANO_LAST_EPOCH,
+};
+
 const QUERY_CREATE_TABLE_EMULATED = `
 CREATE TABLE emulated_block_heights (
   deployment_chain_block_height INTEGER PRIMARY KEY,
@@ -354,4 +374,5 @@ export const TABLES: TableData[] = [
   TABLE_DATA_CDE_CARDANO_POOL,
   TABLE_DATA_CDE_CARDANO_PROJECTED_NFT,
   TABLE_DATA_EMULATED,
+  TABLE_DATA_CARDANO_LAST_EPOCH,
 ];

--- a/packages/node-sdk/paima-db/src/sql/cardano-last-epoch.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cardano-last-epoch.queries.ts
@@ -1,0 +1,61 @@
+/** Types generated for queries found in "src/sql/cardano-last-epoch.sql" */
+import { PreparedQuery } from '@pgtyped/runtime';
+
+/** 'UpdateCardanoEpoch' parameters type */
+export interface IUpdateCardanoEpochParams {
+  epoch: number;
+}
+
+/** 'UpdateCardanoEpoch' return type */
+export type IUpdateCardanoEpochResult = void;
+
+/** 'UpdateCardanoEpoch' query type */
+export interface IUpdateCardanoEpochQuery {
+  params: IUpdateCardanoEpochParams;
+  result: IUpdateCardanoEpochResult;
+}
+
+const updateCardanoEpochIR: any = {"usedParamSet":{"epoch":true},"params":[{"name":"epoch","required":true,"transform":{"type":"scalar"},"locs":[{"a":72,"b":78},{"a":122,"b":128}]}],"statement":"INSERT INTO cardano_last_epoch(\n    id,\n    epoch\n) VALUES (\n    0,\n    :epoch!\n) \nON CONFLICT (id) DO\nUPDATE SET epoch = :epoch!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO cardano_last_epoch(
+ *     id,
+ *     epoch
+ * ) VALUES (
+ *     0,
+ *     :epoch!
+ * ) 
+ * ON CONFLICT (id) DO
+ * UPDATE SET epoch = :epoch!
+ * ```
+ */
+export const updateCardanoEpoch = new PreparedQuery<IUpdateCardanoEpochParams,IUpdateCardanoEpochResult>(updateCardanoEpochIR);
+
+
+/** 'GetCardanoEpoch' parameters type */
+export type IGetCardanoEpochParams = void;
+
+/** 'GetCardanoEpoch' return type */
+export interface IGetCardanoEpochResult {
+  epoch: number;
+}
+
+/** 'GetCardanoEpoch' query type */
+export interface IGetCardanoEpochQuery {
+  params: IGetCardanoEpochParams;
+  result: IGetCardanoEpochResult;
+}
+
+const getCardanoEpochIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT epoch from cardano_last_epoch LIMIT 1"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT epoch from cardano_last_epoch LIMIT 1
+ * ```
+ */
+export const getCardanoEpoch = new PreparedQuery<IGetCardanoEpochParams,IGetCardanoEpochResult>(getCardanoEpochIR);
+
+

--- a/packages/node-sdk/paima-db/src/sql/cardano-last-epoch.sql
+++ b/packages/node-sdk/paima-db/src/sql/cardano-last-epoch.sql
@@ -1,0 +1,13 @@
+/* @name updateCardanoEpoch */
+INSERT INTO cardano_last_epoch(
+    id,
+    epoch
+) VALUES (
+    0,
+    :epoch!
+) 
+ON CONFLICT (id) DO
+UPDATE SET epoch = :epoch!;
+
+/* @name getCardanoEpoch */
+SELECT epoch from cardano_last_epoch LIMIT 1;

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.queries.ts
@@ -10,6 +10,7 @@ export interface ICdeCardanoPoolGetAddressDelegationParams {
 export interface ICdeCardanoPoolGetAddressDelegationResult {
   address: string;
   cde_id: number;
+  epoch: number;
   pool: string | null;
 }
 
@@ -19,13 +20,14 @@ export interface ICdeCardanoPoolGetAddressDelegationQuery {
   result: ICdeCardanoPoolGetAddressDelegationResult;
 }
 
-const cdeCardanoPoolGetAddressDelegationIR: any = {"usedParamSet":{"address":true},"params":[{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":59,"b":67}]}],"statement":"SELECT * FROM cde_cardano_pool_delegation \nWHERE address = :address!"};
+const cdeCardanoPoolGetAddressDelegationIR: any = {"usedParamSet":{"address":true},"params":[{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":59,"b":67}]}],"statement":"SELECT * FROM cde_cardano_pool_delegation \nWHERE address = :address!\nORDER BY epoch"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_cardano_pool_delegation 
  * WHERE address = :address!
+ * ORDER BY epoch
  * ```
  */
 export const cdeCardanoPoolGetAddressDelegation = new PreparedQuery<ICdeCardanoPoolGetAddressDelegationParams,ICdeCardanoPoolGetAddressDelegationResult>(cdeCardanoPoolGetAddressDelegationIR);
@@ -35,6 +37,7 @@ export const cdeCardanoPoolGetAddressDelegation = new PreparedQuery<ICdeCardanoP
 export interface ICdeCardanoPoolInsertDataParams {
   address: string;
   cde_id: number;
+  epoch: number;
   pool: string;
 }
 
@@ -47,7 +50,7 @@ export interface ICdeCardanoPoolInsertDataQuery {
   result: ICdeCardanoPoolInsertDataResult;
 }
 
-const cdeCardanoPoolInsertDataIR: any = {"usedParamSet":{"cde_id":true,"address":true,"pool":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":90,"b":97}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":104,"b":112}]},{"name":"pool","required":true,"transform":{"type":"scalar"},"locs":[{"a":119,"b":124},{"a":181,"b":186}]}],"statement":"INSERT INTO cde_cardano_pool_delegation(\n    cde_id,\n    address,\n    pool\n) VALUES (\n    :cde_id!,\n    :address!,\n    :pool!\n) ON CONFLICT (cde_id, address) DO\n  UPDATE SET pool = :pool!"};
+const cdeCardanoPoolInsertDataIR: any = {"usedParamSet":{"cde_id":true,"address":true,"pool":true,"epoch":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":101,"b":108}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":115,"b":123}]},{"name":"pool","required":true,"transform":{"type":"scalar"},"locs":[{"a":130,"b":135},{"a":212,"b":217}]},{"name":"epoch","required":true,"transform":{"type":"scalar"},"locs":[{"a":142,"b":148}]}],"statement":"INSERT INTO cde_cardano_pool_delegation(\n    cde_id,\n    address,\n    pool,\n    epoch\n) VALUES (\n    :cde_id!,\n    :address!,\n    :pool!,\n    :epoch!\n) ON CONFLICT (cde_id, epoch, address) DO\n  UPDATE SET pool = :pool!"};
 
 /**
  * Query generated from SQL:
@@ -55,15 +58,51 @@ const cdeCardanoPoolInsertDataIR: any = {"usedParamSet":{"cde_id":true,"address"
  * INSERT INTO cde_cardano_pool_delegation(
  *     cde_id,
  *     address,
- *     pool
+ *     pool,
+ *     epoch
  * ) VALUES (
  *     :cde_id!,
  *     :address!,
- *     :pool!
- * ) ON CONFLICT (cde_id, address) DO
+ *     :pool!,
+ *     :epoch!
+ * ) ON CONFLICT (cde_id, epoch, address) DO
  *   UPDATE SET pool = :pool!
  * ```
  */
 export const cdeCardanoPoolInsertData = new PreparedQuery<ICdeCardanoPoolInsertDataParams,ICdeCardanoPoolInsertDataResult>(cdeCardanoPoolInsertDataIR);
+
+
+/** 'RemoveOldEntries' parameters type */
+export interface IRemoveOldEntriesParams {
+  address: string;
+}
+
+/** 'RemoveOldEntries' return type */
+export type IRemoveOldEntriesResult = void;
+
+/** 'RemoveOldEntries' query type */
+export interface IRemoveOldEntriesQuery {
+  params: IRemoveOldEntriesParams;
+  result: IRemoveOldEntriesResult;
+}
+
+const removeOldEntriesIR: any = {"usedParamSet":{"address":true},"params":[{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":179,"b":187},{"a":238,"b":246}]}],"statement":"DELETE FROM cde_cardano_pool_delegation\nWHERE (cde_id, epoch, address) NOT IN (\n    SELECT\n        cde_id, epoch, address\n    FROM cde_cardano_pool_delegation\n    WHERE address = :address!\n    ORDER BY epoch DESC\n\tLIMIT 2\n)\nAND address = :address!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM cde_cardano_pool_delegation
+ * WHERE (cde_id, epoch, address) NOT IN (
+ *     SELECT
+ *         cde_id, epoch, address
+ *     FROM cde_cardano_pool_delegation
+ *     WHERE address = :address!
+ *     ORDER BY epoch DESC
+ * 	LIMIT 2
+ * )
+ * AND address = :address!
+ * ```
+ */
+export const removeOldEntries = new PreparedQuery<IRemoveOldEntriesParams,IRemoveOldEntriesResult>(removeOldEntriesIR);
 
 

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.sql
@@ -1,15 +1,31 @@
 /* @name cdeCardanoPoolGetAddressDelegation */
 SELECT * FROM cde_cardano_pool_delegation 
-WHERE address = :address!;
+WHERE address = :address!
+ORDER BY epoch;
 
 /* @name cdeCardanoPoolInsertData */
 INSERT INTO cde_cardano_pool_delegation(
     cde_id,
     address,
-    pool
+    pool,
+    epoch
 ) VALUES (
     :cde_id!,
     :address!,
-    :pool!
-) ON CONFLICT (cde_id, address) DO
+    :pool!,
+    :epoch!
+) ON CONFLICT (cde_id, epoch, address) DO
   UPDATE SET pool = :pool!;
+
+
+/* @name removeOldEntries */
+DELETE FROM cde_cardano_pool_delegation
+WHERE (cde_id, epoch, address) NOT IN (
+    SELECT
+        cde_id, epoch, address
+    FROM cde_cardano_pool_delegation
+    WHERE address = :address!
+    ORDER BY epoch DESC
+	LIMIT 2
+)
+AND address = :address!;

--- a/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
@@ -197,12 +197,20 @@ export async function internalGetCardanoAddressDelegation(
     throw new Error('Current epoch table not initialized');
   }
 
-  return {
-    currentEpoch: currentEpoch[0].epoch,
-    events: results.map(r => {
-      return { pool: r.pool, epoch: r.epoch };
-    }),
-  };
+  if (currentEpoch[0].epoch === results[results.length - 1].epoch) {
+    return {
+      currentEpoch: currentEpoch[0].epoch,
+      events: results.map(r => {
+        return { pool: r.pool, epoch: r.epoch };
+      }),
+    };
+  } else {
+    const result = results[results.length - 1];
+    return {
+      currentEpoch: currentEpoch[0].epoch,
+      events: [{ pool: result.pool, epoch: result.epoch }],
+    };
+  }
 }
 
 export async function internalGetCardanoProjectedNft(

--- a/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
@@ -182,6 +182,14 @@ export async function internalGetAllOwnedErc6551Accounts(
   return results.map(row => row.account_created);
 }
 
+/**
+ * If the most recent delegation is the current epoch, we need to return the
+ * list of recent delegations so the app can know what delegation the user had
+ * beforehand since delegations only matters once they cross an epoch boundary
+ *
+ * If the most recent delegation isn't from the current epoch, we know it's the
+ * one that is active now
+ */
 export async function internalGetCardanoAddressDelegation(
   readonlyDBConn: Pool,
   address: string

--- a/packages/node-sdk/paima-utils-backend/src/cde-access.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access.ts
@@ -166,7 +166,7 @@ export async function getAllOwnedErc6551Accounts(
 export async function getCardanoAddressDelegation(
   readonlyDBConn: Pool,
   address: string
-): Promise<string | null> {
+): Promise<{ events: { pool: string | null; epoch: number }[]; currentEpoch: number } | null> {
   return await internalGetCardanoAddressDelegation(readonlyDBConn, address);
 }
 

--- a/packages/node-sdk/paima-utils-backend/src/cde-access.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access.ts
@@ -162,6 +162,11 @@ export async function getAllOwnedErc6551Accounts(
 
 /**
  * Fetch the pool this address is delegating to, if any.
+ *
+ * If the last delegation indexed for this address happened during the current
+ * epoch, this returns both the current delegation and the previous entry.
+ *
+ * Otherwise, this will just return a single entry.
  */
 export async function getCardanoAddressDelegation(
   readonlyDBConn: Pool,

--- a/packages/paima-sdk/paima-utils/src/constants.ts
+++ b/packages/paima-sdk/paima-utils/src/constants.ts
@@ -39,3 +39,7 @@ export const enum Network {
 }
 
 export const FUNNEL_PRESYNC_FINISHED = 'finished';
+
+export const enum InternalEventType {
+  CardanoBestEpoch,
+}


### PR DESCRIPTION
## About

### Problem

With the current implementation there is no way to figure out if the delegation has any effect, since there has to be an epoch boundary before that happens.

### Changes

This changes the `getCardanoAddressDelegation` to return either:

1. The last delegation event, if we crossed an epoch boundary already.
2. Both the delegation of the current epoch, plus the previous one.

The current epoch is now stored in the new `cardano_last_epoch` table.

Also `cde_cardano_pool_delegation` now stores the epoch. The epoch is part of the primary key, so only the last event for a certain epoch is in the db. But also only a maximum of 2 rows per address are stored. If the current epoch is greater than both of the epochs in those rows, the earliest one of those is actually ignored in the query, but it's not removed until another delegation tx is indexed for that address.