### PR TITLE
add command to print the json schema of the config

### DIFF
--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -17,6 +17,7 @@ import {
 import { importOpenApiJson, importTsoaFunction } from './import.js';
 import type { Template } from './types.js';
 import RegisterRoutes, { EngineService } from '@paima/rest';
+import { BaseConfigWithoutDefaults } from '@paima/utils/src/config/loading.js';
 
 // Prompt user for input in the CLI
 export const userPrompt = (query: string): Promise<string> => {
@@ -62,6 +63,10 @@ export const argumentRouter = async (): Promise<void> => {
 
     case 'batcher':
       batcherCommand();
+      break;
+
+    case 'gen-config-json-schema':
+      genConfigSchemaCommand();
       break;
 
     default:
@@ -167,11 +172,16 @@ export const helpCommand = (): void => {
   doLog(`   help      Shows list of commands currently available.`);
   doLog(`   version   Shows the version of used paima-engine.`);
   doLog(`   batcher   Saves the bundled batcher project to your local filesystem.`);
+  doLog(`   gen-config-json-schema   Prints the JSON Schema for the engine configuration.`);
 };
 
 // Batcher command logic
 export const batcherCommand = (): void => {
   prepareBatcher();
+};
+
+export const configJsonSchema = (): void => {
+  genConfigSchemaCommand();
 };
 
 // Build middleware for specific .env file and launch webserver:
@@ -249,3 +259,7 @@ const pickGameTemplate = async (templateArg: string): Promise<Template> => {
   doLog(`Unknown selection, ${defaultTemplate} will be used.`);
   return defaultTemplate;
 };
+
+function genConfigSchemaCommand() {
+  doLog(JSON.stringify(BaseConfigWithoutDefaults));
+}

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -1,6 +1,6 @@
 import { FunnelFactory } from '@paima/funnel';
 import paimaRuntime, { registerDocs, registerValidationErrorHandler } from '@paima/runtime';
-import { ENV, GlobalConfig, doLog } from '@paima/utils';
+import { ENV, GlobalConfig, doLog, BaseConfigWithoutDefaults } from '@paima/utils';
 import { exec } from 'child_process';
 import { createInterface } from 'readline';
 import { gameSM } from '../sm.js';
@@ -17,7 +17,6 @@ import {
 import { importOpenApiJson, importTsoaFunction } from './import.js';
 import type { Template } from './types.js';
 import RegisterRoutes, { EngineService } from '@paima/rest';
-import { BaseConfigWithoutDefaults } from '@paima/utils/src/config/loading.js';
 
 // Prompt user for input in the CLI
 export const userPrompt = (query: string): Promise<string> => {

--- a/packages/paima-sdk/paima-utils/src/index.ts
+++ b/packages/paima-sdk/paima-utils/src/index.ts
@@ -15,6 +15,7 @@ import {
   defaultEvmMainNetworkName,
   defaultCardanoNetworkName,
   defaultMinaNetworkName,
+  BaseConfigWithoutDefaults,
 } from './config/loading.js';
 
 export * from './config.js';
@@ -41,6 +42,7 @@ export {
   defaultEvmMainNetworkName,
   defaultCardanoNetworkName,
   defaultMinaNetworkName,
+  BaseConfigWithoutDefaults,
 };
 
 export const DEFAULT_GAS_PRICE = '61000000000' as const;


### PR DESCRIPTION
I think it's nice to have some intellisense when editing the config, and we already have the json schemas for free with typebox.

I want this to use it with [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) like this:

```
./paima-engine-linux gen-config-json-schema | jq > config-json-schema.json
```

And then in `config.localhost.yml`

```
# yaml-language-server: $schema=config-json-schema.json

Network:
  type: evm-main
  chainUri: 'http://localhost:8545'
  chainId: 31337
  chainCurrencyName: 'ETH'
  chainCurrencySymbol: 'ETH'
  chainCurrencyDecimals: 18
  blockTime: 2
  paimaL2Contract: ...
```