### PR TITLE
Fix batcher crashing silently

### DIFF
--- a/packages/batcher/runtime/src/index.ts
+++ b/packages/batcher/runtime/src/index.ts
@@ -190,6 +190,9 @@ async function main(): Promise<void> {
 }
 
 main().catch(e => {
+  // we catch the error here instead of relying on `uncaughtException` monitoring
+  // because if an exception causes us to reach this line, it means the error was thrown during initalization
+  // which is typically something we cannot recover from
   console.error(e);
   process.exit(1);
 });

--- a/packages/batcher/runtime/src/index.ts
+++ b/packages/batcher/runtime/src/index.ts
@@ -189,4 +189,7 @@ async function main(): Promise<void> {
   await runtime.run(gameInputValidator, batchedTransactionPoster, provider);
 }
 
-void main();
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
If the batcher crashed during initialization, for example because of an invalid configuration such that `getRemoteBackendVersion` failed, no error would be printed and the batcher would exit with status code 0. Instead, print that error and exit with an error code.

Such errors were previously being suppressed by the `on('uncaughtException')` handler, because they occurred within 1 second of startup.