### PR TITLE
Split NODE_ENV and NETWORK to two separate variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10530,31 +10530,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/abitype": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "peer": true,
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.19.1"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
@@ -11888,6 +11863,7 @@
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "check-error": "^1.0.2"
       },
@@ -17731,22 +17707,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/isows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "peer": true,
-      "peerDependencies": {
-        "ws": "*"
-      }
     },
     "node_modules/isstream": {
       "version": "0.1.2",
@@ -24993,100 +24953,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/viem": {
-      "version": "1.21.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.4.tgz",
-      "integrity": "sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@scure/bip32": "1.3.2",
-        "@scure/bip39": "1.2.1",
-        "abitype": "0.9.8",
-        "isows": "1.0.3",
-        "ws": "8.13.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vlq": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
@@ -27593,7 +27459,6 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-foundry": "^1.1.1",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-        "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
         "@openzeppelin/contracts": "^4.6.0",
         "hardhat": "^2.19.3",
         "hardhat-abi-exporter": "^2.10.1",
@@ -27603,64 +27468,8 @@
       "peerDependencies": {
         "@nomicfoundation/hardhat-foundry": "^1.1.1",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-        "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
         "@openzeppelin/contracts": "^4.6.0",
         "hardhat": "^2.19.3"
-      }
-    },
-    "packages/contracts/evm-contracts/node_modules/@nomicfoundation/hardhat-toolbox-viem": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox-viem/-/hardhat-toolbox-viem-2.0.0.tgz",
-      "integrity": "sha512-1bxTaC+PcbdctwgP/AvmKJGQTeLoT2kJtAfaDvt5PbL3esZ1EO+pfoBkpliP3DJSNESLSqAjVN1yIFxoLJmiBg==",
-      "dev": true,
-      "dependencies": {
-        "chai-as-promised": "^7.1.1"
-      },
-      "peerDependencies": {
-        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
-        "@nomicfoundation/hardhat-verify": "^2.0.0",
-        "@nomicfoundation/hardhat-viem": "^1.0.0",
-        "@types/chai": "^4.2.0",
-        "@types/chai-as-promised": "^7.1.6",
-        "@types/mocha": ">=9.1.0",
-        "@types/node": ">=16.0.0",
-        "chai": "^4.2.0",
-        "hardhat": "^2.11.0",
-        "hardhat-gas-reporter": "^1.0.8",
-        "solidity-coverage": "^0.8.1",
-        "ts-node": ">=8.0.0",
-        "typescript": "~5.0.4",
-        "viem": "^1.15.1"
-      }
-    },
-    "packages/contracts/evm-contracts/node_modules/@nomicfoundation/hardhat-viem": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-viem/-/hardhat-viem-1.0.2.tgz",
-      "integrity": "sha512-MkUWxHF++6tWr1Mj4kCtyfZasSxGZCn8a51XorKmMQaMtgMXFxGLOzkbuqxfpRyRezS+6uyrzHWYcIcZJFlrcQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "abitype": "^0.9.8",
-        "lodash.memoize": "^4.1.2"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.17.0",
-        "typescript": "~5.0.0",
-        "viem": "^1.15.1"
-      }
-    },
-    "packages/contracts/evm-contracts/node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "packages/engine/paima-funnel": {

--- a/packages/batcher/batcher-standalone/scripts/docker/docker-compose.yml
+++ b/packages/batcher/batcher-standalone/scripts/docker/docker-compose.yml
@@ -38,14 +38,14 @@ services:
     ports:
       - '${BATCHER_PORT}:${BATCHER_PORT}'
     volumes:
-      - ../.env.${NODE_ENV:-production}:/app/.env.${NODE_ENV:-production}
+      - ../.env.${NETWORK:-localhost}:/app/.env.${NETWORK:-localhost}
     restart: 'unless-stopped'
     links:
       - paima-batcher-db
     depends_on:
       - paima-batcher-db
     env_file:
-      - ../.env.${NODE_ENV:-production}
+      - ../.env.${NETWORK:-localhost}
 
 volumes:
   data:

--- a/packages/batcher/batcher-standalone/scripts/docker/shutdown.sh
+++ b/packages/batcher/batcher-standalone/scripts/docker/shutdown.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-export ENV_FILE="../.env.${NODE_ENV:-production}"; docker compose --env-file $ENV_FILE down -v
+export ENV_FILE="../.env.${NETWORK:-localhost}"; docker compose --env-file $ENV_FILE down -v

--- a/packages/batcher/batcher-standalone/scripts/docker/start.sh
+++ b/packages/batcher/batcher-standalone/scripts/docker/start.sh
@@ -7,4 +7,4 @@ fi
 
 if [ ! -x ./paima-batcher-linux ]; then chmod +x ./paima-batcher-linux; fi
 
-export ENV_FILE="../.env.${NODE_ENV:-production}"; echo \"ENV FILE: $ENV_FILE\"; docker compose --env-file $ENV_FILE build && docker compose --env-file $ENV_FILE up
+export ENV_FILE="../.env.${NETWORK:-localhost}"; echo \"ENV FILE: $ENV_FILE\"; docker compose --env-file $ENV_FILE build && docker compose --env-file $ENV_FILE up

--- a/packages/batcher/utils/src/config.ts
+++ b/packages/batcher/utils/src/config.ts
@@ -3,7 +3,7 @@ import { config } from 'dotenv';
 import { ENV as ENGINE_ENV } from '@paima/utils';
 
 // Load environment variables
-config({ path: `${process.cwd()}/.env.${process.env.NODE_ENV || 'development'}` });
+config({ path: `${process.cwd()}/.env.${process.env.NETWORK || 'localhost'}` });
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class ENV {

--- a/packages/build-utils/paima-build-utils/scripts/change-db.js
+++ b/packages/build-utils/paima-build-utils/scripts/change-db.js
@@ -49,7 +49,7 @@ const updateDockerFile = async file => {
 };
 
 const start = async () => {
-  await updateEnvFile(`../.env.${process.env.NODE_ENV ?? 'development'}`);
+  await updateEnvFile(`../.env.${process.env.NETWORK ?? 'localhost'}`);
   await updateDockerFile('db/docker/docker-compose.yml');
 };
 

--- a/packages/contracts/evm-contracts/package.json
+++ b/packages/contracts/evm-contracts/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-foundry": "^1.1.1",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-    "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
     "@openzeppelin/contracts": "^4.6.0",
     "hardhat": "^2.19.3",
     "hardhat-abi-exporter": "^2.10.1",
@@ -37,7 +36,6 @@
   "peerDependencies": {
     "@nomicfoundation/hardhat-foundry": "^1.1.1",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-    "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
     "@openzeppelin/contracts": "^4.6.0",
     "hardhat": "^2.19.3"
   }

--- a/packages/engine/paima-standalone/src/index.ts
+++ b/packages/engine/paima-standalone/src/index.ts
@@ -13,7 +13,7 @@ setLogger(s => {
 });
 
 // Load environment variables
-config({ path: `${process.cwd()}/.env.${process.env.NODE_ENV || 'development'}` });
+config({ path: `${process.cwd()}/.env.${process.env.NETWORK || 'localhost'}` });
 
 async function main(): Promise<void> {
   await parseSecurityYaml();

--- a/packages/engine/paima-standalone/src/utils/index.ts
+++ b/packages/engine/paima-standalone/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { config } from 'dotenv';
 import type { PoolConfig } from 'pg';
 
-config({ path: `${process.cwd()}/.env.${process.env.NODE_ENV || 'development'}` });
+config({ path: `${process.cwd()}/.env.${process.env.NETWORK || 'localhost'}` });
 
 export const poolConfig: PoolConfig = {
   host: process.env.DB_HOST || '',

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -94,7 +94,7 @@ export const runPaimaEngine = async (): Promise<void> => {
   // Verify env file is filled out before progressing
   if (!ENV.CONTRACT_ADDRESS || !ENV.CHAIN_URI || !ENV.CHAIN_ID || !ENV.START_BLOCKHEIGHT) {
     doLog(
-      'Please ensure that your .env.{NODE_ENV} file is filled out properly before starting your game node.'
+      'Please ensure that your .env.{NETWORK} file is filled out properly before starting your game node.'
     );
     process.exit(0);
   }

--- a/packages/paima-sdk/paima-mw-core/package.json
+++ b/packages/paima-sdk/paima-mw-core/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint:eslint": "eslint .",
     "build": "tsc",
-    "build:standalone-web-ui": "NODE_ENV=${NODE_ENV:=development} DOTENV_CONFIG_PATH=\"../../.env.$NODE_ENV\" node --require dotenv/config ./esbuildconfig.cjs",
+    "build:standalone-web-ui": "DOTENV_CONFIG_PATH=\"../../.env.{$NETWORK:-localhost}\" node --require dotenv/config ./esbuildconfig.cjs",
     "start:standalone-web-ui": "npx http-server ./web -o --port 9123"
   },
   "devDependencies": {

--- a/packages/paima-sdk/paima-utils/src/config.ts
+++ b/packages/paima-sdk/paima-utils/src/config.ts
@@ -3,13 +3,13 @@ import type { VersionString } from './types.js';
 export class ENV {
   static doHealthCheck(): void {
     if (!ENV.CONTRACT_ADDRESS) {
-      throw new Error(`Please ensure your .env.${ENV.NODE_ENV} is properly filled out.`);
+      throw new Error(`Please ensure your .env.${ENV.NETWORK} is properly filled out.`);
     }
   }
 
   // System
-  static get NODE_ENV(): string {
-    return process.env.NODE_ENV || 'development';
+  static get NETWORK(): string {
+    return process.env.NETWORK || 'localhost';
   }
 
   // Target Blockchain:


### PR DESCRIPTION
I'm switching how networks work
It used to be NODE_ENV decided the network (development -> testnet, production -> mainnet)

This isn't good because
- testnet is also a production environment
- this doesn't scale when you have more than 2 networks

Notably, starting with the next version of Paima, we will actually have 3 networks for most games
- localhost (the new default)
- testnet
- mainnet

localhost is the locally created EVM network that Hardhat generates for you. All addresses and contracts are deterministic, which helps so much for making Paima games easy to deploy (we can have a .env.localhost that is entirely deterministic people can just use right away