### PR TITLE
Update payload limits for servers

### DIFF
--- a/packages/batcher/webserver/src/index.ts
+++ b/packages/batcher/webserver/src/index.ts
@@ -25,7 +25,7 @@ const port = ENV.BATCHER_PORT;
 let pool: Pool;
 
 const server = express();
-const bodyParser = express.json();
+const bodyParser = express.json({ limit: '50mb' });
 server.use(cors());
 server.use(bodyParser);
 

--- a/packages/engine/paima-runtime/src/server.ts
+++ b/packages/engine/paima-runtime/src/server.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { ValidateError } from 'tsoa';
 
 const server: Express = express();
-const bodyParser = express.json();
+const bodyParser = express.json({ limit: '50mb' });
 
 server.use(cors());
 server.use(bodyParser);


### PR DESCRIPTION
Express defaults with a `100kb` limit for payloads. The SNEK game requires payloads larger than this

Games built with Paima cannot override server configurations like this themselves though, as game endpoints are simply loaded in Paima through the `packaged/endpoints.cjs` file using `engine.addEndpoints(importTsoaFunction());`

To unblock SNEK I added code to loosen these limits. This is not necessarily ideal since it also lets players send larger payloads to games to slow down their server, 

## Alternatives

- _(won't work)_ The `tsoa` library we use to generate the game code does have a way to specify middlewares ([link](https://tsoa-community.github.io/docs/custom-middlewares.html)), but my understanding is that middlewares added through `app.use` in Express are parsed in order they were added, so an error gets thrown before any custom override by a game gets executed (and any modification other than appending at the end with `app.use` is undefined behavior in Express)

- We could allow an ENV variable to override the value of this field in particular. It's not great to need an ENV variable for a single sub-config of a tool we use like this, but express doesn't look like it has any standard for standalone configuration files so ENV files may be the only option we have