### PR TITLE
Add scaffolding for PRC-1 achievements API

### DIFF
--- a/packages/engine/paima-rest/package.json
+++ b/packages/engine/paima-rest/package.json
@@ -7,8 +7,8 @@
   "types": "build/index.d.ts",
   "scripts": {
     "lint:eslint": "eslint .",
-    "build": "tsc --build tsconfig.build.json",
-    "prebuild": "npm run compile:api",
+    "build": "npm run compile:api && tsc --build tsconfig.build.json",
+    "prebuild": "",
     "compile:api": "tsoa spec-and-routes"
   },
   "author": "Paima Studios",

--- a/packages/engine/paima-rest/package.json
+++ b/packages/engine/paima-rest/package.json
@@ -9,7 +9,7 @@
     "lint:eslint": "eslint .",
     "build": "tsc --build tsconfig.build.json",
     "prebuild": "npm run compile:api",
-    "compile:api": "npx tsoa spec-and-routes"
+    "compile:api": "tsoa spec-and-routes"
   },
   "author": "Paima Studios",
   "dependencies": {

--- a/packages/engine/paima-rest/src/EngineService.ts
+++ b/packages/engine/paima-rest/src/EngineService.ts
@@ -1,9 +1,12 @@
 import type { GameStateMachine } from '@paima/sm';
+import { AchievementService } from '@paima/utils-backend';
 
 export class EngineService {
   public static INSTANCE = new EngineService();
 
   private runtime: GameStateMachine | undefined = undefined;
+
+  public achievementService: AchievementService = new AchievementService();
 
   getSM = (): GameStateMachine => {
     if (this.runtime == null) {

--- a/packages/engine/paima-rest/src/controllers/AchievementsController.ts
+++ b/packages/engine/paima-rest/src/controllers/AchievementsController.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Path, Query, Route } from 'tsoa';
-import { EngineService } from '../EngineService';
+import { EngineService } from '../EngineService.js';
 import { ENV } from '@paima/utils';
-import {
+import type {
   AchievementService,
   AchievementPublicList,
   PlayerAchievements,
@@ -65,6 +65,6 @@ export class AchievementsController extends Controller {
     @Query() name?: string
   ): Promise<PlayerAchievements> {
     const wallet = await service().getNftOwner(nft_address);
-    return this.wallet(wallet, name);
+    return await this.wallet(wallet, name);
   }
 }

--- a/packages/engine/paima-rest/src/controllers/AchievementsController.ts
+++ b/packages/engine/paima-rest/src/controllers/AchievementsController.ts
@@ -1,0 +1,182 @@
+import { Controller, Get, Path, Query, Route } from 'tsoa';
+import { EngineService } from '../EngineService';
+import { ENV } from '@paima/utils';
+
+// ----------------------------------------------------------------------------
+// PRC-1 definitions
+
+/** General game info */
+export interface Game {
+  /** Game ID */
+  id: string;
+  /** Optional game name */
+  name?: string;
+  /** Optional game version */
+  version?: string;
+}
+
+/** Data validity */
+export interface Validity {
+  /** Data block height (0 always valid) */
+  block: number;
+  /** Data chain ID */
+  chainId: number;
+  /** Optional date. ISO8601, like YYYY-MM-DDTHH:mm:ss.sssZ */
+  time?: string;
+}
+
+/** Player info */
+export interface Player {
+  /** e.g. addr1234... or 0x1234... */
+  wallet: string;
+  /** Optional wallet-type */
+  walletType?: 'cardano' | 'evm' | 'polkadot' | 'algorand' | string;
+  /** If data for specific user: e.g., "1", "player-1", "unique-name", etc. */
+  userId?: string;
+  /** Player display name */
+  userName?: string;
+}
+
+export interface Achievement {
+  /** Unique Achievement String */
+  name: string;
+  /** Optional: Relative Value of the Achievement */
+  score?: number;
+  /** Optional: 'Gold' | 'Diamond' | 'Beginner' | 'Advanced' | 'Vendor' */
+  category?: string;
+  /** Percent of players that have unlocked the achievement */
+  percentCompleted?: number;
+  /** If achievement can be unlocked at the time. */
+  isActive: boolean;
+  /** Achievement Display Name */
+  displayName: string;
+  /** Achievement Description */
+  description: string;
+  /** Hide entire achievement or description if not completed */
+  spoiler?: 'all' | 'description';
+  /** Optional Icon for Achievement */
+  iconURI?: string;
+  /** Optional Icon for locked Achievement */
+  iconGreyURI?: string;
+  /** Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
+  startDate?: string;
+  /** Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
+  endDate?: string;
+}
+
+/** Result of "Get All Available Achievements" */
+export interface AchievementPublicList extends Game, Validity {
+  achievements: Achievement[];
+}
+
+export interface PlayerAchievement {
+  /** Unique Achievement String */
+  name: string;
+  /** Is Achievement completed */
+  completed: boolean;
+  /** Completed Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
+  completedDate?: Date;
+  /** If achievement has incremental progress */
+  completedRate?: {
+    /** Current Progress */
+    progress: number;
+    /** Total Progress */
+    total: number;
+  };
+}
+
+/** Result of "Get Completed Achievements" */
+export interface PlayerAchievements extends Validity, Player {
+  /** Total number of completed achievements for the game */
+  completed: number;
+  achievements: PlayerAchievement[];
+}
+
+// ----------------------------------------------------------------------------
+// Extension interface
+
+/**
+ * To implement the PRC-1 `/achievements` API, extend this class and set
+ * {@link achievementService} to your instance. At minimum you must override
+ * {@link getGame} for the API to function, and {@link getAllAchievements} to
+ * return a non-empty list for it to be useful.
+ */
+class AchievementService {
+  async getValidity(): Promise<Validity> {
+    return {
+      chainId: ENV.CHAIN_ID,
+      block: await EngineService.INSTANCE.getSM().latestProcessedBlockHeight(),
+      // TODO? time
+    };
+  }
+
+  async getGame(): Promise<Game> {
+    throw new Error('Achievements not available for this game');
+  }
+
+  async getAllAchievements(): Promise<Achievement[]> {
+    return [];
+  }
+
+  async getPlayer(wallet: string): Promise<Player> {
+    return { wallet };
+  }
+
+  async getNftOwner(nft_address: string): Promise<string> {
+    throw new Error('No owner known for NFT address');
+  }
+
+  async getPlayerAchievements(wallet: string): Promise<PlayerAchievement[]> {
+    return [];
+  }
+}
+
+/** Set this to actually implement the achievements API for your game. */
+export let achievementService: AchievementService = new AchievementService();
+
+// ----------------------------------------------------------------------------
+// Controller and routes per PRC-1
+
+@Route('achievements')
+export class AchievementsController extends Controller {
+  @Get('public/list')
+  public async public_list(
+    @Query() category?: string,
+    @Query() isActive?: boolean
+  ): Promise<AchievementPublicList> {
+    return {
+      ...(await achievementService.getGame()),
+      ...(await achievementService.getValidity()),
+      achievements: (await achievementService.getAllAchievements())
+        .filter(ach => !category || category === ach.category)
+        .filter(ach => !isActive || isActive === ach.isActive),
+    };
+  }
+
+  @Get('wallet/{wallet}')
+  public async wallet(
+    @Path() wallet: string,
+    /** Comma-separated list. */
+    @Query() name?: string
+  ): Promise<PlayerAchievements> {
+    const player = await achievementService.getPlayer(wallet);
+    const achievements = await achievementService.getPlayerAchievements(wallet);
+    const nameSet = name ? new Set(name.split(',')) : null;
+    return {
+      ...(await achievementService.getValidity()),
+      ...player,
+      completed: achievements.reduce((n, ach) => n + (ach.completed ? 1 : 0), 0),
+      achievements: nameSet ? achievements.filter(ach => nameSet.has(ach.name)) : achievements,
+    };
+  }
+
+  @Get('nft/{nft_address}')
+  public async nft(
+    @Path() nft_address: string,
+    /** Comma-separated list. */
+    @Query() name?: string
+  ): Promise<PlayerAchievements> {
+    const wallet = await achievementService.getNftOwner(nft_address);
+    return this.wallet(wallet, name);
+  }
+}

--- a/packages/engine/paima-rest/src/controllers/AchievementsController.ts
+++ b/packages/engine/paima-rest/src/controllers/AchievementsController.ts
@@ -1,108 +1,23 @@
 import { Controller, Get, Path, Query, Route } from 'tsoa';
 import { EngineService } from '../EngineService';
 import { ENV } from '@paima/utils';
+import {
+  AchievementService,
+  AchievementPublicList,
+  PlayerAchievements,
+  Validity,
+} from '@paima/utils-backend';
 
 // ----------------------------------------------------------------------------
-// PRC-1 definitions
+// Controller and routes per PRC-1
 
-/** General game info */
-export interface Game {
-  /** Game ID */
-  id: string;
-  /** Optional game name */
-  name?: string;
-  /** Optional game version */
-  version?: string;
+function service(): AchievementService {
+  return EngineService.INSTANCE.achievementService;
 }
 
-/** Data validity */
-export interface Validity {
-  /** Data block height (0 always valid) */
-  block: number;
-  /** Data chain ID */
-  chainId: number;
-  /** Optional date. ISO8601, like YYYY-MM-DDTHH:mm:ss.sssZ */
-  time?: string;
-}
-
-/** Player info */
-export interface Player {
-  /** e.g. addr1234... or 0x1234... */
-  wallet: string;
-  /** Optional wallet-type */
-  walletType?: 'cardano' | 'evm' | 'polkadot' | 'algorand' | string;
-  /** If data for specific user: e.g., "1", "player-1", "unique-name", etc. */
-  userId?: string;
-  /** Player display name */
-  userName?: string;
-}
-
-export interface Achievement {
-  /** Unique Achievement String */
-  name: string;
-  /** Optional: Relative Value of the Achievement */
-  score?: number;
-  /** Optional: 'Gold' | 'Diamond' | 'Beginner' | 'Advanced' | 'Vendor' */
-  category?: string;
-  /** Percent of players that have unlocked the achievement */
-  percentCompleted?: number;
-  /** If achievement can be unlocked at the time. */
-  isActive: boolean;
-  /** Achievement Display Name */
-  displayName: string;
-  /** Achievement Description */
-  description: string;
-  /** Hide entire achievement or description if not completed */
-  spoiler?: 'all' | 'description';
-  /** Optional Icon for Achievement */
-  iconURI?: string;
-  /** Optional Icon for locked Achievement */
-  iconGreyURI?: string;
-  /** Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
-  startDate?: string;
-  /** Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
-  endDate?: string;
-}
-
-/** Result of "Get All Available Achievements" */
-export interface AchievementPublicList extends Game, Validity {
-  achievements: Achievement[];
-}
-
-export interface PlayerAchievement {
-  /** Unique Achievement String */
-  name: string;
-  /** Is Achievement completed */
-  completed: boolean;
-  /** Completed Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
-  completedDate?: Date;
-  /** If achievement has incremental progress */
-  completedRate?: {
-    /** Current Progress */
-    progress: number;
-    /** Total Progress */
-    total: number;
-  };
-}
-
-/** Result of "Get Completed Achievements" */
-export interface PlayerAchievements extends Validity, Player {
-  /** Total number of completed achievements for the game */
-  completed: number;
-  achievements: PlayerAchievement[];
-}
-
-// ----------------------------------------------------------------------------
-// Extension interface
-
-/**
- * To implement the PRC-1 `/achievements` API, extend this class and set
- * {@link achievementService} to your instance. At minimum you must override
- * {@link getGame} for the API to function, and {@link getAllAchievements} to
- * return a non-empty list for it to be useful.
- */
-class AchievementService {
-  async getValidity(): Promise<Validity> {
+@Route('achievements')
+export class AchievementsController extends Controller {
+  private async defaultValidity(): Promise<Validity> {
     return {
       chainId: ENV.CHAIN_ID,
       block: await EngineService.INSTANCE.getSM().latestProcessedBlockHeight(),
@@ -110,44 +25,16 @@ class AchievementService {
     };
   }
 
-  async getGame(): Promise<Game> {
-    throw new Error('Achievements not available for this game');
-  }
-
-  async getAllAchievements(): Promise<Achievement[]> {
-    return [];
-  }
-
-  async getPlayer(wallet: string): Promise<Player> {
-    return { wallet };
-  }
-
-  async getNftOwner(nft_address: string): Promise<string> {
-    throw new Error('No owner known for NFT address');
-  }
-
-  async getPlayerAchievements(wallet: string): Promise<PlayerAchievement[]> {
-    return [];
-  }
-}
-
-/** Set this to actually implement the achievements API for your game. */
-export let achievementService: AchievementService = new AchievementService();
-
-// ----------------------------------------------------------------------------
-// Controller and routes per PRC-1
-
-@Route('achievements')
-export class AchievementsController extends Controller {
   @Get('public/list')
   public async public_list(
     @Query() category?: string,
     @Query() isActive?: boolean
   ): Promise<AchievementPublicList> {
     return {
-      ...(await achievementService.getGame()),
-      ...(await achievementService.getValidity()),
-      achievements: (await achievementService.getAllAchievements())
+      ...(await service().getGame()),
+      ...(await this.defaultValidity()),
+      ...(await service().getValidity()),
+      achievements: (await service().getAllAchievements())
         .filter(ach => !category || category === ach.category)
         .filter(ach => !isActive || isActive === ach.isActive),
     };
@@ -159,11 +46,12 @@ export class AchievementsController extends Controller {
     /** Comma-separated list. */
     @Query() name?: string
   ): Promise<PlayerAchievements> {
-    const player = await achievementService.getPlayer(wallet);
-    const achievements = await achievementService.getPlayerAchievements(wallet);
+    const player = await service().getPlayer(wallet);
+    const achievements = await service().getPlayerAchievements(wallet);
     const nameSet = name ? new Set(name.split(',')) : null;
     return {
-      ...(await achievementService.getValidity()),
+      ...(await this.defaultValidity()),
+      ...(await service().getValidity()),
       ...player,
       completed: achievements.reduce((n, ach) => n + (ach.completed ? 1 : 0), 0),
       achievements: nameSet ? achievements.filter(ach => nameSet.has(ach.name)) : achievements,
@@ -176,7 +64,7 @@ export class AchievementsController extends Controller {
     /** Comma-separated list. */
     @Query() name?: string
   ): Promise<PlayerAchievements> {
-    const wallet = await achievementService.getNftOwner(nft_address);
+    const wallet = await service().getNftOwner(nft_address);
     return this.wallet(wallet, name);
   }
 }

--- a/packages/engine/paima-rest/src/controllers/AchievementsController.ts
+++ b/packages/engine/paima-rest/src/controllers/AchievementsController.ts
@@ -106,7 +106,7 @@ class AchievementService {
     return {
       chainId: ENV.CHAIN_ID,
       block: await EngineService.INSTANCE.getSM().latestProcessedBlockHeight(),
-      // TODO? time
+      time: new Date().toISOString(),
     };
   }
 

--- a/packages/engine/paima-rest/src/index.ts
+++ b/packages/engine/paima-rest/src/index.ts
@@ -1,7 +1,5 @@
 import { RegisterRoutes } from './tsoa/routes.js';
-import * as basicControllerJson from './tsoa/swagger.json';
-// replace the above import with the one below once this is merged and released: https://github.com/prettier/prettier/issues/15699
-// import { default as basicControllerJson } from './tsoa/swagger.json' with { type: "json" };
+import { default as basicControllerJson } from './tsoa/swagger.json' with { type: 'json' };
 export default RegisterRoutes;
 export { basicControllerJson };
 export { EngineService } from './EngineService.js';

--- a/packages/engine/paima-rest/src/tsoa/routes.ts
+++ b/packages/engine/paima-rest/src/tsoa/routes.ts
@@ -142,7 +142,7 @@ const models: TsoaRoute.Models = {
             "chainId": {"dataType":"double","required":true},
             "time": {"dataType":"string"},
             "wallet": {"dataType":"string","required":true},
-            "walletType": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["cardano"]},{"dataType":"enum","enums":["evm"]},{"dataType":"enum","enums":["polkadot"]},{"dataType":"enum","enums":["algorand"]},{"dataType":"string"}]},
+            "walletType": {"dataType":"string"},
             "userId": {"dataType":"string"},
             "userName": {"dataType":"string"},
             "completed": {"dataType":"double","required":true},

--- a/packages/engine/paima-rest/src/tsoa/routes.ts
+++ b/packages/engine/paima-rest/src/tsoa/routes.ts
@@ -14,6 +14,8 @@ import { EmulatedBlockActiveController } from './../controllers/BasicControllers
 import { DeploymentBlockheightToEmulatedController } from './../controllers/BasicControllers';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ConfirmInputAcceptanceController } from './../controllers/BasicControllers';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AchievementsController } from './../controllers/AchievementsController';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
 
@@ -87,6 +89,66 @@ const models: TsoaRoute.Models = {
     "ConfirmInputAcceptanceResponse": {
         "dataType": "refAlias",
         "type": {"ref":"Result_boolean_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Achievement": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "score": {"dataType":"double"},
+            "category": {"dataType":"string"},
+            "percentCompleted": {"dataType":"double"},
+            "isActive": {"dataType":"boolean","required":true},
+            "displayName": {"dataType":"string","required":true},
+            "description": {"dataType":"string","required":true},
+            "spoiler": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["all"]},{"dataType":"enum","enums":["description"]}]},
+            "iconURI": {"dataType":"string"},
+            "iconGreyURI": {"dataType":"string"},
+            "startDate": {"dataType":"string"},
+            "endDate": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AchievementPublicList": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "name": {"dataType":"string"},
+            "version": {"dataType":"string"},
+            "block": {"dataType":"double","required":true},
+            "chainId": {"dataType":"double","required":true},
+            "time": {"dataType":"string"},
+            "achievements": {"dataType":"array","array":{"dataType":"refObject","ref":"Achievement"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PlayerAchievement": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "completed": {"dataType":"boolean","required":true},
+            "completedDate": {"dataType":"datetime"},
+            "completedRate": {"dataType":"nestedObjectLiteral","nestedProperties":{"total":{"dataType":"double","required":true},"progress":{"dataType":"double","required":true}}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PlayerAchievements": {
+        "dataType": "refObject",
+        "properties": {
+            "block": {"dataType":"double","required":true},
+            "chainId": {"dataType":"double","required":true},
+            "time": {"dataType":"string"},
+            "wallet": {"dataType":"string","required":true},
+            "walletType": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["cardano"]},{"dataType":"enum","enums":["evm"]},{"dataType":"enum","enums":["polkadot"]},{"dataType":"enum","enums":["algorand"]},{"dataType":"string"}]},
+            "userId": {"dataType":"string"},
+            "userName": {"dataType":"string"},
+            "completed": {"dataType":"double","required":true},
+            "achievements": {"dataType":"array","array":{"dataType":"refObject","ref":"PlayerAchievement"},"required":true},
+        },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -268,6 +330,99 @@ export function RegisterRoutes(app: Router) {
 
               templateService.apiHandler({
                 methodName: 'get',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/achievements/public/list',
+            ...(fetchMiddlewares<RequestHandler>(AchievementsController)),
+            ...(fetchMiddlewares<RequestHandler>(AchievementsController.prototype.public_list)),
+
+            function AchievementsController_public_list(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    category: {"in":"query","name":"category","dataType":"string"},
+                    isActive: {"in":"query","name":"isActive","dataType":"boolean"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new AchievementsController();
+
+              templateService.apiHandler({
+                methodName: 'public_list',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/achievements/wallet/:wallet',
+            ...(fetchMiddlewares<RequestHandler>(AchievementsController)),
+            ...(fetchMiddlewares<RequestHandler>(AchievementsController.prototype.wallet)),
+
+            function AchievementsController_wallet(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    wallet: {"in":"path","name":"wallet","required":true,"dataType":"string"},
+                    name: {"in":"query","name":"name","dataType":"string"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new AchievementsController();
+
+              templateService.apiHandler({
+                methodName: 'wallet',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/achievements/nft/:nft_address',
+            ...(fetchMiddlewares<RequestHandler>(AchievementsController)),
+            ...(fetchMiddlewares<RequestHandler>(AchievementsController.prototype.nft)),
+
+            function AchievementsController_nft(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    nft_address: {"in":"path","name":"nft_address","required":true,"dataType":"string"},
+                    name: {"in":"query","name":"name","dataType":"string"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new AchievementsController();
+
+              templateService.apiHandler({
+                methodName: 'nft',
                 controller,
                 response,
                 next,

--- a/packages/engine/paima-rest/src/tsoa/swagger.json
+++ b/packages/engine/paima-rest/src/tsoa/swagger.json
@@ -312,20 +312,7 @@
 						"description": "e.g. addr1234... or 0x1234..."
 					},
 					"walletType": {
-						"anyOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "string",
-								"enum": [
-									"cardano",
-									"evm",
-									"polkadot",
-									"algorand"
-								]
-							}
-						],
+						"type": "string",
 						"description": "Optional wallet-type"
 					},
 					"userId": {

--- a/packages/engine/paima-rest/src/tsoa/swagger.json
+++ b/packages/engine/paima-rest/src/tsoa/swagger.json
@@ -135,6 +135,228 @@
 			},
 			"ConfirmInputAcceptanceResponse": {
 				"$ref": "#/components/schemas/Result_boolean_"
+			},
+			"Achievement": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Unique Achievement String"
+					},
+					"score": {
+						"type": "number",
+						"format": "double",
+						"description": "Optional: Relative Value of the Achievement"
+					},
+					"category": {
+						"type": "string",
+						"description": "Optional: 'Gold' | 'Diamond' | 'Beginner' | 'Advanced' | 'Vendor'"
+					},
+					"percentCompleted": {
+						"type": "number",
+						"format": "double",
+						"description": "Percent of players that have unlocked the achievement"
+					},
+					"isActive": {
+						"type": "boolean",
+						"description": "If achievement can be unlocked at the time."
+					},
+					"displayName": {
+						"type": "string",
+						"description": "Achievement Display Name"
+					},
+					"description": {
+						"type": "string",
+						"description": "Achievement Description"
+					},
+					"spoiler": {
+						"type": "string",
+						"enum": [
+							"all",
+							"description"
+						],
+						"description": "Hide entire achievement or description if not completed"
+					},
+					"iconURI": {
+						"type": "string",
+						"description": "Optional Icon for Achievement"
+					},
+					"iconGreyURI": {
+						"type": "string",
+						"description": "Optional Icon for locked Achievement"
+					},
+					"startDate": {
+						"type": "string",
+						"description": "Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ"
+					},
+					"endDate": {
+						"type": "string",
+						"description": "Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ"
+					}
+				},
+				"required": [
+					"name",
+					"isActive",
+					"displayName",
+					"description"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AchievementPublicList": {
+				"description": "Result of \"Get All Available Achievements\"",
+				"properties": {
+					"id": {
+						"type": "string",
+						"description": "Game ID"
+					},
+					"name": {
+						"type": "string",
+						"description": "Optional game name"
+					},
+					"version": {
+						"type": "string",
+						"description": "Optional game version"
+					},
+					"block": {
+						"type": "number",
+						"format": "double",
+						"description": "Data block height (0 always valid)"
+					},
+					"chainId": {
+						"type": "number",
+						"format": "double",
+						"description": "Data chain ID"
+					},
+					"time": {
+						"type": "string",
+						"description": "Optional date. ISO8601, like YYYY-MM-DDTHH:mm:ss.sssZ"
+					},
+					"achievements": {
+						"items": {
+							"$ref": "#/components/schemas/Achievement"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"block",
+					"chainId",
+					"achievements"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PlayerAchievement": {
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Unique Achievement String"
+					},
+					"completed": {
+						"type": "boolean",
+						"description": "Is Achievement completed"
+					},
+					"completedDate": {
+						"type": "string",
+						"format": "date-time",
+						"description": "Completed Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ"
+					},
+					"completedRate": {
+						"properties": {
+							"total": {
+								"type": "number",
+								"format": "double",
+								"description": "Total Progress"
+							},
+							"progress": {
+								"type": "number",
+								"format": "double",
+								"description": "Current Progress"
+							}
+						},
+						"required": [
+							"total",
+							"progress"
+						],
+						"type": "object",
+						"description": "If achievement has incremental progress"
+					}
+				},
+				"required": [
+					"name",
+					"completed"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PlayerAchievements": {
+				"description": "Result of \"Get Completed Achievements\"",
+				"properties": {
+					"block": {
+						"type": "number",
+						"format": "double",
+						"description": "Data block height (0 always valid)"
+					},
+					"chainId": {
+						"type": "number",
+						"format": "double",
+						"description": "Data chain ID"
+					},
+					"time": {
+						"type": "string",
+						"description": "Optional date. ISO8601, like YYYY-MM-DDTHH:mm:ss.sssZ"
+					},
+					"wallet": {
+						"type": "string",
+						"description": "e.g. addr1234... or 0x1234..."
+					},
+					"walletType": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "string",
+								"enum": [
+									"cardano",
+									"evm",
+									"polkadot",
+									"algorand"
+								]
+							}
+						],
+						"description": "Optional wallet-type"
+					},
+					"userId": {
+						"type": "string",
+						"description": "If data for specific user: e.g., \"1\", \"player-1\", \"unique-name\", etc."
+					},
+					"userName": {
+						"type": "string",
+						"description": "Player display name"
+					},
+					"completed": {
+						"type": "number",
+						"format": "double",
+						"description": "Total number of completed achievements for the game"
+					},
+					"achievements": {
+						"items": {
+							"$ref": "#/components/schemas/PlayerAchievement"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"block",
+					"chainId",
+					"wallet",
+					"completed",
+					"achievements"
+				],
+				"type": "object",
+				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {}
@@ -310,6 +532,116 @@
 						"schema": {
 							"format": "double",
 							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/achievements/public/list": {
+			"get": {
+				"operationId": "AchievementsPublic_list",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AchievementPublicList"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "category",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "isActive",
+						"required": false,
+						"schema": {
+							"type": "boolean"
+						}
+					}
+				]
+			}
+		},
+		"/achievements/wallet/{wallet}": {
+			"get": {
+				"operationId": "AchievementsWallet",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PlayerAchievements"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "wallet",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Comma-separated list.",
+						"in": "query",
+						"name": "name",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/achievements/nft/{nft_address}": {
+			"get": {
+				"operationId": "AchievementsNft",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PlayerAchievements"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "nft_address",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Comma-separated list.",
+						"in": "query",
+						"name": "name",
+						"required": false,
+						"schema": {
+							"type": "string"
 						}
 					}
 				]

--- a/packages/engine/paima-rest/tsconfig.json
+++ b/packages/engine/paima-rest/tsconfig.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../../paima-sdk/paima-utils/tsconfig.build.json" },
     { "path": "../../node-sdk/paima-db" },
+    { "path": "../../node-sdk/paima-utils-backend" },
     { "path": "../paima-sm" },
   ]
 }

--- a/packages/engine/paima-rest/tsoa.json
+++ b/packages/engine/paima-rest/tsoa.json
@@ -13,7 +13,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@paima/utils/*": ["../../paima-sdk/paima-utils/*"]
+      "@paima/utils": ["../../paima-sdk/paima-utils/build"],
+      "@paima/node-sdk/paima-utils-backend": ["../../node-sdk/paima-utils-backend/build"]
     }
   }
 }

--- a/packages/engine/paima-runtime/src/server.ts
+++ b/packages/engine/paima-runtime/src/server.ts
@@ -53,6 +53,9 @@ function registerValidationErrorHandler(): void {
       });
     }
     if (err instanceof Error) {
+      // Log rather than swallowing silently, otherwise difficult to debug.
+      console.warn(`${req.method} ${req.path}:`, err);
+
       return res.status(500).json({
         message: 'Internal Server Error',
       });

--- a/packages/engine/paima-standalone/src/utils/import.ts
+++ b/packages/engine/paima-standalone/src/utils/import.ts
@@ -7,9 +7,11 @@ interface GameCodeCjs {
   default: GameStateTransitionFunctionRouter;
 }
 /**
- * Reads repackaged user's code placed next to the executable in `gameCode.cjs` file
+ * Reads packaged user's code placed next to the executable in `gameCode.cjs` file.
  */
 export function importGameStateTransitionRouter(): GameStateTransitionFunctionRouter {
+  // dynamic import cannot be used here due to PKG limitations
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   return (require(`${process.cwd()}/${ROUTER_FILENAME}`) as GameCodeCjs).default;
 }
 
@@ -19,7 +21,7 @@ export interface EndpointsCjs {
   AchievementService?: new () => AchievementService;
 }
 /**
- * Reads repackaged user's code placed next to the executable in `endpoints.cjs` file
+ * Reads packaged user's code placed next to the executable in `endpoints.cjs` file.
  */
 export function importEndpoints(): EndpointsCjs {
   return require(`${process.cwd()}/${API_FILENAME}`);
@@ -28,7 +30,7 @@ export function importEndpoints(): EndpointsCjs {
 export const GAME_OPENAPI_FILENAME = 'packaged/openapi.json';
 export type OpenApiJson = object;
 /**
- * Reads repackaged user's code placed next to the executable in `endpoints.cjs` file
+ * Reads packaged user's OpenAPI definitions placed next to the executable in `openapi.json` file.
  */
 export function importOpenApiJson(): OpenApiJson | undefined {
   try {

--- a/packages/engine/paima-standalone/src/utils/import.ts
+++ b/packages/engine/paima-standalone/src/utils/import.ts
@@ -1,35 +1,39 @@
 import type { GameStateTransitionFunctionRouter } from '@paima/sm';
 import type { TsoaFunction } from '@paima/runtime';
-
-function importFile<T>(file: string): T {
-  // dynamic import cannot be used here due to PKG limitations
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { default: defaultExport } = require(`${process.cwd()}/${file}`);
-
-  return defaultExport;
-}
+import type { AchievementService } from '@paima/utils-backend';
 
 export const ROUTER_FILENAME = 'packaged/gameCode.cjs';
+interface GameCodeCjs {
+  default: GameStateTransitionFunctionRouter;
+}
 /**
  * Reads repackaged user's code placed next to the executable in `gameCode.cjs` file
  */
-export const importGameStateTransitionRouter = (): GameStateTransitionFunctionRouter =>
-  importFile<GameStateTransitionFunctionRouter>(ROUTER_FILENAME);
+export function importGameStateTransitionRouter(): GameStateTransitionFunctionRouter {
+  return (require(`${process.cwd()}/${ROUTER_FILENAME}`) as GameCodeCjs).default;
+}
 
 export const API_FILENAME = 'packaged/endpoints.cjs';
+export interface EndpointsCjs {
+  default: TsoaFunction;
+  AchievementService?: new () => AchievementService;
+}
 /**
  * Reads repackaged user's code placed next to the executable in `endpoints.cjs` file
  */
-export const importTsoaFunction = (): TsoaFunction => importFile<TsoaFunction>(API_FILENAME);
+export function importEndpoints(): EndpointsCjs {
+  return require(`${process.cwd()}/${API_FILENAME}`);
+}
 
 export const GAME_OPENAPI_FILENAME = 'packaged/openapi.json';
+export type OpenApiJson = object;
 /**
  * Reads repackaged user's code placed next to the executable in `endpoints.cjs` file
  */
-export const importOpenApiJson = (): undefined | object => {
+export function importOpenApiJson(): OpenApiJson | undefined {
   try {
     return require(`${process.cwd()}/${GAME_OPENAPI_FILENAME}`);
   } catch (e) {
     return undefined;
   }
-};
+}

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -14,7 +14,7 @@ import {
   prepareDocumentation,
   prepareTemplate,
 } from './file.js';
-import { importOpenApiJson, importTsoaFunction } from './import.js';
+import { importOpenApiJson, importEndpoints } from './import.js';
 import type { Template } from './types.js';
 import RegisterRoutes, { EngineService } from '@paima/rest';
 
@@ -123,8 +123,14 @@ export const runPaimaEngine = async (): Promise<void> => {
     const engine = paimaRuntime.initialize(funnelFactory, stateMachine, ENV.GAME_NODE_VERSION);
 
     EngineService.INSTANCE.updateSM(stateMachine);
+
+    const endpoints = importEndpoints();
+    if (endpoints.AchievementService) {
+      EngineService.INSTANCE.achievementService = new endpoints.AchievementService();
+    }
+
     engine.setPollingRate(ENV.POLLING_RATE);
-    engine.addEndpoints(importTsoaFunction());
+    engine.addEndpoints(endpoints.default);
     engine.addEndpoints(RegisterRoutes);
     registerDocs(importOpenApiJson());
     registerValidationErrorHandler();

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -108,7 +108,7 @@ export const runPaimaEngine = async (): Promise<void> => {
     process.exit(0);
   }
 
-  const [_, config] = await GlobalConfig.mainEvmConfig();
+  const [, config] = await GlobalConfig.mainEvmConfig();
 
   // Check that packed game code is available
   if (checkForPackedGameCode()) {

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -125,9 +125,7 @@ export const runPaimaEngine = async (): Promise<void> => {
     EngineService.INSTANCE.updateSM(stateMachine);
     engine.setPollingRate(ENV.POLLING_RATE);
     engine.addEndpoints(importTsoaFunction());
-    engine.addEndpoints(server => {
-      RegisterRoutes(server);
-    });
+    engine.addEndpoints(RegisterRoutes);
     registerDocs(importOpenApiJson());
     registerValidationErrorHandler();
 

--- a/packages/node-sdk/paima-utils-backend/src/achievements.ts
+++ b/packages/node-sdk/paima-utils-backend/src/achievements.ts
@@ -26,7 +26,7 @@ export interface Player {
   /** e.g. addr1234... or 0x1234... */
   wallet: string;
   /** Optional wallet-type */
-  walletType?: 'cardano' | 'evm' | 'polkadot' | 'algorand' | string;
+  walletType?: string; // ex: 'cardano' | 'evm' | 'polkadot' | 'algorand'
   /** If data for specific user: e.g., "1", "player-1", "unique-name", etc. */
   userId?: string;
   /** Player display name */

--- a/packages/node-sdk/paima-utils-backend/src/achievements.ts
+++ b/packages/node-sdk/paima-utils-backend/src/achievements.ts
@@ -1,0 +1,130 @@
+// ----------------------------------------------------------------------------
+// PRC-1 definitions
+
+/** General game info */
+export interface Game {
+  /** Game ID */
+  id: string;
+  /** Optional game name */
+  name?: string;
+  /** Optional game version */
+  version?: string;
+}
+
+/** Data validity */
+export interface Validity {
+  /** Data block height (0 always valid) */
+  block: number;
+  /** Data chain ID */
+  chainId: number;
+  /** Optional date. ISO8601, like YYYY-MM-DDTHH:mm:ss.sssZ */
+  time?: string;
+}
+
+/** Player info */
+export interface Player {
+  /** e.g. addr1234... or 0x1234... */
+  wallet: string;
+  /** Optional wallet-type */
+  walletType?: 'cardano' | 'evm' | 'polkadot' | 'algorand' | string;
+  /** If data for specific user: e.g., "1", "player-1", "unique-name", etc. */
+  userId?: string;
+  /** Player display name */
+  userName?: string;
+}
+
+export interface Achievement {
+  /** Unique Achievement String */
+  name: string;
+  /** Optional: Relative Value of the Achievement */
+  score?: number;
+  /** Optional: 'Gold' | 'Diamond' | 'Beginner' | 'Advanced' | 'Vendor' */
+  category?: string;
+  /** Percent of players that have unlocked the achievement */
+  percentCompleted?: number;
+  /** If achievement can be unlocked at the time. */
+  isActive: boolean;
+  /** Achievement Display Name */
+  displayName: string;
+  /** Achievement Description */
+  description: string;
+  /** Hide entire achievement or description if not completed */
+  spoiler?: 'all' | 'description';
+  /** Optional Icon for Achievement */
+  iconURI?: string;
+  /** Optional Icon for locked Achievement */
+  iconGreyURI?: string;
+  /** Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
+  startDate?: string;
+  /** Optional Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
+  endDate?: string;
+}
+
+/** Result of "Get All Available Achievements" */
+export interface AchievementPublicList extends Game, Validity {
+  achievements: Achievement[];
+}
+
+export interface PlayerAchievement {
+  /** Unique Achievement String */
+  name: string;
+  /** Is Achievement completed */
+  completed: boolean;
+  /** Completed Date ISO8601 YYYY-MM-DDTHH:mm:ss.sssZ */
+  completedDate?: Date;
+  /** If achievement has incremental progress */
+  completedRate?: {
+    /** Current Progress */
+    progress: number;
+    /** Total Progress */
+    total: number;
+  };
+}
+
+/** Result of "Get Completed Achievements" */
+export interface PlayerAchievements extends Validity, Player {
+  /** Total number of completed achievements for the game */
+  completed: number;
+  achievements: PlayerAchievement[];
+}
+
+// ----------------------------------------------------------------------------
+// Extension interface
+
+/**
+ * To implement the PRC-1 `/achievements` API, extend this class and export
+ * your child class as "AchievementService" from your API project. At minimum
+ * you must override {@link getGame} for the API to function, and
+ * {@link getAllAchievements} to return a non-empty list for it to be useful.
+ */
+export class AchievementService {
+  /** Override this to change the validity repsonse. The default likely suffices. */
+  async getValidity(): Promise<Partial<Validity>> {
+    // See AchievementsController.defaultValidity for default values.
+    // It's over there so it can access EngineService.
+    return {};
+  }
+
+  async getGame(): Promise<Game> {
+    throw new Error('Achievements not available for this game');
+  }
+
+  async getAllAchievements(): Promise<Achievement[]> {
+    return [];
+  }
+
+  async getPlayer(wallet: string): Promise<Player> {
+    return { wallet };
+  }
+
+  async getNftOwner(nft_address: string): Promise<string> {
+    throw new Error('No owner known for NFT address');
+  }
+
+  async getPlayerAchievements(wallet: string): Promise<PlayerAchievement[]> {
+    return [];
+  }
+
+  /** Set this to actually implement the achievements API for your game. */
+  static INSTANCE: AchievementService = new AchievementService();
+}

--- a/packages/node-sdk/paima-utils-backend/src/index.ts
+++ b/packages/node-sdk/paima-utils-backend/src/index.ts
@@ -3,6 +3,7 @@ import Crypto from 'crypto';
 export { parseSecurityYaml } from './security.js';
 export * from './cde-access.js';
 export type * from './types.js';
+export * from './achievements';
 
 export function hashTogether(data: string[]): string {
   return Crypto.createHash('sha256').update(data.join()).digest('base64');

--- a/packages/node-sdk/paima-utils-backend/src/index.ts
+++ b/packages/node-sdk/paima-utils-backend/src/index.ts
@@ -3,7 +3,7 @@ import Crypto from 'crypto';
 export { parseSecurityYaml } from './security.js';
 export * from './cde-access.js';
 export type * from './types.js';
-export * from './achievements';
+export * from './achievements.js';
 
 export function hashTogether(data: string[]): string {
   return Crypto.createHash('sha256').update(data.join()).digest('base64');


### PR DESCRIPTION
Proposed approach:
* `paima-rest` defines a PRC-1 compliant `/achievements` controller
* Its endpoints return an error for games which do not define or override it
* Games can fulfill the API by adding an `AchievementService` export to their `endpoints.cjs`
* Games can fully override the API by duplicating the relevant routes in their game, since game routes take priority over Paima routes (although this currently shows a duplication warning at engine boot time)

Benefits:
* TypeScript types for PRC-1 are defined in `utils-backend` for easy import by games
* Exposed API is verified to be PRC-1 compliant, unless overridden

Drawbacks:
* Adds an additional API contract (`AchievementService`) between Paima Engine and games, thus needing documentation and adding complexity to the module boundary, which is a dangerous place to add complexity
* Game can still fully override routes; no enforcement that types match

Possible alternatives:
* Let games define their own API controller, but whine if it doesn't comply with PRC-1
  * Benefit: simpler API contract
  * Benefit: can still verify PRC-1 spec compliance even if game supplies their own `/achievements` controller
  * Drawback: has to be implemented as some kind of lint plugin, or by checking the OpenAPI spec at engine boot time
* Just export PRC-1 types and let games figure it out
  * Benefit: simplest possible thing
  * Drawback: no static or dynamic enforcement that controller is PRC-1 compliant

Opening this PR since it's what I have right now, but I have to say I am rather tempted to drop all this and just do the simple thing.