### PR TITLE
schedule presync stf events to the first sync block

### DIFF
--- a/packages/engine/paima-sm/src/cde-cardano-mint-burn.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-mint-burn.ts
@@ -4,7 +4,8 @@ import type { SQLUpdate } from '@paima/db';
 import type { CdeCardanoMintBurnDatum } from './types.js';
 
 export default async function processDatum(
-  cdeDatum: CdeCardanoMintBurnDatum
+  cdeDatum: CdeCardanoMintBurnDatum,
+  inPresync: boolean
 ): Promise<SQLUpdate[]> {
   const cdeId = cdeDatum.cdeId;
   const prefix = cdeDatum.scheduledPrefix;
@@ -14,7 +15,7 @@ export default async function processDatum(
   const inputAddresses = cdeDatum.payload.inputAddresses;
   const outputAddresses = cdeDatum.payload.outputAddresses;
 
-  const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
+  const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
   const scheduledInputData = `${prefix}|${txId}|${metadata}|${assets}|${JSON.stringify(inputAddresses)}|${JSON.stringify(outputAddresses)}`;
 
   const updateList: SQLUpdate[] = [

--- a/packages/engine/paima-sm/src/cde-cardano-pool.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-pool.ts
@@ -12,14 +12,11 @@ export default async function processDatum(
   const address = cdeDatum.payload.address;
   const pool = cdeDatum.payload.pool;
 
-  const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
+  const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
   const scheduledInputData = `${prefix}|${address}|${pool}`;
 
-  const updateList: SQLUpdate[] = inPresync
-    ? []
-    : [createScheduledData(scheduledInputData, scheduledBlockHeight)];
-
-  updateList.push(
+  const updateList: SQLUpdate[] = [
+    createScheduledData(scheduledInputData, scheduledBlockHeight),
     [
       cdeCardanoPoolInsertData,
       {
@@ -34,7 +31,8 @@ export default async function processDatum(
       {
         address: cdeDatum.payload.address,
       },
-    ]
-  );
+    ],
+  ];
+
   return updateList;
 }

--- a/packages/engine/paima-sm/src/cde-cardano-projected-nft.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-projected-nft.ts
@@ -25,20 +25,41 @@ export default async function processDatum(
   const datum = cdeDatum.payload.plutusDatum;
   const forHowLong = cdeDatum.payload.forHowLong;
 
-  const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
+  const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
   const scheduledInputData = `${prefix}|${ownerAddress}|${previousTxHash}|${previousOutputIndex}|${currentTxHash}|${currentOutputIndex}|${policyId}|${assetName}|${status}`;
 
   if (previousTxHash === undefined || previousOutputIndex === undefined) {
-    const updateList: SQLUpdate[] = inPresync
-      ? []
-      : [createScheduledData(scheduledInputData, scheduledBlockHeight)];
-    updateList.push([
-      cdeCardanoProjectedNftInsertData,
+    const updateList: SQLUpdate[] = [
+      createScheduledData(scheduledInputData, scheduledBlockHeight),
+      [
+        cdeCardanoProjectedNftInsertData,
+        {
+          cde_id: cdeId,
+          owner_address: ownerAddress,
+          current_tx_hash: currentTxHash,
+          current_tx_output_index: currentOutputIndex,
+          policy_id: policyId,
+          asset_name: assetName,
+          amount: amount,
+          status: status,
+          plutus_datum: datum,
+          for_how_long: forHowLong,
+        },
+      ],
+    ];
+    return updateList;
+  }
+  const updateList: SQLUpdate[] = [
+    createScheduledData(scheduledInputData, scheduledBlockHeight),
+    [
+      cdeCardanoProjectedNftUpdateData,
       {
         cde_id: cdeId,
         owner_address: ownerAddress,
-        current_tx_hash: currentTxHash,
-        current_tx_output_index: currentOutputIndex,
+        new_tx_hash: currentTxHash,
+        new_tx_output_index: currentOutputIndex,
+        previous_tx_hash: previousTxHash,
+        previous_tx_output_index: previousOutputIndex,
         policy_id: policyId,
         asset_name: assetName,
         amount: amount,
@@ -46,29 +67,8 @@ export default async function processDatum(
         plutus_datum: datum,
         for_how_long: forHowLong,
       },
-    ]);
-    return updateList;
-  }
-  const updateList: SQLUpdate[] = inPresync
-    ? []
-    : [createScheduledData(scheduledInputData, scheduledBlockHeight)];
+    ],
+  ];
 
-  updateList.push([
-    cdeCardanoProjectedNftUpdateData,
-    {
-      cde_id: cdeId,
-      owner_address: ownerAddress,
-      new_tx_hash: currentTxHash,
-      new_tx_output_index: currentOutputIndex,
-      previous_tx_hash: previousTxHash,
-      previous_tx_output_index: previousOutputIndex,
-      policy_id: policyId,
-      asset_name: assetName,
-      amount: amount,
-      status: status,
-      plutus_datum: datum,
-      for_how_long: forHowLong,
-    },
-  ]);
   return updateList;
 }

--- a/packages/engine/paima-sm/src/cde-cardano-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-transfer.ts
@@ -4,7 +4,8 @@ import type { SQLUpdate } from '@paima/db';
 import type { CdeCardanoTransferDatum } from './types.js';
 
 export default async function processDatum(
-  cdeDatum: CdeCardanoTransferDatum
+  cdeDatum: CdeCardanoTransferDatum,
+  inPresync: boolean
 ): Promise<SQLUpdate[]> {
   const cdeId = cdeDatum.cdeId;
   const prefix = cdeDatum.scheduledPrefix;
@@ -14,7 +15,7 @@ export default async function processDatum(
   const outputs = JSON.stringify(cdeDatum.payload.outputs);
   const metadata = cdeDatum.payload.metadata || undefined;
 
-  const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
+  const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
   const scheduledInputData = `${prefix}|${txId}|${metadata}|${inputCredentials}|${outputs}`;
 
   const updateList: SQLUpdate[] = [

--- a/packages/engine/paima-sm/src/cde-erc20-deposit.ts
+++ b/packages/engine/paima-sm/src/cde-erc20-deposit.ts
@@ -30,11 +30,9 @@ export default async function processErc20Datum(
 
   const updateList: SQLUpdate[] = [];
   try {
-    if (!inPresync) {
-      const scheduledInputData = `${prefix}|${fromAddr}|${value}`;
-      const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
-      updateList.push(createScheduledData(scheduledInputData, scheduledBlockHeight));
-    }
+    const scheduledInputData = `${prefix}|${fromAddr}|${value}`;
+    const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
+    updateList.push(createScheduledData(scheduledInputData, scheduledBlockHeight));
 
     if (fromRow.length > 0) {
       const oldTotal = BigInt(fromRow[0].total_deposited);

--- a/packages/engine/paima-sm/src/cde-erc721-mint.ts
+++ b/packages/engine/paima-sm/src/cde-erc721-mint.ts
@@ -8,11 +8,11 @@ export default async function processErc721Datum(
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
   const [address, prefix] = [cdeDatum.contractAddress, cdeDatum.scheduledPrefix];
-  if (!prefix || inPresync) {
+  if (!prefix) {
     return [];
   }
   const { tokenId, mintData } = cdeDatum.payload;
-  const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
+  const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
   const scheduledInputData = `${prefix}|${address}|${tokenId}|${mintData}`;
   return [createScheduledData(scheduledInputData, scheduledBlockHeight)];
 }

--- a/packages/engine/paima-sm/src/cde-generic.ts
+++ b/packages/engine/paima-sm/src/cde-generic.ts
@@ -12,7 +12,7 @@ export default async function processDatum(
   const payload = cdeDatum.payload;
   const prefix = cdeDatum.scheduledPrefix;
 
-  const scheduledBlockHeight = Math.max(cdeDatum.blockNumber, ENV.SM_START_BLOCKHEIGHT + 1);
+  const scheduledBlockHeight = inPresync ? ENV.SM_START_BLOCKHEIGHT + 1 : cdeDatum.blockNumber;
   const stringifiedPayload = JSON.stringify(payload);
   const scheduledInputData = `${prefix}|${stringifiedPayload}`;
 

--- a/packages/engine/paima-sm/src/cde-processing.ts
+++ b/packages/engine/paima-sm/src/cde-processing.ts
@@ -42,9 +42,9 @@ export async function cdeTransitionFunction(
     case ChainDataExtensionDatumType.CardanoAssetUtxo:
       return await processCardanoAssetUtxoDatum(cdeDatum);
     case ChainDataExtensionDatumType.CardanoTransfer:
-      return await processCardanoTransferDatum(cdeDatum);
+      return await processCardanoTransferDatum(cdeDatum, inPresync);
     case ChainDataExtensionDatumType.CardanoMintBurn:
-      return await processCardanoMintBurnDatum(cdeDatum);
+      return await processCardanoMintBurnDatum(cdeDatum, inPresync);
     default:
       assertNever(cdeDatum);
   }


### PR DESCRIPTION
I think the change to the scheduled behavior in #314 may have been a mistake. I thought that presync data was being scheduled with the original block which didn't make sense and was useless, but that only happened because of the `Math.max` usage and the block heights in the parallel chain being bigger (in particular, with emulated blocks this is always the case since `SM_START_BLOCKHEIGHT` is 0) . Also, that PR didn't fix the issue for the carp/cardano primitives.

So this restores the behavior to the way it worked before that PR for the scheduled data, but also fixes the original issue for the parallel evm and carp funnels.

If we actually *don't want* to schedule data during the presync like we are doing currently, we still should do it in the carp primitives. But I imagine it's actually more practical to schedule everything in the first stf? The only potential issue is that the first state transition could take a while if there is a lot of presync data.