### PR TITLE
fix: we are storing heights from base chain into parallel chain

### DIFF
--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -300,14 +300,16 @@ async function processCdeData(
 ): Promise<number> {
   const [mainNetwork, _] = await GlobalConfig.mainEvmConfig();
   return await processCdeDataBase(cdeData, dbTx, inPresync, async () => {
-    // During the presync we know that the block_height is for that network in
-    // particular, since the block heights are not mapped in that phase.
-    // But if we are in the sync, the blockHeight we are processing here is for
-    // the main network instead, which doesn't make sense for cde's from other
-    // networks.
-    // We could potentially store the original block in ChainDataExtensionDatum
-    // in order to have something to update here, but currently this is handled
-    // through the internal events.
+    // During the presync,
+    //     we know that the block_height is for that network in particular,
+    //     since the block heights are not mapped in that phase.
+    // During the sync,
+    //     the blockHeight we are processing here is for the main network instead,
+    //     which doesn't make sense for cde's from other networks.
+    // To tackle this, we have 2 options:
+    //     1. Store the original block in ChainDataExtensionDatum
+    //        and then use it to update here
+    //     2. (what we picked) Through the internal events (see EvmLastBlock)
     if (inPresync || network == mainNetwork) {
       await markCdeBlockheightProcessed.run({ block_height: blockHeight, network }, dbTx);
     }


### PR DESCRIPTION
I think https://github.com/PaimaStudios/paima-engine/pull/314 didn't fix one of the issues properly. With the changes in that PR, we stopped writing to `cde_tracking`  when the base chain has no CDE's, which was the reason the CDE's are processed by network now. But I think now we are inserting block_heights from the base network into the parallel ones during the sync.

This is specially a problem if/when the block heights from both networks overlap, since then the db may fail because of the primary key constraint.

I think this change fixes that, although please check my logic if possible. 