### PR TITLE
Fix ssh-agent requirement by using https to clone docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run lint:configs && npx nx run-many --parallel=${NX_PARALLEL:-3} -t build",
     "test": "npm run lint:configs && npx nx run-many --parallel=${NX_PARALLEL:-3} -t test",
     "release:lib": "./wipe.sh && sh ./tools/scripts/bump-version.sh && npm run build && npm run lint && npm run test && read -p 'Enter OTP: ' otp && export NPM_CONFIG_OTP=$otp && npx nx release publish -g paima-sdk && npx nx release publish -g node-sdk",
-    "release:bin": "./wipe.sh && ./tools/scripts/ssh-check.sh && npm run lint:configs && npm run build && npx nx run-many --parallel=${NX_PARALLEL:-3} --projects=tag:type:binary -t release && mkdir -p ./bin && cp -r ./packages/engine/paima-standalone/packaged/@standalone/* ./bin"
+    "release:bin": "./wipe.sh && npm run lint:configs && npm run build && npx nx run-many --parallel=${NX_PARALLEL:-3} --projects=tag:type:binary -t release && mkdir -p ./bin && cp -rf ./packages/engine/paima-standalone/packaged/@standalone/* ./bin"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^2.1.2",

--- a/packages/engine/paima-standalone/scripts/prepare_standalone_folders.sh
+++ b/packages/engine/paima-standalone/scripts/prepare_standalone_folders.sh
@@ -27,7 +27,7 @@ cp -r ../../batcher/batcher-standalone/packaged/@standalone/batcher-bin $BATCHER
 # Fetch documentation
 echo $DOC_PATH
 rm -rf $DOC_PATH
-git clone --depth=1 git@github.com:PaimaStudios/paima-engine-docs.git $DOC_PATH
+git clone --depth=1 https://github.com/PaimaStudios/paima-engine-docs.git $DOC_PATH
 # Remove everything except docs/home
 find $DOC_PATH/* -not -path "$DOC_PATH/docs*" -delete
 # Move the contents of docs/home to the root of $DOC_PATH
@@ -40,7 +40,7 @@ rm -rf $DOC_PATH/.git*
 
 # Fetch templates
 rm -rf $TEMPLATES_PATH
-git clone --depth=1 git@github.com:PaimaStudios/paima-standalone-templates.git $TEMPLATES_PATH
+git clone --depth=1 https://github.com/PaimaStudios/paima-standalone-templates.git $TEMPLATES_PATH
 rm -rf $TEMPLATES_PATH/.git
 
 # Add in swagger static UI

--- a/tools/scripts/ssh-check.sh
+++ b/tools/scripts/ssh-check.sh
@@ -1,8 +1,0 @@
-if ! pgrep -u "$USER" ssh-agent > /dev/null; then
-    echo "Error: ssh-agent not detected. Build process may hang. Are you sure you want to conitnue?" >&2
-    echo "To run an ssh-agent, use the following:"
-    echo 'eval "$(ssh-agent -s)"'
-    echo "ssh-add ~/.ssh/your_github_key"
-    echo 'Press any key to continue once done'
-    read _
-fi


### PR DESCRIPTION
The ssh-agent is only needed because the build process uses SSH to clone GitHub repos. Because these are public repos, we can use HTTPS instead of SSH and bypass this requirement entirely. Now the build will hang neither at the beginning nor the end.

Also `cp -f` will allow the `paima-engine-linux` binary to be replaced on the filesystem even if it's currently running (usually not an issue, I assume Node mmaps it or something).