### PR TITLE
erc721 cde: keep track of the address that burned the asset

### DIFF
--- a/packages/engine/paima-funnel/src/cde/erc721.ts
+++ b/packages/engine/paima-funnel/src/cde/erc721.ts
@@ -39,6 +39,7 @@ function transferToTransferDatum(
       to: event.returnValues.to.toLowerCase(),
       tokenId: event.returnValues.tokenId,
     },
+    burnScheduledPrefix: extension.burnScheduledPrefix,
     network,
   };
 }

--- a/packages/engine/paima-sm/src/cde-erc721-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-erc721-transfer.ts
@@ -19,7 +19,7 @@ export default async function processErc721Datum(
   const { to, tokenId } = cdeDatum.payload;
   const toAddr = to.toLowerCase();
 
-  const isBurn = Boolean(toAddr.match(/^0x0+$/g));
+  const isBurn = Boolean(toAddr.toLocaleLowerCase().match(/^0x0+(dead)?$/g));
 
   const updateList: SQLUpdate[] = [];
   try {
@@ -30,6 +30,8 @@ export default async function processErc721Datum(
     const newOwnerData = { cde_id: cdeId, token_id: tokenId, nft_owner: toAddr };
     if (ownerRow.length > 0) {
       if (isBurn) {
+        // we do this to keep track of the owner before the asset is sent to the
+        // burn address
         updateList.push([
           cdeErc721BurnInsert,
           { cde_id: cdeId, token_id: tokenId, nft_owner: ownerRow[0].nft_owner },

--- a/packages/engine/paima-sm/src/cde-erc721-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-erc721-transfer.ts
@@ -32,11 +32,9 @@ export default async function processErc721Datum(
     const newOwnerData = { cde_id: cdeId, token_id: tokenId, nft_owner: toAddr };
     if (ownerRow.length > 0) {
       if (isBurn) {
-        if (cdeDatum.burnScheduledPrefix) {
+        if (cdeDatum.burnScheduledPrefix && !isPresync) {
           const scheduledInputData = `${cdeDatum.burnScheduledPrefix}|${ownerRow[0].nft_owner}|${tokenId}`;
-          const scheduledBlockHeight = isPresync
-            ? ENV.SM_START_BLOCKHEIGHT + 1
-            : cdeDatum.blockNumber;
+          const scheduledBlockHeight = cdeDatum.blockNumber;
 
           updateList.push(createScheduledData(scheduledInputData, scheduledBlockHeight));
         }

--- a/packages/engine/paima-sm/src/cde-erc721-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-erc721-transfer.ts
@@ -2,7 +2,13 @@ import type { PoolClient } from 'pg';
 
 import { doLog } from '@paima/utils';
 import type { CdeErc721TransferDatum } from './types.js';
-import { cdeErc721GetOwner, cdeErc721InsertOwner, cdeErc721UpdateOwner } from '@paima/db';
+import {
+  cdeErc721BurnInsert,
+  cdeErc721Delete,
+  cdeErc721GetOwner,
+  cdeErc721InsertOwner,
+  cdeErc721UpdateOwner,
+} from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
 
 export default async function processErc721Datum(
@@ -13,6 +19,8 @@ export default async function processErc721Datum(
   const { to, tokenId } = cdeDatum.payload;
   const toAddr = to.toLowerCase();
 
+  const isBurn = Boolean(toAddr.match(/^0x0+$/g));
+
   const updateList: SQLUpdate[] = [];
   try {
     const ownerRow = await cdeErc721GetOwner.run(
@@ -21,7 +29,15 @@ export default async function processErc721Datum(
     );
     const newOwnerData = { cde_id: cdeId, token_id: tokenId, nft_owner: toAddr };
     if (ownerRow.length > 0) {
-      updateList.push([cdeErc721UpdateOwner, newOwnerData]);
+      if (isBurn) {
+        updateList.push([
+          cdeErc721BurnInsert,
+          { cde_id: cdeId, token_id: tokenId, nft_owner: ownerRow[0].nft_owner },
+        ]);
+        updateList.push([cdeErc721Delete, { cde_id: cdeId, token_id: tokenId }]);
+      } else {
+        updateList.push([cdeErc721UpdateOwner, newOwnerData]);
+      }
     } else {
       updateList.push([cdeErc721InsertOwner, newOwnerData]);
     }

--- a/packages/engine/paima-sm/src/cde-processing.ts
+++ b/packages/engine/paima-sm/src/cde-processing.ts
@@ -26,7 +26,7 @@ export async function cdeTransitionFunction(
     case ChainDataExtensionDatumType.ERC20Transfer:
       return await processErc20TransferDatum(readonlyDBConn, cdeDatum);
     case ChainDataExtensionDatumType.ERC721Transfer:
-      return await processErc721TransferDatum(readonlyDBConn, cdeDatum);
+      return await processErc721TransferDatum(readonlyDBConn, cdeDatum, inPresync);
     case ChainDataExtensionDatumType.ERC721Mint:
       return await processErc721MintDatum(cdeDatum, inPresync);
     case ChainDataExtensionDatumType.ERC20Deposit:

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -169,6 +169,7 @@ export interface CdeErc20TransferDatum extends CdeDatumBase {
 export interface CdeErc721TransferDatum extends CdeDatumBase {
   cdeDatumType: ChainDataExtensionDatumType.ERC721Transfer;
   payload: CdeDatumErc721TransferPayload;
+  burnScheduledPrefix?: string | undefined;
 }
 
 export interface CdeErc721MintDatum extends CdeDatumBase {
@@ -287,6 +288,7 @@ export const ChainDataExtensionErc721Config = Type.Intersect([
     type: Type.Literal(CdeEntryTypeName.ERC721),
     contractAddress: EvmAddress,
     scheduledPrefix: Type.String(),
+    burnScheduledPrefix: Type.Optional(Type.String()),
   }),
 ]);
 export type TChainDataExtensionErc721Config = Static<typeof ChainDataExtensionErc721Config>;

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -56,6 +56,13 @@ CREATE TABLE cde_erc721_data (
   PRIMARY KEY (cde_id, token_id)
 );
 
+CREATE TABLE cde_erc721_burn (
+  cde_id INTEGER NOT NULL,
+  token_id TEXT NOT NULL,
+  nft_owner TEXT NOT NULL,
+  PRIMARY KEY(cde_id, token_id)
+);
+
 CREATE TABLE cde_erc20_deposit_data (
   cde_id INTEGER NOT NULL,
   wallet_address TEXT NOT NULL,

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -206,6 +206,27 @@ const TABLE_DATA_CDE_ERC721: TableData = {
   creationQuery: QUERY_CREATE_TABLE_CDE_ERC721,
 };
 
+const QUERY_CREATE_TABLE_CDE_ERC721_BURN = `
+CREATE TABLE cde_erc721_burn (
+  cde_id INTEGER NOT NULL,
+  token_id TEXT NOT NULL,
+  nft_owner TEXT NOT NULL,
+  PRIMARY KEY (cde_id, token_id)
+);
+`;
+
+const TABLE_DATA_CDE_ERC721_BURN: TableData = {
+  tableName: 'cde_erc721_data_burn',
+  primaryKeyColumns: ['cde_id', 'token_id'],
+  columnData: packTuples([
+    ['cde_id', 'integer', 'NO', ''],
+    ['token_id', 'text', 'NO', ''],
+    ['nft_owner', 'text', 'NO', ''],
+  ]),
+  serialColumns: [],
+  creationQuery: QUERY_CREATE_TABLE_CDE_ERC721_BURN,
+};
+
 const QUERY_CREATE_TABLE_CDE_ERC20_DEPOSIT = `
 CREATE TABLE cde_erc20_deposit_data (
   cde_id INTEGER NOT NULL,
@@ -580,6 +601,7 @@ export const TABLES: TableData[] = [
   TABLE_DATA_CDE,
   TABLE_DATA_CDE_ERC20,
   TABLE_DATA_CDE_ERC721,
+  TABLE_DATA_CDE_ERC721_BURN,
   TABLE_DATA_CDE_ERC20_DEPOSIT,
   TABLE_DATA_CDE_GENERIC_DATA,
   TABLE_DATA_CDE_ERC6551_REGISTRY,

--- a/packages/node-sdk/paima-db/src/sql/cde-erc721.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc721.queries.ts
@@ -161,3 +161,66 @@ const cdeErc721GetAllOwnedNftsIR: any = {"usedParamSet":{"nft_owner":true},"para
 export const cdeErc721GetAllOwnedNfts = new PreparedQuery<ICdeErc721GetAllOwnedNftsParams,ICdeErc721GetAllOwnedNftsResult>(cdeErc721GetAllOwnedNftsIR);
 
 
+/** 'CdeErc721Delete' parameters type */
+export interface ICdeErc721DeleteParams {
+  cde_id: number;
+  token_id: string;
+}
+
+/** 'CdeErc721Delete' return type */
+export type ICdeErc721DeleteResult = void;
+
+/** 'CdeErc721Delete' query type */
+export interface ICdeErc721DeleteQuery {
+  params: ICdeErc721DeleteParams;
+  result: ICdeErc721DeleteResult;
+}
+
+const cdeErc721DeleteIR: any = {"usedParamSet":{"cde_id":true,"token_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":43,"b":50}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":67,"b":76}]}],"statement":"DELETE FROM cde_erc721_data\nWHERE cde_id = :cde_id!\nAND token_id = :token_id!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM cde_erc721_data
+ * WHERE cde_id = :cde_id!
+ * AND token_id = :token_id!
+ * ```
+ */
+export const cdeErc721Delete = new PreparedQuery<ICdeErc721DeleteParams,ICdeErc721DeleteResult>(cdeErc721DeleteIR);
+
+
+/** 'CdeErc721BurnInsert' parameters type */
+export interface ICdeErc721BurnInsertParams {
+  cde_id: number;
+  nft_owner: string;
+  token_id: string;
+}
+
+/** 'CdeErc721BurnInsert' return type */
+export type ICdeErc721BurnInsertResult = void;
+
+/** 'CdeErc721BurnInsert' query type */
+export interface ICdeErc721BurnInsertQuery {
+  params: ICdeErc721BurnInsertParams;
+  result: ICdeErc721BurnInsertResult;
+}
+
+const cdeErc721BurnInsertIR: any = {"usedParamSet":{"cde_id":true,"token_id":true,"nft_owner":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":84,"b":91}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":107}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":114,"b":124}]}],"statement":"INSERT INTO cde_erc721_burn(\n    cde_id,\n    token_id,\n    nft_owner\n) VALUES (\n    :cde_id!,\n    :token_id!,\n    :nft_owner!\n)"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO cde_erc721_burn(
+ *     cde_id,
+ *     token_id,
+ *     nft_owner
+ * ) VALUES (
+ *     :cde_id!,
+ *     :token_id!,
+ *     :nft_owner!
+ * )
+ * ```
+ */
+export const cdeErc721BurnInsert = new PreparedQuery<ICdeErc721BurnInsertParams,ICdeErc721BurnInsertResult>(cdeErc721BurnInsertIR);
+
+

--- a/packages/node-sdk/paima-db/src/sql/cde-erc721.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc721.sql
@@ -30,3 +30,20 @@ AND token_id = :token_id!;
 SELECT cde_name, token_id  FROM cde_erc721_data
 JOIN chain_data_extensions ON chain_data_extensions.cde_id = cde_erc721_data.cde_id
 WHERE nft_owner = :nft_owner!;
+
+
+/* @name cdeErc721Delete */
+DELETE FROM cde_erc721_data
+WHERE cde_id = :cde_id!
+AND token_id = :token_id!;
+
+/* @name cdeErc721BurnInsert */
+INSERT INTO cde_erc721_burn(
+    cde_id,
+    token_id,
+    nft_owner
+) VALUES (
+    :cde_id!,
+    :token_id!,
+    :nft_owner!
+);


### PR DESCRIPTION
This keeps track of the address that burned an erc721 asset by putting those into a different table.

Potentially this could be just a new row in the existing table, but I think this may be clearer? This way this could potentially be optional.

Note that this removes the burned asset from the existing table. This means it won't show anymore when searching for the assets of the 0 address. This may nor may not be desired, but I'm not really sure.

The main motivation for doing this is that, while this can potentially be done by adding erc721 transfer events to the cde and doing the indexing on the stf (which is also what's suggested by the current erc721 docs, but with the generic cde instead), this doesn't work for burns found in the presync stage, since there is no stf running for those.

### Questions

What's the appropiate utils function for this? I imagine we may want a `getBurnedNfts(cde, address)`?