### PR TITLE
fix block funnel to use funnelBlockGroupSize

### DIFF
--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -35,7 +35,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
   public override async readData(blockHeight: number): Promise<ChainData[]> {
     const [fromBlock, toBlock] = await this.adjustBlockHeightRange(
       blockHeight,
-      ENV.DEFAULT_FUNNEL_GROUP_SIZE
+      this.config.funnelBlockGroupSize
     );
 
     if (fromBlock < 0 || toBlock < fromBlock) {


### PR DESCRIPTION
the block funnel was also supposed to use this setting instead of the env file. Overlooked this in #300 