### PR TITLE
cardano-presync: avoid error when there was no previous sync started

### DIFF
--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -62,10 +62,14 @@ async function runPresync(
     startBlockHeight
   );
 
-  if (!ENV.CARP_URL && presyncBlockHeight[Network.CARDANO]) {
-    throw new Error(
-      '[paima-runtime] Detected Cardano CDE sync in progress, but CARP_URL is not set.'
-    );
+  if (!ENV.CARP_URL && presyncBlockHeight[Network.CARDANO] === -1) {
+    if (presyncBlockHeight[Network.CARDANO] === -1) {
+      delete presyncBlockHeight[Network.CARDANO];
+    } else {
+      throw new Error(
+        '[paima-runtime] Detected Cardano CDE sync in progress, but CARP_URL is not set.'
+      );
+    }
   }
 
   if (run) {

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -62,7 +62,7 @@ async function runPresync(
     startBlockHeight
   );
 
-  if (!ENV.CARP_URL && presyncBlockHeight[Network.CARDANO] === -1) {
+  if (!ENV.CARP_URL) {
     if (presyncBlockHeight[Network.CARDANO] === -1) {
       delete presyncBlockHeight[Network.CARDANO];
     } else {


### PR DESCRIPTION
When I changed the code to to address this review: https://github.com/PaimaStudios/paima-engine/pull/246#discussion_r1412980763 I forgot that the sigil of `-1` is used when there was no previous presync, instead of the entry not being there.