### PR TITLE
parallel evm funnel: after presync start from startBlockHeight

### DIFF
--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -85,6 +85,11 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
       );
 
       if (queryResults[0]) {
+        // If we are in `readData`, we know that the presync stage finished.
+        // This means `readPresyncData` was actually called with the entire
+        // range up to startBlockHeight - 1 (inclusive), since that's the stop
+        // condition for the presync. So there is no point in starting from
+        // earlier than that, since we know there are no events there.
         cachedState.lastBlock = Math.max(
           queryResults[0].block_height,
           cachedState.startBlockHeight - 1

--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -143,9 +143,6 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
         // wait for blocks to be produced
         await delay(500);
       }
-
-      // potentially we didn't fetch enough blocks in a single request in that
-      // case we get more blocks we loop again
     }
 
     // After we get the blocks from the parallel evm chain, we need to join them


### PR DESCRIPTION
There is currently some code that saves the latest height in order to know from where to start syncing on restart on the parallel chain. The issue is that during the presync this only gets updated if there is an event in the range. So potentially the presync may end up in a block far way from the `startingBlock`, and the sync starts from that point. Even if we already know there is nothing useful there. This sets things in a way that we never start the sync from a point that falls in the presync range.

Also while figuring what was happening I noticed that the funnel is updating the latest chain block much more than necessary, and it's a bit slow, so this optimizes that a bit.