### PR TITLE
Exit batcher with error code if config is invalid

### DIFF
--- a/packages/batcher/runtime/src/index.ts
+++ b/packages/batcher/runtime/src/index.ts
@@ -148,7 +148,7 @@ function checkConfig(): boolean {
 
 async function main(): Promise<void> {
   if (!checkConfig()) {
-    return;
+    process.exit(1);
   }
   await parseSecurityYaml();
 

--- a/packages/batcher/runtime/src/index.ts
+++ b/packages/batcher/runtime/src/index.ts
@@ -148,7 +148,8 @@ function checkConfig(): boolean {
 
 async function main(): Promise<void> {
   if (!checkConfig()) {
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   await parseSecurityYaml();
 


### PR DESCRIPTION
Small annoyance that this failure to start exits like a success.

Related: #338