### PR TITLE
Fix/fetch address at stf

### DIFF
--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -395,14 +395,14 @@ async function processUserInputs(
     const delegateWallet = new DelegateWallet(DBConn);
     if (inputData.inputData.startsWith(DelegateWallet.INTERNAL_COMMAND_PREFIX)) {
       await delegateWallet.process(
-        inputData.realAddress as string,
-        inputData.userAddress as string,
-        inputData.inputData as string
+        inputData.realAddress,
+        inputData.userAddress,
+        inputData.inputData
       );
     } else {
       // If wallet does not exist in address table: create it.
       if (inputData.userId === NO_USER_ID) {
-        const newAddress = await delegateWallet.createAddress(inputData.userAddress as string);
+        const newAddress = await delegateWallet.createAddress(inputData.userAddress);
         inputData.userId = newAddress.id;
       }
       // Trigger STF

--- a/packages/engine/paima-sm/src/randomness.ts
+++ b/packages/engine/paima-sm/src/randomness.ts
@@ -25,7 +25,7 @@ function chooseData(submittedData: SubmittedData[], seed: string): string[] {
   const chosenData = [];
   for (const dataChunk of submittedData) {
     if (randomSelection()) chosenData.push(dataChunk.inputNonce);
-    if (randomSelection()) chosenData.push(dataChunk.userAddress);
+    if (randomSelection()) chosenData.push(dataChunk.realAddress);
     for (const data of parseInput(dataChunk.inputData)) {
       if (randomSelection()) chosenData.push(data);
     }
@@ -35,7 +35,7 @@ function chooseData(submittedData: SubmittedData[], seed: string): string[] {
   if (submittedData.length > 0 && chosenData.length === 0) {
     const randomIndex = Math.floor(prando.next() * submittedData.length);
     const dataChunk = submittedData[randomIndex];
-    const forcedOptions = [dataChunk.inputNonce, dataChunk.userAddress, dataChunk.inputData];
+    const forcedOptions = [dataChunk.inputNonce, dataChunk.realAddress, dataChunk.inputData];
     const forcedValue = forcedOptions[Math.floor(prando.next() * forcedOptions.length)];
     chosenData.push(forcedValue);
   }

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -14,6 +14,7 @@ import type {
   ERC6551RegistryContract,
   InternalEventType,
   ConfigNetworkType,
+  STFSubmittedData,
 } from '@paima/utils';
 import { Type } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
@@ -400,7 +401,7 @@ export type GameStateTransitionFunctionRouter = (
 ) => GameStateTransitionFunction;
 
 export type GameStateTransitionFunction = (
-  inputData: SubmittedData,
+  inputData: STFSubmittedData,
   blockHeight: number,
   randomnessGenerator: any,
   DBConn: PoolClient

--- a/packages/paima-sdk/paima-utils/src/config/singleton.ts
+++ b/packages/paima-sdk/paima-utils/src/config/singleton.ts
@@ -19,6 +19,7 @@ export class GlobalConfig {
 
           GlobalConfig.instance = config;
         }
+        return;
       });
     }
 

--- a/packages/paima-sdk/paima-utils/src/types.ts
+++ b/packages/paima-sdk/paima-utils/src/types.ts
@@ -34,14 +34,18 @@ export type NonceString = string;
 export interface SubmittedData {
   // Address of the wallet that submitted the data.
   realAddress: WalletAddress;
-  // Mapped address to main wallet.
-  userAddress: WalletAddress;
-  // Fixed User ID
-  userId: number;
   inputData: InputDataString;
   inputNonce: NonceString;
   suppliedValue: string;
   scheduled: boolean;
   dryRun?: boolean;
 }
+
+export interface STFSubmittedData extends SubmittedData {
+  // Mapped address to main wallet.
+  userAddress: WalletAddress;
+  // Fixed User ID
+  userId: number;
+}
+
 export type SubmittedChainData = SubmittedData;


### PR DESCRIPTION
When processing chucks of blocks it tries to resolve the sender's real `address`.
If in the same chunk, the user has submitted their first wallet-connect input and any second input in the same chunk, then the second input will not be updated correctly with the user's real-address as the first block has still not been processed.

This PR changes the random generator, as the real-address was used for calculations, but this value is not always available.
Other possible solutions:

* Process STF wallet connect commands before the event mapper
* If the input has a `wallet-connect` format `&w*`, then we split the block into smaller parts. 