### PR TITLE
add cml dependency

### DIFF
--- a/packages/engine/paima-funnel/package.json
+++ b/packages/engine/paima-funnel/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "assert-never": "^1.2.1",
     "@dcspark/carp-client": "^2.3.1",
-    "@dcspark/cardano-multiplatform-lib-nodejs": "^3.0.1"
+    "@dcspark/cardano-multiplatform-lib-nodejs": "^5.1.0"
   }
 }

--- a/packages/engine/paima-funnel/package.json
+++ b/packages/engine/paima-funnel/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "assert-never": "^1.2.1",
-    "@dcspark/carp-client": "^2.3.1"
+    "@dcspark/carp-client": "^2.3.1",
+    "@dcspark/cardano-multiplatform-lib-nodejs": "^3.0.1"
   }
 }

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -9,6 +9,7 @@ import type { FunnelSharedData } from '../BaseFunnel.js';
 import { RpcCacheEntry, RpcRequestState } from '../FunnelCache.js';
 import type { PoolClient } from 'pg';
 import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
+import { BigInt, Transaction } from '@dcspark/cardano-multiplatform-lib-nodejs';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
 
@@ -169,6 +170,10 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
     // we always write to this cache instead of reading from it
     // as other funnels used may want to read from this cached data
 
+    const tx =
+      '84ac008482582070d2229cb8737535ac876226fca8939f510e5819ca28eb6f952d50303917f87c1818825820859839bf9a1e3e6ef29502a0f48b444e579840816c43274d03574162fc01ae8c00825820c0621c786b6dba70ccc8059127d5f38504a4562f9e2125e2f62670109259b9df01825820e92617cf88c81c9ff13160e857740dab3f7906ef6d813c3e43220ff7236694f5140184a300581d70b4ba3beeaf14b14971e4604027ca594e8fd155f0cdbf1ada9cbd389401821a002dc6c0a1581ca07d73e29a97d0c2e4057badbc27896819cec90d11e052b236b20e41a14001028201d818479f0000000000ffa300581d7068b27aef9fd71651b76eabe6994367439822e8374727118a35eadddc01821a002dc6c0a1581c51bed4db1e9ec8ca4668fc3d217c2efb0029f727c2b80e1e1833796ba14001028201d81858739f1b00000151fe122045021b000043305ce669931b0000000603ce842e1a07512d241b003bf7720a76461e9fc24a032b7cd486b794d2d4d3c24c1580931d1970000000000000ff1b0000018ceecf05901b0000018ceedf84389f1b0000015807bb2ef61b000043305ce66993ff1a002dc6c0ffa300581d703a85e74973d226016bb10f39a0113708856af24408c69ee983f4f73001821a002dc6c0a2581c919d4c2c9455016289341b1a14dedf697687af31751170d56a31466ea144744d494e1b00000151fe122047581ca609c1e386119f68c1d8c5a6555d3417fb10995cee7c8ae1f059d689a14001028201d8184a9f9f0000000000ff02ff82581d609023df4c4713f77ecf9059fe3bba69483cf05de4774218bbb18c8f2d1a0016a05d021a00055e5d031a02464153081a024640270b58204406bffec23011ce81ceab9f7b63f54a8aeff4ef306b08ed7a887666d6805cf70d818258202bca342967927bcb745c69481bd5ad8f30bad124c5d393975e7338d2b098495f040e81581c9023df4c4713f77ecf9059fe3bba69483cf05de4774218bbb18c8f2d0f001082581d609023df4c4713f77ecf9059fe3bba69483cf05de4774218bbb18c8f2d1a0ad79d9b111a002dc6c01283825820025b9cbf45c8464a089bc2684273ad5c6cc2ef27722c8bc2ce42a9543ef3d9d9008258204280930e71e84199480b3511c94dd98251936edb35bdad0e91213e8a6ae5724804825820ccbe05ae6e573702c4596e57541bab35301c4d92c4d79ca4c1c3cdffc72d5eb200a3008182582069b608b7ca2772942d57c7ed4258e4a6bfbae49c633d58e33848e7b50af705aa58402cea244415e440dd75f3f7db3fc946eb70a0b62302c4000817c7318f1efebde1da1c27b5f1c4e7cd3dbceae15804c186d51b722e1b84caece20cdb0bc2a56701048005828400011a002dc6c0821a0017c76d1a28e19b56840002d87980821984221a00cd339ff5f6';
+    console.log('tx decoded', computeOutputs(Buffer.from(tx, 'hex')));
+
     const latestBlock: number = await timeout(
       sharedData.web3.eth.getBlockNumber(),
       GET_BLOCK_NUMBER_TIMEOUT
@@ -186,4 +191,78 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
 
     return new BlockFunnel(sharedData, dbTx);
   }
+}
+
+function computeOutputs(
+  tx: Buffer
+): { asset: { policyId: string; assetName: string } | null; amount: string; address: string }[] {
+  const transaction = Transaction.from_bytes(tx);
+
+  const rawOutputs = transaction.body().outputs();
+
+  const outputs = [];
+
+  for (let i = 0; i < rawOutputs.len(); i++) {
+    const output = rawOutputs.get(i);
+
+    const rawAddress = output.address();
+    const address = rawAddress.to_bech32();
+    rawAddress.free();
+
+    const amount = output.amount();
+    const ma = amount.multiasset();
+
+    if (ma) {
+      const policyIds = ma.keys();
+
+      for (let j = 0; j < policyIds.len(); j++) {
+        const policyId = policyIds.get(j);
+
+        const assets = ma.get(policyId);
+
+        if (!assets) {
+          policyId.free();
+          continue;
+        }
+
+        const assetNames = assets.keys();
+
+        for (let k = 0; k < assetNames.len(); k++) {
+          const assetName = assetNames.get(k);
+
+          const amount = assets.get(assetName);
+
+          if (amount !== undefined) {
+            outputs.push({
+              amount: amount.to_str(),
+              asset: {
+                policyId: policyId.to_hex(),
+                assetName: Buffer.from(assetName.to_bytes()).toString('hex'),
+              },
+              address,
+            });
+          }
+
+          assetName.free();
+        }
+
+        assetNames.free();
+        assets.free();
+        policyId.free();
+      }
+
+      policyIds.free();
+      ma.free();
+    }
+
+    outputs.push({ amount: amount.coin().toString(), asset: null, address });
+
+    amount.free();
+    output.free();
+  }
+
+  rawOutputs.free();
+  transaction.free();
+
+  return outputs;
 }

--- a/packages/engine/paima-standalone/package.json
+++ b/packages/engine/paima-standalone/package.json
@@ -31,7 +31,8 @@
       "./contracts/**/*",
       "./batcher/**/*",
       "./documentation/**/*",
-      "./swagger-ui/**/*"
+      "./swagger-ui/**/*",
+      "./cardano_multiplatform_lib_bg.wasm"
     ],
     "targets": [
       "node20-linux-x64",

--- a/packages/engine/paima-standalone/scripts/prepare_standalone_folders.sh
+++ b/packages/engine/paima-standalone/scripts/prepare_standalone_folders.sh
@@ -46,3 +46,6 @@ rm -rf $TEMPLATES_PATH/.git
 # Add in swagger static UI
 cp -r ../../../node_modules/swagger-ui-dist/ $SWAGGER_UI
 rm $SWAGGER_UI/index.html # this will get overwriten at runtime by swagger-ui-express
+
+# Copy CML wasm file
+cp ../../../node_modules/@dcspark/cardano-multiplatform-lib-nodejs/cardano_multiplatform_lib_bg.wasm $PACKAGED_PATH


### PR DESCRIPTION
Not necessarily a PR to merge, mostly to isolate a problem that I don't know how to fix, although we could remove the test code and merge it if it works.

The code in the block funnel is there only to test this without needing to setup a cde, just running the engine should be enough.

The problem:

*version*: ^3.0.1

I get this error when bootstrapping:

```
LinkError: WebAssembly.Instance(): Import #4 module="__wbindgen_placeholder__" function="__wbg_new_1d9a920c6bfc44a8" error: function import requires a callable
```

*version*: 4.0.2 (latest)

This version was giving a similar error to me yesterday, but now it actually manages to run partially, so there may be other issue around. The problem is that when the binding code uses https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN it gets undefined (for example, when trying to get the amount of a multiasset from an asset name).

I think this may be because the class does not get extended correctly. The code in `engineCorePacked.js` has something like this

```ts
var BigInt4 = class _BigInt {
      static __wrap(ptr) {
        const obj2 = Object.create(_BigInt.prototype);
     ...
```

Which does not seem correct? (The original uses `BigInt` in both places).

Ideally we would use this version, but I tried both just in case it was only an issue with `BigInt` support.