### PR TITLE
Add Dockerfile for engine, batcher, and SDK images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# NOTE: unlike .gitignore, ** is not implied, and only the root .dockerignore is considered.
+
+# Dockerignore exclusive
+/.dockerignore
+/Dockerfile
+/docker-tag
+/.git
+
+# .gitignore
+/**/node_modules
+/**/bin
+/**/.nx
+/**/dist
+/**/build
+/**/*.tsbuildinfo
+/**/*.log
+/**/.idea
+
+# .husky/_/.gitignore
+/.husky/_
+
+# packages/batcher/batcher-standalone/.gitignore
+/packages/batcher/batcher-standalone/packaged
+
+# packages/contracts/evm-contracts/.gitignore
+/packages/contracts/evm-contracts/artifacts
+/packages/contracts/evm-contracts/build
+/packages/contracts/evm-contracts/cache
+/packages/contracts/evm-contracts/publish
+/packages/contracts/evm-contracts/typechain-types
+
+# packages/engine/paima-standalone/.gitignore
+/packages/engine/paima-standalone/packaged
+
+# packages/paima-sdk/paima-utils/.gitignore
+/packages/paima-sdk/paima-utils/src/contract-types/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-FROM alpine:3.18.6 AS build
+FROM --platform=linux/amd64 alpine:3.18.6 AS build
 RUN apk add --no-cache \
     gcompat \
     bash \
@@ -39,7 +39,7 @@ COPY --link --from=build /src/packages/contracts/evm-contracts/ /node_modules/@p
 
 # -----------------------------------------------------------------------------
 # paima-batcher binary
-FROM alpine:3.18.6 AS paima-batcher
+FROM --platform=linux/amd64 alpine:3.18.6 AS paima-batcher
 RUN apk add --no-cache \
     gcompat \
     libstdc++
@@ -53,7 +53,7 @@ ENTRYPOINT [ "/usr/local/bin/paima-batcher" ]
 
 # -----------------------------------------------------------------------------
 # paima-engine binary, defaults to "run" subcommand
-FROM alpine:3.18.6 AS paima-engine
+FROM --platform=linux/amd64 alpine:3.18.6 AS paima-engine
 RUN apk add --no-cache \
     gcompat \
     libstdc++

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# -----------------------------------------------------------------------------
+FROM alpine:3.18.6 AS build
+RUN apk add --no-cache \
+    gcompat \
+    bash \
+    npm
+
+# Installing a newer npm helps avert timeouts somehow.
+RUN npm install -g npm@10.5.1
+
+# Install "forge" binary from https://github.com/foundry-rs/foundry
+# Just picked a popular tag.
+COPY --link --from=ghcr.io/foundry-rs/foundry:nightly-de33b6af53005037b463318d2628b5cfcaf39916 \
+    /usr/local/bin /usr/local/bin
+
+# Speed up build by caching node_modules separately.
+WORKDIR /src
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run release:bin
+
+# -----------------------------------------------------------------------------
+# paima-SDK node_modules substitute
+FROM scratch AS paima-sdk
+COPY --link --from=build /src/packages/paima-sdk/paima-concise /node_modules/@paima/concise
+COPY --link --from=build /src/packages/paima-sdk/paima-crypto /node_modules/@paima/crypto
+COPY --link --from=build /src/packages/paima-sdk/paima-executors /node_modules/@paima/executors
+COPY --link --from=build /src/packages/paima-sdk/paima-mw-core /node_modules/@paima/mw-core
+COPY --link --from=build /src/packages/paima-sdk/paima-prando /node_modules/@paima/prando
+COPY --link --from=build /src/packages/paima-sdk/paima-providers /node_modules/@paima/providers
+COPY --link --from=build /src/packages/paima-sdk/paima-utils /node_modules/@paima/utils
+COPY --link --from=build /src/packages/paima-sdk/paima-sdk/build /node_modules/@paima/sdk
+COPY --link --from=build /src/packages/node-sdk/paima-db /node_modules/@paima/db
+COPY --link --from=build /src/packages/build-utils/paima-build-utils /node_modules/@paima/build-utils
+COPY --link --from=build /src/packages/node-sdk/paima-utils-backend /node_modules/@paima/utils-backend
+COPY --link --from=build /src/packages/node-sdk/publish-wrapper/build /node_modules/@paima/node-sdk
+COPY --link --from=build /src/packages/contracts/evm-contracts/ /node_modules/@paima/evm-contracts
+
+# -----------------------------------------------------------------------------
+# paima-batcher binary
+FROM alpine:3.18.6 AS paima-batcher
+RUN apk add --no-cache \
+    gcompat \
+    libstdc++
+COPY --link --from=build \
+    /src/packages/batcher/batcher-standalone/packaged/@standalone/batcher-bin/paima-batcher-linux \
+    /usr/local/bin/paima-batcher
+#COPY --from=build \
+#    /src/packages/batcher/batcher-standalone/packaged/@standalone/batcher/db/migrations/up.sql \
+#    /init.sql
+ENTRYPOINT [ "/usr/local/bin/paima-batcher" ]
+
+# -----------------------------------------------------------------------------
+# paima-engine binary, defaults to "run" subcommand
+FROM alpine:3.18.6 AS paima-engine
+RUN apk add --no-cache \
+    gcompat \
+    libstdc++
+COPY --link --from=build \
+    /src/bin/paima-engine-linux \
+    /usr/local/bin/paima-engine
+WORKDIR "/paima"
+ENTRYPOINT [ "/usr/local/bin/paima-engine" ]
+CMD [ "run" ]
+# Per https://docs.paimastudios.com/home/releasing-a-game/generate-build, user
+# supplies packaged/gameCode.cjs, packaged/endpoints.cjs, and .env.$NETWORK

--- a/docker-tag
+++ b/docker-tag
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+version=${1:-latest}
+docker buildx build . --target paima-sdk --tag ghcr.io/paimastudios/paima-sdk:"$version"
+docker buildx build . --target paima-engine --tag ghcr.io/paimastudios/paima-engine:"$version"
+docker buildx build . --target paima-batcher --tag ghcr.io/paimastudios/paima-batcher:"$version"


### PR DESCRIPTION
A bit of an experiment. The goal is to make it easier to version and deploy games, and to reduce accidental structural differences between dev, test, and production.

`./docker-tag [tag]` builds and tags the images with the given tag (ex: `2.3.0`) or `latest` if not specified.

The intended use of the images are:

* `paima-engine` serves as a base for game backend images:
  ```Dockerfile
  FROM ghcr.io/paimastudios/paima-engine:2.3.0 AS mygame-backend
  COPY --from=build-backend /src/packaged packaged
  ARG NETWORK=docker
  COPY .env.$NETWORK .env.$NETWORK
  COPY config.$NETWORK.yml config.$NETWORK.yml
  COPY extensions.$NETWORK.yml extensions.yml
  ENV NETWORK=$NETWORK
  ```

* `paima-batcher` can be run directly, supplying just the configuration:
  ```sh
  docker run --env-file .env.docker ghcr.io/paimastudios/paima-batcher:2.3.0
  ```
  or included in a docker-compose file:
  ```yaml
  batcher:
    image: ghcr.io/paimastudios/paima-batcher:2.3.0
    depends_on:
      - hardhat
      - backend
      - database
    env_file:
      - .env.docker
    ports:
      - "3340:3340"
  ```

* `paima-sdk` can be used as a `COPY` source for a Docker build that needs a newer Node SDK than is on NPM:
  ```Dockerfile
  COPY --from=ghcr.io/paimastudios/paima-sdk:latest \
    /node_modules/@paima \
    node_modules/@paima
  ```

Caveats:
- The `paima-engine` image is bigger than it needs to be because the binary includes the batcher, contracts, templates, so on. The image only really needs the `run` subcommand.
- The old batcher and db docker-compose templates are still hanging around.
- The `paima-sdk` image is a little goofy. An image of just free-hanging files is not really how Docker is meant to be used. But this seems like the easiest way to make compiled outputs of non-NPM-tagged versions available to downstream Docker builds.

Thoughts?