### PR TITLE
parallel evm chain funnel sync + move multiple network configurations to a file

### DIFF
--- a/packages/batcher/utils/src/config-validation.ts
+++ b/packages/batcher/utils/src/config-validation.ts
@@ -5,7 +5,6 @@ export function getInvalidEnvVars(): string[] {
 
   const MANDATORY_TRUTHY_VARS: ReadonlyArray<keyof typeof ENV> = [
     // Blockchain
-    'CHAIN_URI',
     'CONTRACT_ADDRESS',
     'DEFAULT_FEE',
     'BATCHER_PRIVATE_KEY',

--- a/packages/batcher/webserver/src/index.ts
+++ b/packages/batcher/webserver/src/index.ts
@@ -19,6 +19,7 @@ import type { BatchedSubunit } from '@paima/concise';
 import { createMessageForBatcher } from '@paima/concise';
 import { AddressType, getWriteNamespace } from '@paima/utils';
 import { hashBatchSubunit } from '@paima/concise';
+import { GlobalConfig } from '@paima/utils';
 
 const port = ENV.BATCHER_PORT;
 
@@ -105,7 +106,8 @@ async function initializeServer(
   errorCodeToMessage: ErrorMessageFxn,
   truffleProvider: TruffleEvmProvider
 ): Promise<void> {
-  const addressValidator = new AddressValidator(ENV.CHAIN_URI, pool);
+  const [chainName, config] = await GlobalConfig.mainEvmConfig();
+  const addressValidator = new AddressValidator(config.chainUri, pool);
   await addressValidator.initialize();
 
   server.get(

--- a/packages/build-utils/paima-build-utils/src/middleware-esbuildconfig.template.cts
+++ b/packages/build-utils/paima-build-utils/src/middleware-esbuildconfig.template.cts
@@ -17,13 +17,7 @@ if (process.env.SECURITY_NAMESPACE) {
 }
 
 // Verify env file is filled out
-if (
-  !process.env.CONTRACT_ADDRESS ||
-  !process.env.CHAIN_URI ||
-  !process.env.CHAIN_ID ||
-  !process.env.BACKEND_URI
-)
-  throw new Error('Please ensure you have filled out your .env file');
+if (!process.env.BACKEND_URI) throw new Error('Please ensure you have filled out your .env file');
 
 export const config: esbuild.BuildOptions = {
   // JS output from previous compilation step used here instead of index.ts to have more control over the TS build process

--- a/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
+++ b/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
@@ -124,6 +124,7 @@ export class EvmFunnelCacheEntry implements FunnelCacheEntry {
       timestampToBlockNumber: [number, number][];
       lastBlock: number | undefined;
       startBlockHeight: number;
+      maxTimestamp: number;
     }>
   > = {};
   public static readonly SYMBOL = Symbol('EvmFunnelCacheEntry');
@@ -136,7 +137,13 @@ export class EvmFunnelCacheEntry implements FunnelCacheEntry {
   ): void => {
     this.cachedData[chainId] = {
       state: RpcRequestState.HasResult,
-      result: { bufferedChainData, timestampToBlockNumber, startBlockHeight, lastBlock: undefined },
+      result: {
+        bufferedChainData,
+        timestampToBlockNumber,
+        startBlockHeight,
+        lastBlock: undefined,
+        maxTimestamp: 0,
+      },
     };
   };
 
@@ -146,6 +153,7 @@ export class EvmFunnelCacheEntry implements FunnelCacheEntry {
       timestampToBlockNumber: [number, number][];
       lastBlock: number | undefined;
       startBlockHeight: number;
+      maxTimestamp: number;
     }>
   > {
     return (

--- a/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
+++ b/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
@@ -116,17 +116,16 @@ export class CarpFunnelCacheEntry implements FunnelCacheEntry {
   };
 }
 
+export type EvmFunnelCacheEntryState = {
+  bufferedChainData: ChainData[];
+  timestampToBlockNumber: [number, number][];
+  lastBlock: number | undefined;
+  startBlockHeight: number;
+  lastMaxTimestamp: number;
+};
+
 export class EvmFunnelCacheEntry implements FunnelCacheEntry {
-  private cachedData: Record<
-    number,
-    RpcRequestResult<{
-      bufferedChainData: ChainData[];
-      timestampToBlockNumber: [number, number][];
-      lastBlock: number | undefined;
-      startBlockHeight: number;
-      maxTimestamp: number;
-    }>
-  > = {};
+  private cachedData: Record<number, RpcRequestResult<EvmFunnelCacheEntryState>> = {};
   public static readonly SYMBOL = Symbol('EvmFunnelCacheEntry');
 
   public updateState = (
@@ -142,20 +141,12 @@ export class EvmFunnelCacheEntry implements FunnelCacheEntry {
         timestampToBlockNumber,
         startBlockHeight,
         lastBlock: undefined,
-        maxTimestamp: 0,
+        lastMaxTimestamp: 0,
       },
     };
   };
 
-  public getState(chainId: number): Readonly<
-    RpcRequestResult<{
-      bufferedChainData: ChainData[];
-      timestampToBlockNumber: [number, number][];
-      lastBlock: number | undefined;
-      startBlockHeight: number;
-      maxTimestamp: number;
-    }>
-  > {
+  public getState(chainId: number): Readonly<RpcRequestResult<EvmFunnelCacheEntryState>> {
     return (
       this.cachedData[chainId] ?? {
         state: RpcRequestState.NotRequested,

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -9,7 +9,7 @@ import type { FunnelSharedData } from '../BaseFunnel.js';
 import { RpcCacheEntry, RpcRequestState } from '../FunnelCache.js';
 import type { PoolClient } from 'pg';
 import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import { ConfigNetworkType } from '@paima/utils';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
 

--- a/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
@@ -263,7 +263,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
       ]);
 
       let grouped = groupCdeData(
-        'cardano',
+        this.chainName,
         ConfigNetworkType.CARDANO,
         arg.from,
         arg.to,

--- a/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
@@ -163,7 +163,8 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
       lastTimestamp,
       this.cache,
       this.config.confirmationDepth,
-      this.era
+      this.era,
+      this.chainName
     );
 
     const composed = composeChainData(this.bufferedData, grouped);
@@ -342,7 +343,8 @@ async function readDataInternal(
   lastTimestamp: number,
   cache: CarpFunnelCacheEntry,
   confirmationDepth: number,
-  era: Era
+  era: Era,
+  chainName: string
 ): Promise<PresyncChainData[]> {
   // the lower range is exclusive
   const min = timestampToAbsoluteSlot(era, lastTimestamp, confirmationDepth);
@@ -434,8 +436,7 @@ async function readDataInternal(
   );
 
   let grouped = groupCdeData(
-    // TODO: not really
-    'cardano',
+    chainName,
     ConfigNetworkType.CARDANO,
     data[0].blockNumber,
     data[data.length - 1].blockNumber,

--- a/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
@@ -8,6 +8,7 @@ import {
   GlobalConfig,
   logError,
   timeout,
+  ConfigNetworkType,
 } from '@paima/utils';
 import type { InternalEvent } from '@paima/sm';
 import {
@@ -29,7 +30,6 @@ import { Routes } from '@dcspark/carp-client/shared/routes';
 import { FUNNEL_PRESYNC_FINISHED, InternalEventType } from '@paima/utils';
 import { CarpFunnelCacheEntry } from '../FunnelCache.js';
 import { getCardanoEpoch } from '@paima/db';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
 
 const delayForWaitingForFinalityLoop = 1000;
 

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -91,8 +91,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
       }
     }
 
-    // TODO: just pick the last item?
-    const maxTimestamp = Math.max(...chainData.map(data => data.timestamp));
+    const maxTimestamp = chainData[chainData.length - 1].timestamp;
 
     const blocks = [];
 

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -222,7 +222,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
       );
     }
 
-    // This adds the internal even that updates the last block point. This is
+    // This adds the internal event that updates the last block point. This is
     // mostly to avoid having to do a binary search each time we boot the
     // engine. Since we need to know from where to start searching for blocks in
     // the timestamp range.

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -22,14 +22,12 @@ import {
   RpcRequestState,
 } from '../FunnelCache.js';
 import type { PoolClient } from 'pg';
-import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import { FUNNEL_PRESYNC_FINISHED, ConfigNetworkType } from '@paima/utils';
 import { getMultipleBlockData } from '../../reading.js';
 import { getLatestProcessedCdeBlockheight } from '@paima/db';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
 
-// INVARIANT:
 export class EvmFunnel extends BaseFunnel implements ChainFunnel {
   config: EvmConfig;
   chainName: string;

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -239,7 +239,6 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
       //
       // in this case it could be more optimal to set the block number here to
       // the one in the next block, but it shouldn't make much of a difference.
-      // TODO: is that true?
       if (originalBlockNumber) {
         chainData.internalEvents?.push({
           type: InternalEventType.EvmLastBlock,

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -1,0 +1,428 @@
+import { ENV, EvmConfig, doLog, initWeb3, logError, timeout, Web3, delay } from '@paima/utils';
+import type { ChainFunnel, ReadPresyncDataFrom } from '@paima/runtime';
+import type { ChainData, PresyncChainData } from '@paima/sm';
+import { getUngroupedCdeData } from '../../cde/reading.js';
+import { composeChainData, groupCdeData } from '../../utils.js';
+import { BaseFunnel } from '../BaseFunnel.js';
+import type { FunnelSharedData } from '../BaseFunnel.js';
+import { EvmFunnelCacheEntry, RpcCacheEntry, RpcRequestState } from '../FunnelCache.js';
+import type { PoolClient } from 'pg';
+import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
+import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import { getMultipleBlockData } from '../../reading.js';
+
+const GET_BLOCK_NUMBER_TIMEOUT = 5000;
+
+// INVARIANT:
+export class EvmFunnel extends BaseFunnel implements ChainFunnel {
+  config: EvmConfig;
+  chainName: string;
+
+  protected constructor(
+    sharedData: FunnelSharedData,
+    dbTx: PoolClient,
+    config: EvmConfig,
+    chainName: string,
+    private readonly baseFunnel: ChainFunnel,
+    private readonly web3: Web3
+  ) {
+    super(sharedData, dbTx);
+    this.readData.bind(this);
+    this.readPresyncData.bind(this);
+    this.getDbTx.bind(this);
+    this.config = config;
+    this.chainName = chainName;
+  }
+
+  public override async readData(blockHeight: number): Promise<ChainData[]> {
+    const cachedState = this.getState();
+
+    // if in the previous round we couldn't return some blocks because the
+    // parallel chain didn't get far enough, we first process those.
+    if (cachedState.bufferedChainData.length === 0) {
+      const baseData = await this.baseFunnel.readData(blockHeight);
+      cachedState.bufferedChainData.push(...baseData);
+    }
+
+    const latestBlockQueryState = this.latestBlock();
+    const latestBlock = await this.web3.eth.getBlock(latestBlockQueryState);
+
+    const chainData: ChainData[] = [];
+
+    // filter the data so that we are sure we can get all the blocks in the range
+    for (const data of cachedState.bufferedChainData) {
+      if (data.timestamp <= Number(latestBlock.timestamp)) {
+        chainData.push(data);
+      }
+    }
+
+    // the blocks that are not below the filtered are kept in the cache
+    // TODO: is it fine to do this here, or should it happen at the end?
+    chainData.forEach(_ => cachedState.bufferedChainData.shift());
+
+    if (chainData.length === 0) {
+      return chainData;
+    }
+
+    if (!cachedState.lastBlock) {
+      const block = await this.sharedData.web3.eth.getBlock(chainData[0].blockNumber - 1);
+
+      const ts = Number(block.timestamp);
+      cachedState.lastBlock = await findBlockByTimestamp(this.web3, ts);
+    }
+
+    const minTimestamp = Math.min(...chainData.map(data => data.timestamp));
+    const maxTimestamp = Math.max(...chainData.map(data => data.timestamp));
+
+    const blocks = [];
+
+    while (true) {
+      const latestBlock = this.latestBlock();
+
+      // we need to fetch the blocks in order to know the timestamps, so that we
+      // can make a mapping from the trunk chain to the parallel chain.
+      const parallelEvmBlocks = await getMultipleBlockData(
+        this.web3,
+        cachedState.lastBlock + 1,
+        Math.min(latestBlock, cachedState.lastBlock + 1 + ENV.DEFAULT_FUNNEL_GROUP_SIZE),
+        this.chainName
+      );
+
+      blocks.push(...parallelEvmBlocks);
+
+      if (blocks.length > 0 && blocks[blocks.length - 1].timestamp >= maxTimestamp) {
+        break;
+      }
+
+      while ((await this.updateLatestBlock()) === latestBlock) {
+        // wait for blocks to be produced
+        await delay(500);
+      }
+
+      // potentially we didn't fetch enough blocks in a single request in that
+      // case we get more blocks we loop again
+    }
+
+    // After we get the blocks from the parallel evm chain, we need to join them
+    // with the trunk. We need to then assign back the blocks from the side
+    // chain to the main chain.
+    const inverseMapping: { [blockNumber: number]: number } = {};
+
+    // chainData is sorted by timestamp, so we never need to search old entries,
+    // we keep this around to know from where to start searching for a block
+    // from the original chain that has a timestamp >= than the current
+    // sidechain block
+    let currIndex = 0;
+
+    for (const block of blocks) {
+      cachedState.timestampToBlockNumber.push([block.timestamp, block.blockNumber]);
+
+      while (currIndex < chainData.length) {
+        if (chainData[currIndex].timestamp >= block.timestamp) {
+          inverseMapping[block.blockNumber] = chainData[currIndex].blockNumber;
+          break;
+        } else {
+          currIndex++;
+        }
+      }
+
+      cachedState.lastBlock = block.blockNumber;
+    }
+
+    while (true) {
+      if (cachedState.timestampToBlockNumber.length === 0) {
+        return chainData;
+      }
+
+      if (cachedState.timestampToBlockNumber[0][0] < minTimestamp) {
+        cachedState.timestampToBlockNumber.shift();
+      } else {
+        break;
+      }
+    }
+
+    if (!cachedState.timestampToBlockNumber[0]) {
+      return chainData;
+    }
+
+    const fromBlock = cachedState.timestampToBlockNumber[0][1];
+
+    let toBlock = getToBlock(cachedState.timestampToBlockNumber, maxTimestamp) || fromBlock;
+
+    if (!toBlock || fromBlock < 0 || toBlock < fromBlock) {
+      return chainData;
+    }
+
+    if (toBlock === fromBlock) {
+      doLog(`EVM CDE funnel ${this.config.chainId}: #${toBlock}`);
+      return await this.internalReadDataSingle(fromBlock, chainData[0]);
+    } else {
+      doLog(`EVM CDE funnel ${this.config.chainId}: #${fromBlock}-${toBlock}`);
+      return await this.internalReadDataMulti(
+        fromBlock,
+        toBlock,
+        chainData,
+        blockNumber => inverseMapping[blockNumber]
+      );
+    }
+  }
+
+  private internalReadDataSingle = async (
+    blockNumber: number,
+    baseChainData: ChainData
+  ): Promise<ChainData[]> => {
+    if (blockNumber < 0) {
+      return [];
+    }
+    try {
+      const cdeData = await getUngroupedCdeData(
+        this.web3,
+        this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+        blockNumber,
+        blockNumber
+      );
+
+      return [
+        {
+          ...baseChainData,
+          extensionDatums: baseChainData.extensionDatums?.concat(cdeData.flat()) || cdeData.flat(),
+        },
+      ];
+    } catch (err) {
+      doLog(`[funnel] at ${blockNumber} caught ${err}`);
+      throw err;
+    }
+  };
+
+  private internalReadDataMulti = async (
+    fromBlock: number,
+    toBlock: number,
+    baseChainData: ChainData[],
+    sidechainToMainchainNumber: (blockNumber: number) => number
+  ): Promise<ChainData[]> => {
+    if (toBlock < fromBlock || fromBlock < 0) {
+      return [];
+    }
+
+    try {
+      const ungroupedCdeData = await getUngroupedCdeData(
+        this.web3,
+        this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+        fromBlock,
+        toBlock
+      );
+
+      const cdeData = groupCdeData(
+        this.chainName,
+        ConfigNetworkType.EVM_OTHER,
+        fromBlock,
+        toBlock,
+        ungroupedCdeData
+      );
+
+      for (const data of cdeData) {
+        data.blockNumber = sidechainToMainchainNumber(data.blockNumber);
+      }
+
+      return composeChainData(baseChainData, cdeData);
+    } catch (err) {
+      doLog(`[funnel] at ${fromBlock}-${toBlock} caught ${err}`);
+      throw err;
+    }
+  };
+
+  public override async readPresyncData(
+    args: ReadPresyncDataFrom
+  ): Promise<{ [network: string]: PresyncChainData[] | typeof FUNNEL_PRESYNC_FINISHED }> {
+    const baseData = await this.baseFunnel.readPresyncData(args);
+
+    let arg = args.find(arg => arg.network == this.chainName);
+
+    if (!arg) {
+      return baseData;
+    }
+
+    let fromBlock = arg.from;
+    let toBlock = arg.to;
+
+    if (fromBlock >= this.getState().startBlockHeight) {
+      return { ...baseData, [this.chainName]: FUNNEL_PRESYNC_FINISHED };
+    }
+
+    try {
+      toBlock = Math.min(toBlock, this.getState().startBlockHeight);
+      fromBlock = Math.max(fromBlock, 0);
+      if (fromBlock > toBlock) {
+        return baseData;
+      }
+
+      const ungroupedCdeData = await getUngroupedCdeData(
+        this.web3,
+        this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+        fromBlock,
+        toBlock
+      );
+      return {
+        ...baseData,
+        [this.chainName]: groupCdeData(
+          this.chainName,
+          ConfigNetworkType.EVM_OTHER,
+          fromBlock,
+          toBlock,
+          ungroupedCdeData
+        ),
+      };
+    } catch (err) {
+      doLog(`[paima-funnel::readPresyncData] Exception occurred while reading blocks: ${err}`);
+      throw err;
+    }
+  }
+
+  public static async recoverState(
+    sharedData: FunnelSharedData,
+    dbTx: PoolClient,
+    baseFunnel: ChainFunnel,
+    chainName: string,
+    config: EvmConfig,
+    startingBlockHeight: number
+  ): Promise<EvmFunnel> {
+    const web3 = await initWeb3(config.chainUri);
+    // we always write to this cache instead of reading from it
+    // as other funnels used may want to read from this cached data
+
+    const latestBlock: number = await timeout(web3.eth.getBlockNumber(), GET_BLOCK_NUMBER_TIMEOUT);
+    const cacheEntry = ((): RpcCacheEntry => {
+      const entry = sharedData.cacheManager.cacheEntries[RpcCacheEntry.SYMBOL];
+      if (entry != null) return entry;
+
+      const newEntry = new RpcCacheEntry();
+      sharedData.cacheManager.cacheEntries[RpcCacheEntry.SYMBOL] = newEntry;
+      return newEntry;
+    })();
+
+    cacheEntry.updateState(config.chainId, latestBlock);
+
+    const evmCacheEntry = ((): EvmFunnelCacheEntry => {
+      const entry = sharedData.cacheManager.cacheEntries[EvmFunnelCacheEntry.SYMBOL];
+      if (entry != null) return entry;
+
+      const newEntry = new EvmFunnelCacheEntry();
+
+      sharedData.cacheManager.cacheEntries[EvmFunnelCacheEntry.SYMBOL] = newEntry;
+      return newEntry;
+    })();
+
+    if (evmCacheEntry.getState(config.chainId).state !== RpcRequestState.HasResult) {
+      const startingBlock = await sharedData.web3.eth.getBlock(startingBlockHeight);
+
+      const mappedStartingBlockHeight = await findBlockByTimestamp(
+        web3,
+        Number(startingBlock.timestamp)
+      );
+
+      evmCacheEntry.updateState(config.chainId, [], [], mappedStartingBlockHeight);
+    }
+
+    return new EvmFunnel(sharedData, dbTx, config, chainName, baseFunnel, web3);
+  }
+
+  private latestBlock(): number {
+    const latestBlockQueryState = this.sharedData.cacheManager.cacheEntries[
+      RpcCacheEntry.SYMBOL
+    ]?.getState(this.config.chainId);
+
+    if (latestBlockQueryState?.state !== RpcRequestState.HasResult) {
+      throw new Error(`[funnel] latest block cache entry not found`);
+    }
+    return latestBlockQueryState.result;
+  }
+
+  private async updateLatestBlock(): Promise<number> {
+    const newLatestBlock = await this.web3.eth.getBlockNumber();
+
+    this.sharedData.cacheManager.cacheEntries[RpcCacheEntry.SYMBOL]?.updateState(
+      this.config.chainId,
+      newLatestBlock
+    );
+
+    return newLatestBlock;
+  }
+
+  private getState(): {
+    bufferedChainData: ChainData[];
+    timestampToBlockNumber: [number, number][];
+    lastBlock: number | undefined;
+    startBlockHeight: number;
+  } {
+    const bufferedState = this.sharedData.cacheManager.cacheEntries[
+      EvmFunnelCacheEntry.SYMBOL
+    ]?.getState(this.config.chainId);
+
+    if (bufferedState?.state !== RpcRequestState.HasResult) {
+      throw new Error(`[funnel] evm funnel state not initialized`);
+    }
+
+    return bufferedState.result;
+  }
+}
+
+export async function wrapToEvmFunnel(
+  chainFunnel: ChainFunnel,
+  sharedData: FunnelSharedData,
+  dbTx: PoolClient,
+  startingBlockHeight: number,
+  chainName: string,
+  config: EvmConfig
+): Promise<ChainFunnel> {
+  try {
+    const ebp = await EvmFunnel.recoverState(
+      sharedData,
+      dbTx,
+      chainFunnel,
+      chainName,
+      config,
+      startingBlockHeight
+    );
+    return ebp;
+  } catch (err) {
+    doLog('[paima-funnel] Unable to initialize evm cde events processor:');
+    logError(err);
+    throw new Error('[paima-funnel] Unable to initialize evm cde events processor');
+  }
+}
+
+async function findBlockByTimestamp(web3: Web3, timestamp: number): Promise<number> {
+  let low = 0;
+  let high = Number(await web3.eth.getBlockNumber()) + 1;
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+
+    const block = await web3.eth.getBlock(mid);
+
+    if (Number(block.timestamp) < timestamp) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}
+
+function getToBlock(
+  timestampToBlockNumber: [number, number][],
+  maxTimestamp: number
+): number | undefined {
+  let toBlock: number | undefined = undefined;
+
+  for (let i = timestampToBlockNumber.length; i > 0; i--) {
+    const [ts, toBlockInner] = timestampToBlockNumber[i - 1];
+
+    if (maxTimestamp <= ts) {
+      toBlock = toBlockInner;
+    }
+  }
+
+  return toBlock;
+}

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -270,7 +270,9 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
     try {
       const cdeData = await getUngroupedCdeData(
         this.web3,
-        this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+        this.sharedData.extensions.filter(
+          extension => !extension.network || extension.network === this.chainName
+        ),
         blockNumber,
         blockNumber
       );

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -90,7 +90,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
         const block = await this.sharedData.web3.eth.getBlock(chainData[0].blockNumber - 1);
 
         const ts = Number(block.timestamp);
-        cachedState.lastBlock = (await findBlockByTimestamp(this.web3, ts)) - 1;
+        cachedState.lastBlock = (await findBlockByTimestamp(this.web3, ts, this.chainName)) - 1;
       }
     }
 
@@ -434,7 +434,8 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
 
       const mappedStartingBlockHeight = await findBlockByTimestamp(
         web3,
-        Number(startingBlock.timestamp)
+        Number(startingBlock.timestamp),
+        chainName
       );
 
       evmCacheEntry.updateState(config.chainId, [], [], mappedStartingBlockHeight);
@@ -508,7 +509,11 @@ export async function wrapToEvmFunnel(
 }
 
 // performs binary search to find the corresponding block
-async function findBlockByTimestamp(web3: Web3, timestamp: number): Promise<number> {
+async function findBlockByTimestamp(
+  web3: Web3,
+  timestamp: number,
+  chainName: string
+): Promise<number> {
   let low = 0;
   let high = Number(await web3.eth.getBlockNumber()) + 1;
 
@@ -528,7 +533,9 @@ async function findBlockByTimestamp(web3: Web3, timestamp: number): Promise<numb
     }
   }
 
-  doLog(`EVM CDE funnel: Found block ${low} by binary search with #${requests} requests`);
+  doLog(
+    `EVM CDE funnel: Found block #${low} on ${chainName} by binary search with ${requests} requests`
+  );
 
   return low;
 }

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -360,12 +360,14 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
     let fromBlock = arg.from;
     let toBlock = arg.to;
 
-    if (fromBlock >= this.getState().startBlockHeight) {
+    const startBlockHeight = this.getState().startBlockHeight;
+
+    if (fromBlock >= startBlockHeight) {
       return { ...baseData, [this.chainName]: FUNNEL_PRESYNC_FINISHED };
     }
 
     try {
-      toBlock = Math.min(toBlock, this.getState().startBlockHeight);
+      toBlock = Math.min(toBlock, startBlockHeight - 1);
       fromBlock = Math.max(fromBlock, 0);
       if (fromBlock > toBlock) {
         return baseData;

--- a/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/evm/funnel.ts
@@ -92,7 +92,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
         const block = await this.sharedData.web3.eth.getBlock(chainData[0].blockNumber - 1);
 
         const ts = Number(block.timestamp);
-        cachedState.lastBlock = await findBlockByTimestamp(this.web3, ts);
+        cachedState.lastBlock = (await findBlockByTimestamp(this.web3, ts)) - 1;
       }
     }
 

--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -28,7 +28,7 @@ import { getLatestProcessedCdeBlockheight } from '@paima/db';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
 
-export class EvmFunnel extends BaseFunnel implements ChainFunnel {
+export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
   config: EvmConfig;
   chainName: string;
 
@@ -406,7 +406,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
     chainName: string,
     config: EvmConfig,
     startingBlockHeight: number
-  ): Promise<EvmFunnel> {
+  ): Promise<ParallelEvmFunnel> {
     const web3 = await initWeb3(config.chainUri);
 
     const latestBlock: number = await timeout(web3.eth.getBlockNumber(), GET_BLOCK_NUMBER_TIMEOUT);
@@ -443,7 +443,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
       evmCacheEntry.updateState(config.chainId, [], [], mappedStartingBlockHeight);
     }
 
-    return new EvmFunnel(sharedData, dbTx, config, chainName, baseFunnel, web3);
+    return new ParallelEvmFunnel(sharedData, dbTx, config, chainName, baseFunnel, web3);
   }
 
   // this is the latestBlock of the chain synced by this funnel
@@ -485,7 +485,7 @@ export class EvmFunnel extends BaseFunnel implements ChainFunnel {
   }
 }
 
-export async function wrapToEvmFunnel(
+export async function wrapToParallelEvmFunnel(
   chainFunnel: ChainFunnel,
   sharedData: FunnelSharedData,
   dbTx: PoolClient,
@@ -494,7 +494,7 @@ export async function wrapToEvmFunnel(
   config: EvmConfig
 ): Promise<ChainFunnel> {
   try {
-    const ebp = await EvmFunnel.recoverState(
+    const ebp = await ParallelEvmFunnel.recoverState(
       sharedData,
       dbTx,
       chainFunnel,

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -15,7 +15,7 @@ import { BlockFunnel } from './funnels/block/funnel.js';
 import type { FunnelSharedData } from './funnels/BaseFunnel.js';
 import { FunnelCacheManager } from './funnels/FunnelCache.js';
 import { wrapToCarpFunnel } from './funnels/carp/funnel.js';
-import { wrapToEvmFunnel } from './funnels/evm/funnel.js';
+import { wrapToParallelEvmFunnel } from './funnels/parallelEvm/funnel.js';
 import { ConfigNetworkType } from '@paima/utils';
 import type Web3 from 'web3';
 
@@ -83,7 +83,7 @@ export class FunnelFactory implements IFunnelFactory {
 
     let chainFunnel: ChainFunnel = await BlockFunnel.recoverState(this.sharedData, dbTx);
     for (const [chainName, config] of await GlobalConfig.otherEvmConfig()) {
-      chainFunnel = await wrapToEvmFunnel(
+      chainFunnel = await wrapToParallelEvmFunnel(
         chainFunnel,
         this.sharedData,
         dbTx,

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -16,7 +16,7 @@ import type { FunnelSharedData } from './funnels/BaseFunnel.js';
 import { FunnelCacheManager } from './funnels/FunnelCache.js';
 import { wrapToCarpFunnel } from './funnels/carp/funnel.js';
 import { wrapToEvmFunnel } from './funnels/evm/funnel.js';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import { ConfigNetworkType } from '@paima/utils';
 import type Web3 from 'web3';
 
 export class FunnelFactory implements IFunnelFactory {

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -1,6 +1,12 @@
 import type { PoolClient } from 'pg';
 
-import { ENV, getPaimaL2Contract, initWeb3, validatePaimaL2ContractAddress } from '@paima/utils';
+import {
+  ENV,
+  GlobalConfig,
+  getPaimaL2Contract,
+  initWeb3,
+  validatePaimaL2ContractAddress,
+} from '@paima/utils';
 import { loadChainDataExtensions } from '@paima/runtime';
 import type { ChainFunnel, IFunnelFactory } from '@paima/runtime';
 import type { ChainDataExtension } from '@paima/sm';
@@ -48,13 +54,7 @@ export class FunnelFactory implements IFunnelFactory {
     // and wrap it with dynamic decorators as needed
 
     let chainFunnel: ChainFunnel = await BlockFunnel.recoverState(this.sharedData, dbTx);
-    chainFunnel = await wrapToCarpFunnel(
-      chainFunnel,
-      this.sharedData,
-      dbTx,
-      ENV.CARP_URL,
-      ENV.START_BLOCKHEIGHT
-    );
+    chainFunnel = await wrapToCarpFunnel(chainFunnel, this.sharedData, dbTx, ENV.START_BLOCKHEIGHT);
     chainFunnel = await wrapToEmulatedBlocksFunnel(
       chainFunnel,
       this.sharedData,

--- a/packages/engine/paima-funnel/src/utils.ts
+++ b/packages/engine/paima-funnel/src/utils.ts
@@ -33,10 +33,31 @@ export function composeChainData(
   baseChainData: ChainData[],
   cdeData: PresyncChainData[]
 ): ChainData[] {
-  return baseChainData.map(blockData => ({
-    ...blockData,
-    extensionDatums: cdeData.find(
+  return baseChainData.map(blockData => {
+    const matchingData = cdeData.find(
       blockCdeData => blockCdeData.blockNumber === blockData.blockNumber
-    )?.extensionDatums,
-  }));
+    );
+
+    if (!matchingData) {
+      return blockData;
+    }
+
+    if (blockData.extensionDatums) {
+      if (matchingData.extensionDatums) {
+        blockData.extensionDatums.push(...matchingData.extensionDatums);
+      }
+    } else if (matchingData.extensionDatums) {
+      blockData.extensionDatums = matchingData.extensionDatums;
+    }
+
+    if (blockData.internalEvents) {
+      if (matchingData.internalEvents) {
+        blockData.internalEvents.push(...matchingData.internalEvents);
+      }
+    } else if (matchingData.internalEvents) {
+      blockData.internalEvents = matchingData.internalEvents;
+    }
+
+    return blockData;
+  });
 }

--- a/packages/engine/paima-funnel/src/utils.ts
+++ b/packages/engine/paima-funnel/src/utils.ts
@@ -1,5 +1,5 @@
 import type { ChainData, ChainDataExtensionDatum, PresyncChainData } from '@paima/sm';
-import { ConfigNetworkType } from '@paima/utils';
+import type { ConfigNetworkType } from '@paima/utils';
 
 export function groupCdeData(
   network: string,

--- a/packages/engine/paima-funnel/src/utils.ts
+++ b/packages/engine/paima-funnel/src/utils.ts
@@ -1,8 +1,9 @@
 import type { ChainData, ChainDataExtensionDatum, PresyncChainData } from '@paima/sm';
-import type { Network } from '@paima/utils';
+import { ConfigNetworkType } from '@paima/utils/src/config/loading';
 
 export function groupCdeData(
-  network: Network,
+  network: string,
+  networkType: ConfigNetworkType,
   fromBlock: number,
   toBlock: number,
   data: ChainDataExtensionDatum[][]
@@ -22,6 +23,7 @@ export function groupCdeData(
       blockNumber,
       extensionDatums,
       network,
+      networkType,
     });
   }
   return result;

--- a/packages/engine/paima-funnel/src/utils.ts
+++ b/packages/engine/paima-funnel/src/utils.ts
@@ -1,5 +1,5 @@
 import type { ChainData, ChainDataExtensionDatum, PresyncChainData } from '@paima/sm';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading';
+import { ConfigNetworkType } from '@paima/utils';
 
 export function groupCdeData(
   network: string,

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -71,6 +71,8 @@ export async function loadChainDataExtensions(
   }
 }
 
+const networkTagType = Type.Partial(Type.Object({ network: Type.String() }));
+
 // Validate the overall structure of the config file and extract the relevant data
 export function parseCdeConfigFile(configFileData: string): Static<typeof CdeConfig> {
   // Parse the YAML content into an object
@@ -84,73 +86,49 @@ export function parseCdeConfigFile(configFileData: string): Static<typeof CdeCon
       case CdeEntryTypeName.ERC20:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionErc20Config,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionErc20Config, networkTagType]),
           entry
         );
       case CdeEntryTypeName.ERC721:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionErc721Config,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionErc721Config, networkTagType]),
           entry
         );
       case CdeEntryTypeName.ERC20Deposit:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionErc20DepositConfig,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionErc20DepositConfig, networkTagType]),
           entry
         );
       case CdeEntryTypeName.Generic:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionGenericConfig,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionGenericConfig, networkTagType]),
           entry
         );
       case CdeEntryTypeName.ERC6551Registry:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionErc6551RegistryConfig,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionErc6551RegistryConfig, networkTagType]),
           entry
         );
       case CdeEntryTypeName.CardanoDelegation:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionCardanoDelegationConfig,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionCardanoDelegationConfig, networkTagType]),
           entry
         );
       case CdeEntryTypeName.CardanoProjectedNFT:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionCardanoProjectedNFTConfig,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionCardanoProjectedNFTConfig, networkTagType]),
           entry
         );
       case CdeEntryTypeName.CardanoDelayedAsset:
         return checkOrError(
           entry.name,
-          Type.Intersect([
-            ChainDataExtensionCardanoDelayedAssetConfig,
-            Type.Partial(Type.Object({ network: Type.String() })),
-          ]),
+          Type.Intersect([ChainDataExtensionCardanoDelayedAssetConfig, networkTagType]),
           entry
         );
       default:

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import YAML from 'yaml';
 import type Web3 from 'web3';
-import type { Static, TSchema } from '@sinclair/typebox';
+import { Type, type Static, type TSchema } from '@sinclair/typebox';
 import { Value, ValueErrorType } from '@sinclair/typebox/value';
 
 import type { AbiItem } from '@paima/utils';
@@ -80,21 +80,71 @@ export function parseCdeConfigFile(configFileData: string): Static<typeof CdeCon
   const checkedConfig = baseConfig.extensions.map(entry => {
     switch (entry.type) {
       case CdeEntryTypeName.ERC20:
-        return checkOrError(entry.name, ChainDataExtensionErc20Config, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([ChainDataExtensionErc20Config, Type.Object({ network: Type.String() })]),
+          entry
+        );
       case CdeEntryTypeName.ERC721:
-        return checkOrError(entry.name, ChainDataExtensionErc721Config, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([ChainDataExtensionErc721Config, Type.Object({ network: Type.String() })]),
+          entry
+        );
       case CdeEntryTypeName.ERC20Deposit:
-        return checkOrError(entry.name, ChainDataExtensionErc20DepositConfig, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([
+            ChainDataExtensionErc20DepositConfig,
+            Type.Object({ network: Type.String() }),
+          ]),
+          entry
+        );
       case CdeEntryTypeName.Generic:
-        return checkOrError(entry.name, ChainDataExtensionGenericConfig, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([
+            ChainDataExtensionGenericConfig,
+            Type.Object({ network: Type.String() }),
+          ]),
+          entry
+        );
       case CdeEntryTypeName.ERC6551Registry:
-        return checkOrError(entry.name, ChainDataExtensionErc6551RegistryConfig, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([
+            ChainDataExtensionErc6551RegistryConfig,
+            Type.Object({ network: Type.String() }),
+          ]),
+          entry
+        );
       case CdeEntryTypeName.CardanoDelegation:
-        return checkOrError(entry.name, ChainDataExtensionCardanoDelegationConfig, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([
+            ChainDataExtensionCardanoDelegationConfig,
+            Type.Object({ network: Type.String() }),
+          ]),
+          entry
+        );
       case CdeEntryTypeName.CardanoProjectedNFT:
-        return checkOrError(entry.name, ChainDataExtensionCardanoProjectedNFTConfig, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([
+            ChainDataExtensionCardanoProjectedNFTConfig,
+            Type.Object({ network: Type.String() }),
+          ]),
+          entry
+        );
       case CdeEntryTypeName.CardanoDelayedAsset:
-        return checkOrError(entry.name, ChainDataExtensionCardanoDelayedAssetConfig, entry);
+        return checkOrError(
+          entry.name,
+          Type.Intersect([
+            ChainDataExtensionCardanoDelayedAssetConfig,
+            Type.Object({ network: Type.String() }),
+          ]),
+          entry
+        );
       default:
         assertNever(entry.type);
     }
@@ -185,7 +235,7 @@ async function instantiateExtension(
         contract: getErc20Contract(config.contractAddress, web3),
       };
     case CdeEntryTypeName.Generic:
-      return await instantiateCdeGeneric(config, index, web3);
+      return { ...(await instantiateCdeGeneric(config, index, web3)), network: config.network };
     case CdeEntryTypeName.ERC6551Registry:
       const contractAddress = config.contractAddress ?? ERC6551_REGISTRY_DEFAULT.New;
       return {

--- a/packages/engine/paima-runtime/src/cde-config/utils.ts
+++ b/packages/engine/paima-runtime/src/cde-config/utils.ts
@@ -4,9 +4,9 @@ import { doLog } from '@paima/utils';
 
 import type { ChainDataExtension } from '@paima/sm';
 
-export function getEarliestStartBlockheight(config: ChainDataExtension[]): number {
+export function getEarliestStartBlockheight(config: ChainDataExtension[], network: string): number {
   const minStartBlockheight = config.reduce((min, cde) => {
-    if ('startBlockHeight' in cde) {
+    if ('startBlockHeight' in cde && cde.network === network) {
       return Math.min(min, cde.startBlockHeight);
     }
     return min;

--- a/packages/engine/paima-runtime/src/index.ts
+++ b/packages/engine/paima-runtime/src/index.ts
@@ -1,6 +1,6 @@
 import process from 'process';
 
-import { doLog, logError, ENV } from '@paima/utils';
+import { doLog, logError, ENV, GlobalConfig } from '@paima/utils';
 import { DataMigrations } from '@paima/db';
 import { validatePersistentCdeConfig } from './cde-config/validation.js';
 import type { IFunnelFactory, PaimaRuntimeInitializer } from './types.js';
@@ -100,8 +100,11 @@ async function runInitializationProcedures(
     );
     return false;
   }
+
+  const [chainName, config] = await GlobalConfig.mainEvmConfig();
+
   const smStarted =
-    (await gameStateMachine.presyncStarted()) || (await gameStateMachine.syncStarted());
+    (await gameStateMachine.presyncStarted(chainName)) || (await gameStateMachine.syncStarted());
   const cdeResult = await validatePersistentCdeConfig(
     funnelFactory.getExtensions(),
     gameStateMachine.getReadWriteDbConn(),

--- a/packages/engine/paima-runtime/src/index.ts
+++ b/packages/engine/paima-runtime/src/index.ts
@@ -139,7 +139,6 @@ async function startSafeRuntime(
         gameStateMachine,
         funnelFactory,
         pollingRate,
-        ENV.DEFAULT_PRESYNC_STEP_SIZE,
         ENV.START_BLOCKHEIGHT,
         stopBlockHeight,
         ENV.EMULATED_BLOCKS

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -83,7 +83,7 @@ async function runPresync(
         doLog(
           `[paima-runtime] Fetching data from ${network} in range: ${presyncBlockHeight[network]}-${upper[network]}`
         );
-      } else {
+      } else if (presyncBlockHeight[network]) {
         doLog(
           `[paima-runtime] Fetching data from ${network} in block: ${presyncBlockHeight[network]}`
         );

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -101,7 +101,8 @@ async function runPresync(
           network: network,
           from: height,
           to: upper[network],
-        }))
+        })),
+        cardanoConfig
       );
     });
   }
@@ -166,7 +167,8 @@ async function runPresyncRound(
   gameStateMachine: GameStateMachine,
   chainFunnel: ChainFunnel,
   pollingPeriod: number,
-  from: ReadPresyncDataFrom
+  from: ReadPresyncDataFrom,
+  cardanoConfig: [string, CardanoConfig] | undefined
 ): Promise<{ [network: string]: number }> {
   const latestPresyncDataList = await chainFunnel.readPresyncData(from);
 
@@ -188,8 +190,7 @@ async function runPresyncRound(
     await gameStateMachine.presyncProcess(dbTx, presyncData);
   }
 
-  // TODO: use the non-hardcoded name
-  const cardanoFrom = from.find(arg => arg.network === 'cardano');
+  const cardanoFrom = cardanoConfig && from.find(arg => arg.network === cardanoConfig[0]);
   if (cardanoFrom) {
     await gameStateMachine.markCardanoPresyncMilestone(dbTx, cardanoFrom.to);
   }

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -14,9 +14,8 @@ import {
 } from './utils.js';
 import { cleanNoncesIfTime } from './nonce-gc.js';
 import type { PoolClient } from 'pg';
-import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
-import type { CardanoConfig } from '@paima/utils/src/config/loading.js';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import { FUNNEL_PRESYNC_FINISHED, ConfigNetworkType } from '@paima/utils';
+import type { CardanoConfig } from '@paima/utils';
 
 // The core logic of paima runtime which polls the funnel and processes the resulting chain data using the game's state machine.
 // Of note, the runtime is designed to continue running/attempting to process the next required block no matter what errors propagate upwards.
@@ -81,11 +80,9 @@ async function runPresync(
 
     for (const network of Object.keys(networks)) {
       if (upper[network] > presyncBlockHeight[network]) {
-        doLog(
-          `${network}: ${JSON.stringify(presyncBlockHeight[network])}-${JSON.stringify(upper[network])}`
-        );
+        doLog(`[presync-round] ${network}: ${presyncBlockHeight[network]}-${upper[network]}`);
       } else {
-        doLog(`${network}: ${JSON.stringify(presyncBlockHeight[network])}`);
+        doLog(`[presync-round] ${network}: ${presyncBlockHeight[network]}`);
       }
     }
 

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -1,5 +1,5 @@
 import process from 'process';
-import { doLog, logError, delay, ENV, GlobalConfig } from '@paima/utils';
+import { doLog, logError, delay, GlobalConfig } from '@paima/utils';
 import { tx, DataMigrations } from '@paima/db';
 import { getEarliestStartBlockheight, getEarliestStartSlot } from './cde-config/utils.js';
 import type { ChainFunnel, IFunnelFactory, ReadPresyncDataFrom } from './types.js';

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -80,9 +80,13 @@ async function runPresync(
 
     for (const network of Object.keys(networks)) {
       if (upper[network] > presyncBlockHeight[network]) {
-        doLog(`[presync-round] ${network}: ${presyncBlockHeight[network]}-${upper[network]}`);
+        doLog(
+          `[paima-runtime] Fetching data from ${network} in range: ${presyncBlockHeight[network]}-${upper[network]}`
+        );
       } else {
-        doLog(`[presync-round] ${network}: ${presyncBlockHeight[network]}`);
+        doLog(
+          `[paima-runtime] Fetching data from ${network} in block: ${presyncBlockHeight[network]}`
+        );
       }
     }
 

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -15,11 +15,8 @@ import {
 import { cleanNoncesIfTime } from './nonce-gc.js';
 import type { PoolClient } from 'pg';
 import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
-import {
-  CardanoConfig,
-  CardanoConfigSchema,
-  ConfigNetworkType,
-} from '@paima/utils/src/config/loading.js';
+import type { CardanoConfig } from '@paima/utils/src/config/loading.js';
+import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
 
 // The core logic of paima runtime which polls the funnel and processes the resulting chain data using the game's state machine.
 // Of note, the runtime is designed to continue running/attempting to process the next required block no matter what errors propagate upwards.
@@ -82,12 +79,15 @@ async function runPresync(
         .map(([network, h]) => [network, h + stepSize - 1])
     );
 
-    // TODO: uncomment this
-    // if (upper[Network.EVM] > presyncBlockHeight[Network.EVM]) {
-    //   doLog(`${JSON.stringify(presyncBlockHeight)}-${JSON.stringify(upper)}`);
-    // } else {
-    //   doLog(`${JSON.stringify(presyncBlockHeight)}`);
-    // }
+    for (const network of Object.keys(networks)) {
+      if (upper[network] > presyncBlockHeight[network]) {
+        doLog(
+          `${network}: ${JSON.stringify(presyncBlockHeight[network])}-${JSON.stringify(upper[network])}`
+        );
+      } else {
+        doLog(`${network}: ${JSON.stringify(presyncBlockHeight[network])}`);
+      }
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-loop-func
     presyncBlockHeight = await tx(gameStateMachine.getReadWriteDbConn(), async dbTx => {

--- a/packages/engine/paima-runtime/src/types.ts
+++ b/packages/engine/paima-runtime/src/types.ts
@@ -4,7 +4,6 @@ import type {
   VersionString,
   SubmittedChainData,
   SubmittedData,
-  Network,
   FUNNEL_PRESYNC_FINISHED,
 } from '@paima/utils';
 import type { ChainData, PresyncChainData, ChainDataExtension, GameStateMachine } from '@paima/sm';
@@ -14,7 +13,7 @@ export { SubmittedChainData, SubmittedData };
 export type TsoaFunction = (s: Express) => void;
 
 export type ReadPresyncDataFrom = {
-  network: Network;
+  network: string;
   from: number;
   to: number;
 }[];
@@ -23,7 +22,7 @@ export interface ChainFunnel {
   readData: (blockHeight: number) => Promise<ChainData[]>;
   readPresyncData: (
     args: ReadPresyncDataFrom
-  ) => Promise<{ [network: number]: PresyncChainData[] | typeof FUNNEL_PRESYNC_FINISHED }>;
+  ) => Promise<{ [network: string]: PresyncChainData[] | typeof FUNNEL_PRESYNC_FINISHED }>;
   getDbTx(): PoolClient;
 }
 

--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -119,7 +119,9 @@ const SM: GameStateMachineInitializer = {
             dbTx
           );
           if (cdeDataLength > 0) {
-            doLog(`Processed ${cdeDataLength} CDE events in block #${latestCdeData.blockNumber}`);
+            doLog(
+              `[${latestCdeData.network}] Processed ${cdeDataLength} CDE events in block #${latestCdeData.blockNumber}`
+            );
           }
         } else if (latestCdeData.networkType === ConfigNetworkType.CARDANO) {
           const cdeDataLength = await processCardanoCdeData(
@@ -128,7 +130,9 @@ const SM: GameStateMachineInitializer = {
             dbTx
           );
           if (cdeDataLength > 0) {
-            doLog(`Processed ${cdeDataLength} CDE events in slot #${latestCdeData.blockNumber}`);
+            doLog(
+              `[${latestCdeData.network}] Processed ${cdeDataLength} CDE events in slot #${latestCdeData.blockNumber}`
+            );
           }
         }
       },

--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -44,6 +44,7 @@ import type {
   InternalEvent,
 } from './types.js';
 import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import assertNever from 'assert-never';
 
 export * from './types.js';
 export type * from './types.js';
@@ -423,6 +424,17 @@ async function processInternalEvents(
       case InternalEventType.CardanoBestEpoch:
         await updateCardanoEpoch.run({ epoch: event.epoch }, dbTx);
         break;
+      case InternalEventType.EvmLastBlock:
+        await markCdeBlockheightProcessed.run(
+          {
+            block_height: event.block,
+            network: event.network,
+          },
+          dbTx
+        );
+        break;
+      default:
+        assertNever(event);
     }
   }
 }

--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -43,7 +43,7 @@ import type {
   GameStateMachineInitializer,
   InternalEvent,
 } from './types.js';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading.js';
+import { ConfigNetworkType } from '@paima/utils';
 import assertNever from 'assert-never';
 
 export * from './types.js';

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -362,7 +362,7 @@ export const CdeConfig = Type.Object({
         ChainDataExtensionCardanoProjectedNFTConfig,
         ChainDataExtensionCardanoDelayedAssetConfig,
       ]),
-      Type.Object({ network: Type.String() }),
+      Type.Partial(Type.Object({ network: Type.String() })),
     ])
   ),
 });
@@ -390,7 +390,7 @@ export type ChainDataExtension = (
   | ChainDataExtensionCardanoDelegation
   | ChainDataExtensionCardanoProjectedNFT
   | ChainDataExtensionCardanoDelayedAsset
-) & { network: string };
+) & { network: string | undefined };
 
 export type GameStateTransitionFunctionRouter = (
   blockHeight: number

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -13,10 +13,10 @@ import type {
   OldERC6551RegistryContract,
   ERC6551RegistryContract,
   InternalEventType,
+  ConfigNetworkType,
 } from '@paima/utils';
 import { Type } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
-import { ConfigNetworkType } from '@paima/utils/src/config/loading';
 
 export { SubmittedChainData, SubmittedData };
 

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -42,7 +42,7 @@ export interface PresyncChainData {
   network: string;
   networkType: ConfigNetworkType;
   blockNumber: number;
-  extensionDatums?: ChainDataExtensionDatum[];
+  extensionDatums: ChainDataExtensionDatum[];
   internalEvents?: InternalEvent[];
 }
 

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -30,14 +30,20 @@ export interface ChainData {
   internalEvents?: InternalEvent[];
 }
 
-export type InternalEvent = CardanoEpochEvent;
+export type InternalEvent = CardanoEpochEvent | EvmLastBlockEvent;
 export type CardanoEpochEvent = { type: InternalEventType.CardanoBestEpoch; epoch: number };
+export type EvmLastBlockEvent = {
+  type: InternalEventType.EvmLastBlock;
+  block: number;
+  network: string;
+};
 
 export interface PresyncChainData {
   network: string;
   networkType: ConfigNetworkType;
   blockNumber: number;
-  extensionDatums: ChainDataExtensionDatum[];
+  extensionDatums?: ChainDataExtensionDatum[];
+  internalEvents?: InternalEvent[];
 }
 
 interface CdeDatumErc20TransferPayload {

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -340,15 +340,18 @@ export type ChainDataExtensionCardanoDelayedAsset = ChainDataExtensionBase &
 
 export const CdeConfig = Type.Object({
   extensions: Type.Array(
-    Type.Union([
-      ChainDataExtensionErc20Config,
-      ChainDataExtensionErc721Config,
-      ChainDataExtensionErc20DepositConfig,
-      ChainDataExtensionGenericConfig,
-      ChainDataExtensionErc6551RegistryConfig,
-      ChainDataExtensionCardanoDelegationConfig,
-      ChainDataExtensionCardanoProjectedNFTConfig,
-      ChainDataExtensionCardanoDelayedAssetConfig,
+    Type.Intersect([
+      Type.Union([
+        ChainDataExtensionErc20Config,
+        ChainDataExtensionErc721Config,
+        ChainDataExtensionErc20DepositConfig,
+        ChainDataExtensionGenericConfig,
+        ChainDataExtensionErc6551RegistryConfig,
+        ChainDataExtensionCardanoDelegationConfig,
+        ChainDataExtensionCardanoProjectedNFTConfig,
+        ChainDataExtensionCardanoDelayedAssetConfig,
+      ]),
+      Type.Object({ network: Type.String() }),
     ])
   ),
 });
@@ -366,7 +369,7 @@ export const CdeBaseConfig = Type.Object({
     })
   ),
 });
-export type ChainDataExtension =
+export type ChainDataExtension = (
   | ChainDataExtensionErc20
   | ChainDataExtensionErc721
   | ChainDataExtensionPaimaErc721
@@ -375,7 +378,8 @@ export type ChainDataExtension =
   | ChainDataExtensionErc6551Registry
   | ChainDataExtensionCardanoDelegation
   | ChainDataExtensionCardanoProjectedNFT
-  | ChainDataExtensionCardanoDelayedAsset;
+  | ChainDataExtensionCardanoDelayedAsset
+) & { network: string };
 
 export type GameStateTransitionFunctionRouter = (
   blockHeight: number

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -1,6 +1,6 @@
 import { FunnelFactory } from '@paima/funnel';
 import paimaRuntime, { registerDocs, registerValidationErrorHandler } from '@paima/runtime';
-import { ENV, doLog } from '@paima/utils';
+import { ENV, GlobalConfig, doLog } from '@paima/utils';
 import { exec } from 'child_process';
 import { createInterface } from 'readline';
 import { gameSM } from '../sm.js';
@@ -92,20 +92,7 @@ export const initCommand = async (): Promise<void> => {
 // Run command logic
 export const runPaimaEngine = async (): Promise<void> => {
   // Verify env file is filled out before progressing
-  const restrictions = [
-    {
-      name: 'CONTRACT_ADDRESS',
-      val: ENV.CONTRACT_ADDRESS || undefined,
-    },
-    {
-      name: 'CHAIN_URI',
-      val: ENV.CHAIN_URI || undefined,
-    },
-    {
-      name: 'CHAIN_ID',
-      val: ENV.CHAIN_ID || undefined,
-    },
-  ];
+  const restrictions = [];
   // localhost networks start at block 0, so it's easier to just enable a start block of 0 for them
   if (ENV.NETWORK !== 'localhost') {
     restrictions.push({
@@ -121,17 +108,22 @@ export const runPaimaEngine = async (): Promise<void> => {
     process.exit(0);
   }
 
+  const [_, config] = await GlobalConfig.mainEvmConfig();
+
   // Check that packed game code is available
   if (checkForPackedGameCode()) {
     doLog(`Starting Game Node...`);
-    doLog(`Using RPC: ${ENV.CHAIN_URI}`);
-    doLog(`Targeting Smart Contact: ${ENV.CONTRACT_ADDRESS}`);
+    doLog(`Using RPC: ${config.chainUri}`);
+    doLog(`Targeting Smart Contact: ${config.paimaL2ContractAddress}`);
     const stateMachine = gameSM();
-    const funnelFactory = await FunnelFactory.initialize(ENV.CHAIN_URI, ENV.CONTRACT_ADDRESS);
+    const funnelFactory = await FunnelFactory.initialize(
+      config.chainUri,
+      config.paimaL2ContractAddress
+    );
     const engine = paimaRuntime.initialize(funnelFactory, stateMachine, ENV.GAME_NODE_VERSION);
 
     EngineService.INSTANCE.updateSM(stateMachine);
-    engine.setPollingRate(ENV.POLLING_RATE);
+    engine.setPollingRate(config.pollingRate);
     engine.addEndpoints(importTsoaFunction());
     engine.addEndpoints(server => {
       RegisterRoutes(server);

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -123,7 +123,7 @@ export const runPaimaEngine = async (): Promise<void> => {
     const engine = paimaRuntime.initialize(funnelFactory, stateMachine, ENV.GAME_NODE_VERSION);
 
     EngineService.INSTANCE.updateSM(stateMachine);
-    engine.setPollingRate(config.pollingRate);
+    engine.setPollingRate(ENV.POLLING_RATE);
     engine.addEndpoints(importTsoaFunction());
     engine.addEndpoints(server => {
       RegisterRoutes(server);

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -23,7 +23,9 @@ CREATE TABLE historical_game_inputs (
 );
 
 CREATE TABLE cde_tracking (
-  block_height INTEGER PRIMARY KEY
+  block_height INTEGER NOT NULL,
+  network TEXT NOT NULL,
+  PRIMARY KEY (block_height, network)
 );
 
 CREATE TABLE cde_tracking_cardano (

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -83,14 +83,19 @@ const TABLE_DATA_HISTORICAL: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_TRACKING = `
 CREATE TABLE cde_tracking (
-  block_height INTEGER PRIMARY KEY
+  block_height INTEGER NOT NULL,
+  network TEXT NOT NULL,
+  PRIMARY KEY (block_height, network)
 );
 `;
 
 const TABLE_DATA_CDE_TRACKING: TableData = {
   tableName: 'cde_tracking',
-  primaryKeyColumns: ['block_height'],
-  columnData: packTuples([['block_height', 'integer', 'NO', '']]),
+  primaryKeyColumns: ['block_height', 'network'],
+  columnData: packTuples([
+    ['block_height', 'integer', 'NO', ''],
+    ['network', 'text', 'NO', ''],
+  ]),
   serialColumns: [],
   creationQuery: QUERY_CREATE_TABLE_CDE_TRACKING,
 };

--- a/packages/node-sdk/paima-db/src/sql/cde-tracking.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-tracking.queries.ts
@@ -4,6 +4,7 @@ import { PreparedQuery } from '@pgtyped/runtime';
 /** 'MarkCdeBlockheightProcessed' parameters type */
 export interface IMarkCdeBlockheightProcessedParams {
   block_height: number;
+  network: string;
 }
 
 /** 'MarkCdeBlockheightProcessed' return type */
@@ -15,20 +16,22 @@ export interface IMarkCdeBlockheightProcessedQuery {
   result: IMarkCdeBlockheightProcessedResult;
 }
 
-const markCdeBlockheightProcessedIR: any = {"usedParamSet":{"block_height":true},"params":[{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":47,"b":60}]}],"statement":"INSERT INTO cde_tracking(block_height)\nVALUES (:block_height!)"};
+const markCdeBlockheightProcessedIR: any = {"usedParamSet":{"block_height":true,"network":true},"params":[{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":56,"b":69}]},{"name":"network","required":true,"transform":{"type":"scalar"},"locs":[{"a":72,"b":80}]}],"statement":"INSERT INTO cde_tracking(block_height, network)\nVALUES (:block_height!, :network!)"};
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO cde_tracking(block_height)
- * VALUES (:block_height!)
+ * INSERT INTO cde_tracking(block_height, network)
+ * VALUES (:block_height!, :network!)
  * ```
  */
 export const markCdeBlockheightProcessed = new PreparedQuery<IMarkCdeBlockheightProcessedParams,IMarkCdeBlockheightProcessedResult>(markCdeBlockheightProcessedIR);
 
 
 /** 'GetLatestProcessedCdeBlockheight' parameters type */
-export type IGetLatestProcessedCdeBlockheightParams = void;
+export interface IGetLatestProcessedCdeBlockheightParams {
+  network: string;
+}
 
 /** 'GetLatestProcessedCdeBlockheight' return type */
 export interface IGetLatestProcessedCdeBlockheightResult {
@@ -41,12 +44,13 @@ export interface IGetLatestProcessedCdeBlockheightQuery {
   result: IGetLatestProcessedCdeBlockheightResult;
 }
 
-const getLatestProcessedCdeBlockheightIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT * FROM cde_tracking\nORDER BY block_height DESC\nLIMIT 1"};
+const getLatestProcessedCdeBlockheightIR: any = {"usedParamSet":{"network":true},"params":[{"name":"network","required":true,"transform":{"type":"scalar"},"locs":[{"a":54,"b":62}]}],"statement":"SELECT block_height FROM cde_tracking\nWHERE network = :network!\nORDER BY block_height DESC\nLIMIT 1"};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT * FROM cde_tracking
+ * SELECT block_height FROM cde_tracking
+ * WHERE network = :network!
  * ORDER BY block_height DESC
  * LIMIT 1
  * ```

--- a/packages/node-sdk/paima-db/src/sql/cde-tracking.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-tracking.sql
@@ -1,8 +1,9 @@
 /* @name markCdeBlockheightProcessed */
-INSERT INTO cde_tracking(block_height)
-VALUES (:block_height!);
+INSERT INTO cde_tracking(block_height, network)
+VALUES (:block_height!, :network!);
 
 /* @name getLatestProcessedCdeBlockheight */
-SELECT * FROM cde_tracking
+SELECT block_height FROM cde_tracking
+WHERE network = :network!
 ORDER BY block_height DESC
 LIMIT 1;

--- a/packages/paima-sdk/paima-mw-core/esbuildconfig.cjs
+++ b/packages/paima-sdk/paima-mw-core/esbuildconfig.cjs
@@ -19,16 +19,6 @@ if (process.env.SECURITY_NAMESPACE) {
   }
 }
 
-// Verify env file is filled out
-if (
-  !process.env.CONTRACT_ADDRESS ||
-  !process.env.CHAIN_URI ||
-  !process.env.CHAIN_ID ||
-  !process.env.BACKEND_URI
-) {
-  throw new Error('Please ensure you have filled out your .env file');
-}
-
 const config = {
   entryPoints: ['build/index.js'],
   bundle: true,

--- a/packages/paima-sdk/paima-mw-core/src/state.ts
+++ b/packages/paima-sdk/paima-mw-core/src/state.ts
@@ -1,5 +1,5 @@
 import type { ContractAddress, Deployment, URI, VersionString, Web3 } from '@paima/utils';
-import { ENV, GlobalConfig } from '@paima/utils';
+import { ENV } from '@paima/utils';
 import { initWeb3 } from '@paima/utils';
 
 import { PaimaMiddlewareErrorCode, paimaErrorMessageFxn } from './errors.js';
@@ -17,18 +17,17 @@ let gameName: string = '';
 let backendUri: URI = ENV.BACKEND_URI;
 const batcherUri: URI = ENV.BATCHER_URI;
 
-const [chainName, config] = await GlobalConfig.mainEvmConfig();
+const chainUri: URI = ENV.CHAIN_URI;
+const chainExplorerUri: URI = ENV.CHAIN_EXPLORER_URI;
+const chainId: number = ENV.CHAIN_ID;
+const chainName: string = ENV.CHAIN_NAME;
+const chainCurrencyName: string = ENV.CHAIN_CURRENCY_NAME;
+const chainCurrencySymbol: string = ENV.CHAIN_CURRENCY_SYMBOL;
+const chainCurrencyDecimals: number = ENV.CHAIN_CURRENCY_DECIMALS;
 
-const chainUri: URI = config.chainUri;
-const chainExplorerUri: URI = config.chainExplorerUri;
-const chainId: number = config.chainId;
-const chainCurrencyName: string = config.chainCurrencyName;
-const chainCurrencySymbol: string = config.chainCurrencySymbol;
-const chainCurrencyDecimals: number = config.chainCurrencyDecimals;
+const storageAddress: ContractAddress = ENV.CONTRACT_ADDRESS;
 
-const storageAddress: ContractAddress = config.paimaL2ContractAddress;
-
-const deployment: Deployment = config.deployment as Deployment;
+const deployment: Deployment = ENV.DEPLOYMENT as Deployment;
 
 let emulatedBlocksActive: undefined | boolean = undefined;
 

--- a/packages/paima-sdk/paima-mw-core/src/state.ts
+++ b/packages/paima-sdk/paima-mw-core/src/state.ts
@@ -1,5 +1,5 @@
 import type { ContractAddress, Deployment, URI, VersionString, Web3 } from '@paima/utils';
-import { ENV } from '@paima/utils';
+import { ENV, GlobalConfig } from '@paima/utils';
 import { initWeb3 } from '@paima/utils';
 
 import { PaimaMiddlewareErrorCode, paimaErrorMessageFxn } from './errors.js';
@@ -17,17 +17,18 @@ let gameName: string = '';
 let backendUri: URI = ENV.BACKEND_URI;
 const batcherUri: URI = ENV.BATCHER_URI;
 
-const chainUri: URI = ENV.CHAIN_URI;
-const chainExplorerUri: URI = ENV.CHAIN_EXPLORER_URI;
-const chainId: number = ENV.CHAIN_ID;
-const chainName: string = ENV.CHAIN_NAME;
-const chainCurrencyName: string = ENV.CHAIN_CURRENCY_NAME;
-const chainCurrencySymbol: string = ENV.CHAIN_CURRENCY_SYMBOL;
-const chainCurrencyDecimals: number = ENV.CHAIN_CURRENCY_DECIMALS;
+const [chainName, config] = await GlobalConfig.mainEvmConfig();
 
-const storageAddress: ContractAddress = ENV.CONTRACT_ADDRESS;
+const chainUri: URI = config.chainUri;
+const chainExplorerUri: URI = config.chainExplorerUri;
+const chainId: number = config.chainId;
+const chainCurrencyName: string = config.chainCurrencyName;
+const chainCurrencySymbol: string = config.chainCurrencySymbol;
+const chainCurrencyDecimals: number = config.chainCurrencyDecimals;
 
-const deployment: Deployment = ENV.DEPLOYMENT as Deployment;
+const storageAddress: ContractAddress = config.paimaL2ContractAddress;
+
+const deployment: Deployment = config.deployment as Deployment;
 
 let emulatedBlocksActive: undefined | boolean = undefined;
 

--- a/packages/paima-sdk/paima-mw-core/src/wallets/evm/injected.ts
+++ b/packages/paima-sdk/paima-mw-core/src/wallets/evm/injected.ts
@@ -17,12 +17,15 @@ import { connectInjected } from '../wallet-modes.js';
 import { WalletMode } from '@paima/providers';
 import type { ApiForMode, IProvider } from '@paima/providers';
 import { EvmInjectedConnector } from '@paima/providers';
+import { EvmConfig, GlobalConfig } from '@paima/utils';
 
 interface SwitchError {
   code: number;
 }
 
 async function switchChain(): Promise<boolean> {
+  const [chainName, config] = await GlobalConfig.mainEvmConfig();
+
   const errorFxn = buildEndpointErrorFxn('switchChain');
 
   const CHAIN_NOT_ADDED_ERROR_CODE = 4902;
@@ -40,15 +43,15 @@ async function switchChain(): Promise<boolean> {
           .getOrThrowProvider()
           .addChain({
             chainId: hexChainId,
-            chainName: getChainName(),
+            chainName: chainName,
             nativeCurrency: {
-              name: getChainCurrencyName(),
-              symbol: getChainCurrencySymbol(),
-              decimals: getChainCurrencyDecimals(),
+              name: config.chainCurrencyName,
+              symbol: config.chainCurrencySymbol,
+              decimals: config.chainCurrencyDecimals,
             },
             rpcUrls: [getChainUri()],
             // blockExplorerUrls: Chain not added with empty string.
-            blockExplorerUrls: getChainExplorerUri() ? [getChainExplorerUri()] : undefined,
+            blockExplorerUrls: config.chainExplorerUri ? [config.chainExplorerUri] : undefined,
           });
         await EvmInjectedConnector.instance().getOrThrowProvider().switchChain(hexChainId);
         return await verifyWalletChain();

--- a/packages/paima-sdk/paima-utils/src/config.ts
+++ b/packages/paima-sdk/paima-utils/src/config.ts
@@ -5,11 +5,7 @@ import type { VersionString } from './types.js';
  * which might not be set depending on the framework used for the frontend of an app
  */
 export class ENV {
-  static doHealthCheck(): void {
-    if (!ENV.CONTRACT_ADDRESS) {
-      throw new Error(`Please ensure your .env.${ENV.NETWORK} is properly filled out.`);
-    }
-  }
+  static doHealthCheck(): void {}
 
   // System
   static get NETWORK(): string {
@@ -117,15 +113,5 @@ export class ENV {
       return `http://localhost:${process.env.BATCHER_PORT}`;
     }
     return '';
-  }
-
-  static get CARP_URL(): string | undefined {
-    return process.env.CARP_URL;
-  }
-  static get CARDANO_NETWORK(): string | undefined {
-    return process.env.CARDANO_NETWORK;
-  }
-  static get CARDANO_CONFIRMATION_DEPTH(): number | undefined {
-    return Number(process.env.CARDANO_CONFIRMATION_DEPTH);
   }
 }

--- a/packages/paima-sdk/paima-utils/src/config.ts
+++ b/packages/paima-sdk/paima-utils/src/config.ts
@@ -114,4 +114,14 @@ export class ENV {
     }
     return '';
   }
+
+  static get CARP_URL(): string | undefined {
+    return process.env.CARP_URL;
+  }
+  static get CARDANO_NETWORK(): string | undefined {
+    return process.env.CARDANO_NETWORK;
+  }
+  static get CARDANO_CONFIRMATION_DEPTH(): number | undefined {
+    return Number(process.env.CARDANO_CONFIRMATION_DEPTH);
+  }
 }

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -21,14 +21,12 @@ const EvmConfigSchemaRequiredProperties = Type.Object({
   chainCurrencyName: Type.String(),
   chainCurrencySymbol: Type.String(),
   chainCurrencyDecimals: Type.Number(),
-  blockTime: Type.Number(),
 });
 
 const PaimaL2ContractType = Type.RegExp(/^0x[0-9a-fA-F]{40}$/i);
 
 const EvmConfigSchemaOptionalProperties = Type.Object({
   chainExplorerUri: Type.String({ default: '' }),
-  pollingRate: Type.Number({ default: 4 - 0.1 }),
   funnelBlockGroupSize: Type.Number({ default: 100 }),
   presyncStepSize: Type.Number({ default: 1000 }),
 });
@@ -99,11 +97,8 @@ export const BaseConfig = <T extends boolean>(T: T) => Type.Record(Type.String()
 export const BaseConfigWithoutDefaults = BaseConfig(false);
 export const BaseConfigWithDefaults = BaseConfig(true);
 
-const evmConfigDefaults = (
-  blockTime: number | undefined
-): Static<typeof EvmConfigSchemaOptionalProperties> => ({
+const evmConfigDefaults = (): Static<typeof EvmConfigSchemaOptionalProperties> => ({
   chainExplorerUri: '',
-  pollingRate: (blockTime || 4) - 0.1,
   funnelBlockGroupSize: 100,
   presyncStepSize: 1000,
 });
@@ -133,9 +128,7 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
       chainCurrencyName: ENV.CHAIN_CURRENCY_NAME,
       chainCurrencySymbol: ENV.CHAIN_CURRENCY_SYMBOL,
       chainCurrencyDecimals: ENV.CHAIN_CURRENCY_DECIMALS,
-      blockTime: ENV.BLOCK_TIME,
       chainExplorerUri: ENV.CHAIN_EXPLORER_URI,
-      pollingRate: ENV.POLLING_RATE,
       funnelBlockGroupSize: ENV.DEFAULT_FUNNEL_GROUP_SIZE,
       presyncStepSize: ENV.DEFAULT_PRESYNC_STEP_SIZE,
       paimaL2ContractAddress: ENV.CONTRACT_ADDRESS,
@@ -170,10 +163,7 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
       switch (networkConfig.type) {
         case ConfigNetworkType.EVM_OTHER:
         case ConfigNetworkType.EVM:
-          config[network] = Object.assign(
-            evmConfigDefaults(networkConfig.blockTime),
-            networkConfig
-          );
+          config[network] = Object.assign(evmConfigDefaults(), networkConfig);
           break;
         case ConfigNetworkType.CARDANO:
           config[network] = Object.assign(cardanoConfigDefaults, networkConfig);

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -3,10 +3,9 @@ import YAML from 'yaml';
 import type { Static, TSchema } from '@sinclair/typebox';
 import { Value, ValueErrorType } from '@sinclair/typebox/value';
 import { Type } from '@sinclair/typebox';
-import { doLog } from '../logging';
-import { ENV } from '../config';
+// import { ENV, doLog } from '../index';
 
-enum ConfigNetworkType {
+export enum ConfigNetworkType {
   EVM = 'evm-main',
   EVM_OTHER = 'evm-other',
   CARDANO = 'cardano',
@@ -78,7 +77,8 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
   let configFileData: string;
   try {
     // TODO: would be nice to also read .yaml
-    configFileData = await fs.readFile(`config.${ENV.NETWORK}.yml`, 'utf8');
+    // configFileData = await fs.readFile(`config.${ENV.NETWORK}.yml`, 'utf8');
+    configFileData = await fs.readFile(`config.localhost.yml`, 'utf8');
   } catch (err) {
     throw new Error('config file not found');
   }
@@ -106,7 +106,7 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
 
     return config;
   } catch (err) {
-    doLog(`Invalid config file: ${err}`);
+    // doLog(`Invalid config file: ${err}`);
     return undefined;
   }
 }

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -1,0 +1,152 @@
+import * as fs from 'fs/promises';
+import YAML from 'yaml';
+import type { Static, TSchema } from '@sinclair/typebox';
+import { Value, ValueErrorType } from '@sinclair/typebox/value';
+import { Type } from '@sinclair/typebox';
+import { doLog } from '../logging';
+import { ENV } from '../config';
+
+enum ConfigNetworkType {
+  EVM = 'evm-main',
+  EVM_OTHER = 'evm-other',
+  CARDANO = 'cardano',
+}
+
+export type EvmConfig = Static<typeof EvmConfigSchema>;
+
+export const EvmConfigSchema = Type.Object({
+  chainUri: Type.String({ default: '' }),
+  chainId: Type.Number({ default: 0 }),
+  chainExplorerUri: Type.String({ default: '' }),
+  chainCurrencyName: Type.String({ default: 'UNKNOWN_CURRENCY_NAME' }),
+  chainCurrencySymbol: Type.String({ default: 'NONAME' }),
+  chainCurrencyDecimals: Type.Number({ default: 0 }),
+  // TODO: this depends on the settings actually, but hard to express that
+  //ENV.BLOCK_TIME - 0.1
+  blockTime: Type.Number({ default: 4 }),
+  pollingRate: Type.Number({ default: 4 - 0.1 }),
+  deployment: Type.String({ default: '' }),
+  paimaL2ContractAddress: Type.RegExp(/^0x[0-9a-fA-F]{40}$/i),
+});
+
+export const CardanoConfigSchema = Type.Object({
+  carpUrl: Type.String(),
+  network: Type.String(),
+  confirmationDepth: Type.Number(),
+});
+
+export type CardanoConfig = Static<typeof CardanoConfigSchema>;
+
+export const TaggedConfig = <T extends boolean>(T: T) =>
+  Type.Union([
+    Type.Intersect([
+      T ? EvmConfigSchema : Type.Partial(EvmConfigSchema),
+      Type.Required(
+        Type.Object({
+          type: Type.Union([
+            Type.Literal(ConfigNetworkType.EVM),
+            Type.Literal(ConfigNetworkType.EVM_OTHER),
+          ]),
+        })
+      ),
+    ]),
+    Type.Intersect([
+      CardanoConfigSchema,
+      Type.Object({ type: Type.Literal(ConfigNetworkType.CARDANO) }),
+    ]),
+  ]);
+
+export const BaseConfig = <T extends boolean>(T: T) => Type.Record(Type.String(), TaggedConfig(T));
+
+export const BaseConfigWithoutDefaults = BaseConfig(false);
+export const BaseConfigWithDefaults = BaseConfig(true);
+export const FullEvmConfig = EvmConfigSchema;
+
+const evmConfigDefaults = (blockTime: number | undefined) => ({
+  chainUri: '',
+  chainId: 0,
+  chainExplorerUri: '',
+  chainCurrencyName: 'UNKNOWN_CURRENCY_NAME',
+  chainCurrencySymbol: 'NONAME',
+  chainCurrencyDecimals: 0,
+  blockTime: 4,
+  pollingRate: (blockTime || 4) - 0.1,
+  deployment: '',
+});
+
+export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults> | undefined> {
+  let configFileData: string;
+  try {
+    // TODO: would be nice to also read .yaml
+    configFileData = await fs.readFile(`config.${ENV.NETWORK}.yml`, 'utf8');
+  } catch (err) {
+    throw new Error('config file not found');
+  }
+
+  try {
+    const config = parseConfigFile(configFileData);
+
+    for (const network of Object.keys(config)) {
+      const networkConfig = config[network];
+
+      switch (networkConfig.type) {
+        case ConfigNetworkType.EVM_OTHER:
+        case ConfigNetworkType.EVM:
+          // TODO: current version of typebox doesn't have Value.Default
+          config[network] = Object.assign(
+            evmConfigDefaults(networkConfig.blockTime),
+            networkConfig
+          );
+          break;
+        case ConfigNetworkType.CARDANO:
+        default:
+          throw new Error('unknown network type');
+      }
+    }
+
+    return config;
+  } catch (err) {
+    doLog(`Invalid config file: ${err}`);
+    return undefined;
+  }
+}
+
+// Validate the overall structure of the config file and extract the relevant data
+export function parseConfigFile(configFileData: string): Static<typeof BaseConfigWithoutDefaults> {
+  // Parse the YAML content into an object
+  const configObject = YAML.parse(configFileData);
+
+  // Validate the YAML object against the schema
+  const baseConfig = checkOrError(undefined, BaseConfigWithoutDefaults, configObject);
+
+  return baseConfig;
+}
+
+// TODO: copy pasted code
+function checkOrError<T extends TSchema>(
+  name: undefined | string,
+  structure: T,
+  config: unknown
+): Static<T> {
+  // 1) Check if there are any errors since Value.Decode doesn't give error messages
+  {
+    const skippableErrors: ValueErrorType[] = [];
+
+    const errors = Array.from(Value.Errors(structure, config));
+    for (const error of errors) {
+      if (errors.length !== 1 && skippableErrors.find(val => val === error.type) != null) continue;
+      console.error({
+        name: name ?? 'Configuration root',
+        path: error.path,
+        valueProvided: error.value,
+        message: error.message,
+      });
+    }
+    if (errors.length > 1) {
+      throw new Error(`config field missing or invalid. See above for error.`);
+    }
+  }
+
+  const decoded = Value.Decode(structure, config);
+  return decoded;
+}

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -3,7 +3,7 @@ import YAML from 'yaml';
 import type { Static, TSchema } from '@sinclair/typebox';
 import { Value, ValueErrorType } from '@sinclair/typebox/value';
 import { Type } from '@sinclair/typebox';
-// import { ENV, doLog } from '../index';
+import { ENV, doLog } from '../index';
 
 export enum ConfigNetworkType {
   EVM = 'evm-main',
@@ -77,8 +77,8 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
   let configFileData: string;
   try {
     // TODO: would be nice to also read .yaml
-    // configFileData = await fs.readFile(`config.${ENV.NETWORK}.yml`, 'utf8');
-    configFileData = await fs.readFile(`config.localhost.yml`, 'utf8');
+    configFileData = await fs.readFile(`config.${ENV.NETWORK}.yml`, 'utf8');
+    // configFileData = await fs.readFile(`config.localhost.yml`, 'utf8');
   } catch (err) {
     throw new Error('config file not found');
   }

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -1,9 +1,10 @@
 import * as fs from 'fs/promises';
 import YAML from 'yaml';
 import type { Static, TSchema } from '@sinclair/typebox';
-import { Value, ValueErrorType } from '@sinclair/typebox/value';
+import type { ValueErrorType } from '@sinclair/typebox/value';
+import { Value } from '@sinclair/typebox/value';
 import { Type } from '@sinclair/typebox';
-import { ENV, doLog } from '../index';
+import { ENV, doLog } from '../index.js';
 
 export enum ConfigNetworkType {
   EVM = 'evm-main',
@@ -80,7 +81,6 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
   try {
     // TODO: would be nice to also read .yaml
     configFileData = await fs.readFile(`config.${ENV.NETWORK}.yml`, 'utf8');
-    // configFileData = await fs.readFile(`config.localhost.yml`, 'utf8');
   } catch (err) {
     throw new Error('config file not found');
   }

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -108,7 +108,7 @@ export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults
 
     return config;
   } catch (err) {
-    // doLog(`Invalid config file: ${err}`);
+    doLog(`Invalid config file: ${err}`);
     return undefined;
   }
 }

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs/promises';
 import YAML from 'yaml';
 import type { Static, TSchema } from '@sinclair/typebox';
-import type { ValueErrorType } from '@sinclair/typebox/value';
 import { Value } from '@sinclair/typebox/value';
 import { Type } from '@sinclair/typebox';
 import { ENV, doLog } from '../index.js';
@@ -124,7 +123,6 @@ export function parseConfigFile(configFileData: string): Static<typeof BaseConfi
   return baseConfig;
 }
 
-// TODO: copy pasted code
 function checkOrError<T extends TSchema>(
   name: undefined | string,
   structure: T,
@@ -132,11 +130,9 @@ function checkOrError<T extends TSchema>(
 ): Static<T> {
   // 1) Check if there are any errors since Value.Decode doesn't give error messages
   {
-    const skippableErrors: ValueErrorType[] = [];
-
     const errors = Array.from(Value.Errors(structure, config));
     for (const error of errors) {
-      if (errors.length !== 1 && skippableErrors.find(val => val === error.type) != null) continue;
+      if (errors.length !== 1) continue;
       console.error({
         name: name ?? 'Configuration root',
         path: error.path,

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -26,6 +26,7 @@ export const EvmConfigSchema = Type.Object({
   pollingRate: Type.Number({ default: 4 - 0.1 }),
   deployment: Type.String({ default: '' }),
   paimaL2ContractAddress: Type.RegExp(/^0x[0-9a-fA-F]{40}$/i),
+  funnelBlockGroupSize: Type.Number({ default: 100 }),
 });
 
 export const CardanoConfigSchema = Type.Object({
@@ -71,6 +72,7 @@ const evmConfigDefaults = (blockTime: number | undefined) => ({
   blockTime: 4,
   pollingRate: (blockTime || 4) - 0.1,
   deployment: '',
+  funnelBlockGroupSize: 100,
 });
 
 export async function loadConfig(): Promise<Static<typeof BaseConfigWithDefaults> | undefined> {

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -24,7 +24,6 @@ export const EvmConfigSchema = Type.Object({
   //ENV.BLOCK_TIME - 0.1
   blockTime: Type.Number({ default: 4 }),
   pollingRate: Type.Number({ default: 4 - 0.1 }),
-  deployment: Type.String({ default: '' }),
   paimaL2ContractAddress: Type.RegExp(/^0x[0-9a-fA-F]{40}$/i),
   funnelBlockGroupSize: Type.Number({ default: 100 }),
   presyncStepSize: Type.Number({ default: 1000 }),
@@ -73,7 +72,6 @@ const evmConfigDefaults = (blockTime: number | undefined) => ({
   chainCurrencyDecimals: 0,
   blockTime: 4,
   pollingRate: (blockTime || 4) - 0.1,
-  deployment: '',
   funnelBlockGroupSize: 100,
   presyncStepSize: 1000,
 });

--- a/packages/paima-sdk/paima-utils/src/config/loading.ts
+++ b/packages/paima-sdk/paima-utils/src/config/loading.ts
@@ -98,7 +98,6 @@ export const BaseConfig = <T extends boolean>(T: T) => Type.Record(Type.String()
 
 export const BaseConfigWithoutDefaults = BaseConfig(false);
 export const BaseConfigWithDefaults = BaseConfig(true);
-export const FullEvmConfig = EvmConfigSchema;
 
 const evmConfigDefaults = (
   blockTime: number | undefined

--- a/packages/paima-sdk/paima-utils/src/config/singleton.ts
+++ b/packages/paima-sdk/paima-utils/src/config/singleton.ts
@@ -5,6 +5,7 @@ import {
   EvmConfigSchema,
   CardanoConfig,
   EvmConfig,
+  ConfigNetworkType,
 } from './loading';
 
 export type Config = Static<typeof BaseConfigWithDefaults>;
@@ -12,8 +13,6 @@ export type Config = Static<typeof BaseConfigWithDefaults>;
 export class GlobalConfig {
   private static instance: Config;
   private static promise: Promise<void> | null;
-
-  private constructor() {}
 
   public static async getInstance(): Promise<Config> {
     // avoid double initialization/race
@@ -33,13 +32,12 @@ export class GlobalConfig {
     return GlobalConfig.instance;
   }
 
-  public static async mainEvmConfig(): Promise<[string, Static<typeof EvmConfigSchema>]> {
+  public static async mainEvmConfig(): Promise<[string, EvmConfig]> {
     const instance = await GlobalConfig.getInstance();
 
     for (const key of Object.keys(instance)) {
-      if (instance[key].type === 'evm-main') {
-        // TODO: try to remove this cast
-        return [key, instance[key] as Static<typeof EvmConfigSchema>];
+      if (instance[key].type === ConfigNetworkType.EVM) {
+        return [key, instance[key] as EvmConfig];
       }
     }
 
@@ -50,8 +48,7 @@ export class GlobalConfig {
     const instance = await GlobalConfig.getInstance();
 
     for (const key of Object.keys(instance)) {
-      if (instance[key].type === 'cardano') {
-        // TODO: try to remove this cast
+      if (instance[key].type === ConfigNetworkType.CARDANO) {
         return [key, instance[key] as CardanoConfig];
       }
     }
@@ -63,7 +60,7 @@ export class GlobalConfig {
     const instance = await GlobalConfig.getInstance();
 
     return Object.keys(instance)
-      .filter(key => instance[key].type === 'evm-other')
+      .filter(key => instance[key].type === ConfigNetworkType.EVM_OTHER)
       .map(key => [key, instance[key] as EvmConfig]);
   }
 }

--- a/packages/paima-sdk/paima-utils/src/config/singleton.ts
+++ b/packages/paima-sdk/paima-utils/src/config/singleton.ts
@@ -1,12 +1,6 @@
-import { Static } from '@sinclair/typebox';
-import {
-  BaseConfigWithDefaults,
-  loadConfig,
-  EvmConfigSchema,
-  CardanoConfig,
-  EvmConfig,
-  ConfigNetworkType,
-} from './loading';
+import type { Static } from '@sinclair/typebox';
+import type { CardanoConfig, EvmConfig } from './loading.js';
+import { BaseConfigWithDefaults, loadConfig, ConfigNetworkType } from './loading.js';
 
 export type Config = Static<typeof BaseConfigWithDefaults>;
 

--- a/packages/paima-sdk/paima-utils/src/config/singleton.ts
+++ b/packages/paima-sdk/paima-utils/src/config/singleton.ts
@@ -1,0 +1,55 @@
+import { Static } from '@sinclair/typebox';
+import { BaseConfigWithDefaults, loadConfig, EvmConfigSchema, CardanoConfig } from './loading';
+
+export type Config = Static<typeof BaseConfigWithDefaults>;
+
+export class GlobalConfig {
+  private static instance: Config;
+  private static promise: Promise<void> | null;
+
+  private constructor() {}
+
+  public static async getInstance(): Promise<Config> {
+    // avoid double initialization/race
+    if (!GlobalConfig.promise) {
+      GlobalConfig.promise = loadConfig().then(config => {
+        if (!GlobalConfig.instance) {
+          if (!config) {
+            throw new Error("Couldn't read config file");
+          }
+
+          GlobalConfig.instance = config;
+        }
+      });
+    }
+
+    await GlobalConfig.promise;
+    return GlobalConfig.instance;
+  }
+
+  public static async mainEvmConfig(): Promise<[string, Static<typeof EvmConfigSchema>]> {
+    const instance = await GlobalConfig.getInstance();
+
+    for (const key of Object.keys(instance)) {
+      if (instance[key].type === 'evm-main') {
+        // TODO: try to remove this cast
+        return [key, instance[key] as Static<typeof EvmConfigSchema>];
+      }
+    }
+
+    throw new Error('main config not found');
+  }
+
+  public static async cardanoConfig(): Promise<CardanoConfig | undefined> {
+    const instance = await GlobalConfig.getInstance();
+
+    for (const key of Object.keys(instance)) {
+      if (instance[key].type === 'cardano') {
+        // TODO: try to remove this cast
+        return instance[key] as CardanoConfig;
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/paima-sdk/paima-utils/src/config/singleton.ts
+++ b/packages/paima-sdk/paima-utils/src/config/singleton.ts
@@ -1,5 +1,11 @@
 import { Static } from '@sinclair/typebox';
-import { BaseConfigWithDefaults, loadConfig, EvmConfigSchema, CardanoConfig } from './loading';
+import {
+  BaseConfigWithDefaults,
+  loadConfig,
+  EvmConfigSchema,
+  CardanoConfig,
+  EvmConfig,
+} from './loading';
 
 export type Config = Static<typeof BaseConfigWithDefaults>;
 
@@ -40,16 +46,24 @@ export class GlobalConfig {
     throw new Error('main config not found');
   }
 
-  public static async cardanoConfig(): Promise<CardanoConfig | undefined> {
+  public static async cardanoConfig(): Promise<[string, CardanoConfig] | undefined> {
     const instance = await GlobalConfig.getInstance();
 
     for (const key of Object.keys(instance)) {
       if (instance[key].type === 'cardano') {
         // TODO: try to remove this cast
-        return instance[key] as CardanoConfig;
+        return [key, instance[key] as CardanoConfig];
       }
     }
 
     return undefined;
+  }
+
+  public static async otherEvmConfig(): Promise<[string, EvmConfig][]> {
+    const instance = await GlobalConfig.getInstance();
+
+    return Object.keys(instance)
+      .filter(key => instance[key].type === 'evm-other')
+      .map(key => [key, instance[key] as EvmConfig]);
   }
 }

--- a/packages/paima-sdk/paima-utils/src/config/singleton.ts
+++ b/packages/paima-sdk/paima-utils/src/config/singleton.ts
@@ -1,6 +1,6 @@
 import type { Static } from '@sinclair/typebox';
-import type { CardanoConfig, EvmConfig } from './loading.js';
-import { BaseConfigWithDefaults, loadConfig, ConfigNetworkType } from './loading.js';
+import type { CardanoConfig, EvmConfig, MainEvmConfig, BaseConfigWithDefaults } from './loading.js';
+import { loadConfig, ConfigNetworkType } from './loading.js';
 
 export type Config = Static<typeof BaseConfigWithDefaults>;
 
@@ -26,12 +26,12 @@ export class GlobalConfig {
     return GlobalConfig.instance;
   }
 
-  public static async mainEvmConfig(): Promise<[string, EvmConfig]> {
+  public static async mainEvmConfig(): Promise<[string, MainEvmConfig]> {
     const instance = await GlobalConfig.getInstance();
 
     for (const key of Object.keys(instance)) {
       if (instance[key].type === ConfigNetworkType.EVM) {
-        return [key, instance[key] as EvmConfig];
+        return [key, instance[key] as MainEvmConfig];
       }
     }
 

--- a/packages/paima-sdk/paima-utils/src/constants.ts
+++ b/packages/paima-sdk/paima-utils/src/constants.ts
@@ -39,4 +39,5 @@ export const FUNNEL_PRESYNC_FINISHED = 'finished';
 
 export const enum InternalEventType {
   CardanoBestEpoch,
+  EvmLastBlock,
 }

--- a/packages/paima-sdk/paima-utils/src/constants.ts
+++ b/packages/paima-sdk/paima-utils/src/constants.ts
@@ -35,11 +35,6 @@ export const enum ChainDataExtensionDatumType {
   CardanoAssetUtxo,
 }
 
-export const enum Network {
-  EVM = 1,
-  CARDANO = 2,
-}
-
 export const FUNNEL_PRESYNC_FINISHED = 'finished';
 
 export const enum InternalEventType {

--- a/packages/paima-sdk/paima-utils/src/index.ts
+++ b/packages/paima-sdk/paima-utils/src/index.ts
@@ -19,7 +19,13 @@ import {
   ChainDataExtensionDatumType,
 } from './constants.js';
 import { GlobalConfig } from './config/singleton.js';
-import { EvmConfig, CardanoConfig, ConfigNetworkType } from './config/loading.js';
+import {
+  EvmConfig,
+  CardanoConfig,
+  ConfigNetworkType,
+  defaultEvmMainNetworkName,
+  defaultCardanoNetworkName,
+} from './config/loading.js';
 
 const { isAddress } = web3UtilsPkg;
 
@@ -51,6 +57,8 @@ export {
   EvmConfig,
   CardanoConfig,
   ConfigNetworkType,
+  defaultEvmMainNetworkName,
+  defaultCardanoNetworkName,
 };
 
 export const DEFAULT_GAS_PRICE = '61000000000' as const;

--- a/packages/paima-sdk/paima-utils/src/index.ts
+++ b/packages/paima-sdk/paima-utils/src/index.ts
@@ -19,7 +19,7 @@ import {
   ChainDataExtensionDatumType,
 } from './constants.js';
 import { GlobalConfig } from './config/singleton.js';
-import { EvmConfig, CardanoConfig } from './config/loading.js';
+import { EvmConfig, CardanoConfig, ConfigNetworkType } from './config/loading.js';
 
 const { isAddress } = web3UtilsPkg;
 
@@ -50,6 +50,7 @@ export {
   GlobalConfig,
   EvmConfig,
   CardanoConfig,
+  ConfigNetworkType,
 };
 
 export const DEFAULT_GAS_PRICE = '61000000000' as const;

--- a/packages/paima-sdk/paima-utils/src/index.ts
+++ b/packages/paima-sdk/paima-utils/src/index.ts
@@ -35,6 +35,8 @@ export type {
 } from './contract-types/PaimaERC721Contract.js';
 export type { Transfer as ERC721Transfer } from './contract-types/ERC721Contract.js';
 export * from './constants.js';
+export { GlobalConfig } from './config/singleton.js';
+export { EvmConfig, CardanoConfig } from './config/loading.js';
 
 export type { Web3, Contract, AbiItem, EventData };
 export {

--- a/packages/paima-sdk/paima-utils/src/index.ts
+++ b/packages/paima-sdk/paima-utils/src/index.ts
@@ -18,6 +18,8 @@ import {
   ChainDataExtensionType,
   ChainDataExtensionDatumType,
 } from './constants.js';
+import { GlobalConfig } from './config/singleton.js';
+import { EvmConfig, CardanoConfig } from './config/loading.js';
 
 const { isAddress } = web3UtilsPkg;
 
@@ -35,8 +37,6 @@ export type {
 } from './contract-types/PaimaERC721Contract.js';
 export type { Transfer as ERC721Transfer } from './contract-types/ERC721Contract.js';
 export * from './constants.js';
-export { GlobalConfig } from './config/singleton.js';
-export { EvmConfig, CardanoConfig } from './config/loading.js';
 
 export type { Web3, Contract, AbiItem, EventData };
 export {
@@ -47,6 +47,9 @@ export {
   logError,
   setLogger,
   doLog,
+  GlobalConfig,
+  EvmConfig,
+  CardanoConfig,
 };
 
 export const DEFAULT_GAS_PRICE = '61000000000' as const;


### PR DESCRIPTION
# About

This PR introduces a new funnel type, called evm funnel. This funnel gets instantiated for each additional evm network that needs to be synced. For the presync it works similar to the block funnel, but for the sync phase it does act differently. Here we get first the data from the block funnel, and then these blocks are paired with the CDE events from the additional evm chain.

The pairing works by using timestamps, so a block from the new chain gets assigned to the first block in the main chain with a timestamp greater or equal than its own. This is done in order to provide determinism.

## Config changes

The network configuration is moved to a file, which should be named `config.$NETWORK.yml` (not `.yaml`). This is because otherwise difficult to namespace variable names for each different network.

```yaml
# config.localhost.yml (config.$NETWORK.yml)
Hardhat:
  type: evm-main
  chainUri: 'http://localhost:8545'
  chainId: 31337
  chainCurrencyName: 'Test Hardhat Tokens'
  chainCurrencySymbol: 'TEST'
  chainCurrencyDecimals: 18
  blockTime: 2
  paimaL2ContractAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3'

Arbitrum:
  type: evm-other
  chainUri: 'https://arb1.arbitrum.io/rpc'
  chainId: 42161
  chainCurrencyName: 'ETH'
  chainCurrencySymbol: 'ETH'
  chainCurrencyDecimals: 18
  blockTime: 2
  # this regulates the amount of blocks fetched during the sync in a single round. It helps to avoid rate-limiting.
  funnelBlockGroupSize: 20
```
*NOTE:* The *funnelBlockGroupSize* in the example is what I had to set in order to not get rate limited with arbitrum  

And the extensions have to be specified like:

```yaml
# extensions.yml
extensions:
  - name: "Bar"
    type: "erc20"
    network: "Hardhat"
    contractAddress: "0x0000000000000000000000000000000000000001"
    startBlockHeight: 0

  - name: "USDC"
    type: "erc20"
    contractAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
    startBlockHeight: 178573900
    # This is required so that the funnel can know which extensions should it care about
    network: "Arbitrum"
```

Note that the network field uses the id of the label in the other object.

I think potentially the extensions.yml file should be removed and just moved to the other file under a field, but I'm not sure.

### TODO
- ? Removed unused ENV vars . *Here I'm not sure if the vars are currently used by other stuff, like frontends, that may not want to read a file*
- ? Store the config and check it which fields shouldn't change 
- ? Probably don't need `evm-main` and `evm-other`, since the `paimaL2ContractAddress` can be used for discrimination anyway .
- [x] Instantiation of one funnel per evm network.
- [x] Figure out how to match blocks across networks.
