### PR TITLE
fix parallel funnel block mapping issue

### DIFF
--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -188,8 +188,8 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
     //  We would want to merge this new base block with the last from the
     // previous round (timestamp 4).
     //
-    //  We know that this block it's still in the cached state, because we only
-    // removed stuff <= 3 (maxTimestamp). If we used the blocks from the current
+    //  We know that this block is still in the cached state, because we only
+    // removed blocks with timestamp <= 3 (maxTimestamp). If we used the blocks from the current
     // call then instead we would map the block to the one with timestamp 5,
     // breaking the invariant.
     //

--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -170,7 +170,28 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
 
     cachedState.lastMaxTimestamp = maxTimestamp;
 
-    // Now we need to join the parallel evm chain with the trunk.
+    //  Now we need to join the parallel evm chain with the trunk.
+    //
+    //  We use the cached timestamp to block number mapping to build the
+    // following objects. It's important the we used the cached data and not the
+    // data that we just fetched, since in the previous round we may had fetched
+    // extra blocks.
+    //  For example: if we previously had timestamps:
+    //
+    // Round 1:
+    //    Base chain pull: [1, 2, 3]
+    //    This chain pull: [1, 2, 3, 4]
+    // Round 2:
+    //    Base chain pull: [4]
+    //    This chain pull: [5]
+    //
+    //  We would want to merge this new base block with the last from the
+    // previous round (timestamp 4).
+    //
+    //  We know that this block it's still in the cached state, because we only
+    // removed stuff <= 3 (maxTimestamp). If we used the blocks from the current
+    // call then instead we would map the block to the one with timestamp 5,
+    // breaking the invariant.
     //
     // This maps timestamps from the sidechain to the mainchain.
     const sidechainToMainchainBlockHeightMapping: { [blockNumber: number]: number } = {};


### PR DESCRIPTION
There are two issues here:

1. The cdeDatum blockNumber is not getting mapped to the main evm chain when using `internalReadDataSingle` (but it is when using `internalReadDataMultiple`). This can potentially lead to non scheduling inputs at the right time.
2. Currently the objects that we are using to map blocks from the parallel chain to the main chain are constructed _only_ with the timestamps obtained in the current call to `readData`. This doesn't correctly handle all the cases, since potentially the funnels can be configured to get 1 block from the wrapped funnel and a 100 of the other one. The fix here is basically to build these objects from the cached data, which includes data from the previous round, but was not needed.