### PR TITLE
setup for dynamic evm extensions

### DIFF
--- a/packages/engine/paima-funnel/src/cde/cardanoMintBurn.ts
+++ b/packages/engine/paima-funnel/src/cde/cardanoMintBurn.ts
@@ -73,7 +73,7 @@ function eventToCdeDatum(
   };
 
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.CardanoMintBurn,
     blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/cardanoPool.ts
+++ b/packages/engine/paima-funnel/src/cde/cardanoPool.ts
@@ -75,7 +75,7 @@ function eventToCdeDatum(
   };
 
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.CardanoPool,
     blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/cardanoProjectedNFT.ts
+++ b/packages/engine/paima-funnel/src/cde/cardanoProjectedNFT.ts
@@ -82,7 +82,7 @@ function eventToCdeDatum(
   };
 
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.CardanoProjectedNFT,
     blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/cardanoTransfer.ts
+++ b/packages/engine/paima-funnel/src/cde/cardanoTransfer.ts
@@ -83,7 +83,7 @@ function eventToCdeDatum(
   const outputs = computeOutputs(event.transaction.payload);
 
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.CardanoTransfer,
     blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/delayedAsset.ts
+++ b/packages/engine/paima-funnel/src/cde/delayedAsset.ts
@@ -76,7 +76,7 @@ function eventToCdeDatum(
   };
 
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.CardanoAssetUtxo,
     blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -30,6 +30,7 @@ export default async function getCdeDynamicPrimitive(
     },
     network,
     scheduledPrefix: extension.scheduledPrefix,
+    burnScheduledPrefix: extension.burnScheduledPrefix,
     cdeName: '',
   }));
 }

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -25,12 +25,12 @@ export default async function getCdeDynamicPrimitive(
     cdeDatumType: ChainDataExtensionDatumType.DynamicPrimitive,
     blockNumber: event.blockNumber,
     payload: {
-      contractAddress: event.returnValues[extension.fields.contractAddress],
-      type: extension.targetType,
+      contractAddress: event.returnValues[extension.dynamicFields.contractAddress],
+      type: extension.targetConfig.type,
     },
     network,
-    scheduledPrefix: extension.scheduledPrefix,
-    burnScheduledPrefix: extension.burnScheduledPrefix,
+    scheduledPrefix: extension.targetConfig.scheduledPrefix,
+    burnScheduledPrefix: extension.targetConfig.burnScheduledPrefix,
     cdeName: '',
   }));
 }

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -21,7 +21,7 @@ export default async function getCdeDynamicEvmPrimitive(
   );
 
   return events.map(event => ({
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.DynamicEvmPrimitive,
     blockNumber: event.blockNumber,
     payload: {
@@ -31,6 +31,5 @@ export default async function getCdeDynamicEvmPrimitive(
     network,
     scheduledPrefix: extension.targetConfig.scheduledPrefix,
     burnScheduledPrefix: extension.targetConfig.burnScheduledPrefix,
-    cdeName: '',
   }));
 }

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -1,5 +1,4 @@
-import { ChainDataExtensionDynamicPrimitive } from '@paima/sm';
-import type { ChainDataExtensionDatum } from '@paima/sm';
+import type { ChainDataExtensionDynamicPrimitive, ChainDataExtensionDatum } from '@paima/sm';
 import { ChainDataExtensionDatumType, DEFAULT_FUNNEL_TIMEOUT, timeout } from '@paima/utils';
 
 export default async function getCdeDynamicPrimitive(

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -25,9 +25,7 @@ export default async function getCdeDynamicPrimitive(
     cdeDatumType: ChainDataExtensionDatumType.DynamicPrimitive,
     blockNumber: event.blockNumber,
     payload: {
-      contractAddress:
-        // TODO: change the name of this (or make this more generic)
-        event.returnValues.value,
+      contractAddress: event.returnValues[extension.fields.contractAddress],
     },
     network,
     scheduledPrefix: extension.scheduledPrefix,

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -1,0 +1,37 @@
+import { ChainDataExtensionDynamicPrimitive } from '@paima/sm';
+import type { ChainDataExtensionDatum } from '@paima/sm';
+import { ChainDataExtensionDatumType, DEFAULT_FUNNEL_TIMEOUT, timeout } from '@paima/utils';
+
+export default async function getCdeDynamicPrimitive(
+  extension: ChainDataExtensionDynamicPrimitive,
+  fromBlock: number,
+  toBlock: number,
+  network: string
+): Promise<ChainDataExtensionDatum[]> {
+  // TODO: typechain is missing the proper type generation for getPastEvents
+  // https://github.com/dethcrypto/TypeChain/issues/767
+  const events = await timeout(
+    extension.contract.getPastEvents(extension.eventName, {
+      filter: {
+        topics: [extension.eventSignatureHash],
+      },
+      fromBlock: fromBlock,
+      toBlock: toBlock,
+    }),
+    DEFAULT_FUNNEL_TIMEOUT
+  );
+
+  return events.map(event => ({
+    cdeId: extension.cdeId,
+    cdeDatumType: ChainDataExtensionDatumType.DynamicPrimitive,
+    blockNumber: event.blockNumber,
+    payload: {
+      contractAddress:
+        // TODO: change the name of this (or make this more generic)
+        event.returnValues.value,
+    },
+    network,
+    scheduledPrefix: extension.scheduledPrefix,
+    cdeName: '',
+  }));
+}

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -1,8 +1,8 @@
-import type { ChainDataExtensionDynamicPrimitive, ChainDataExtensionDatum } from '@paima/sm';
+import type { ChainDataExtensionDynamicEvmPrimitive, ChainDataExtensionDatum } from '@paima/sm';
 import { ChainDataExtensionDatumType, DEFAULT_FUNNEL_TIMEOUT, timeout } from '@paima/utils';
 
-export default async function getCdeDynamicPrimitive(
-  extension: ChainDataExtensionDynamicPrimitive,
+export default async function getCdeDynamicEvmPrimitive(
+  extension: ChainDataExtensionDynamicEvmPrimitive,
   fromBlock: number,
   toBlock: number,
   network: string
@@ -22,7 +22,7 @@ export default async function getCdeDynamicPrimitive(
 
   return events.map(event => ({
     cdeId: extension.cdeId,
-    cdeDatumType: ChainDataExtensionDatumType.DynamicPrimitive,
+    cdeDatumType: ChainDataExtensionDatumType.DynamicEvmPrimitive,
     blockNumber: event.blockNumber,
     payload: {
       contractAddress: event.returnValues[extension.dynamicFields.contractAddress],

--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -26,6 +26,7 @@ export default async function getCdeDynamicPrimitive(
     blockNumber: event.blockNumber,
     payload: {
       contractAddress: event.returnValues[extension.fields.contractAddress],
+      type: extension.targetType,
     },
     network,
     scheduledPrefix: extension.scheduledPrefix,

--- a/packages/engine/paima-funnel/src/cde/erc1155.ts
+++ b/packages/engine/paima-funnel/src/cde/erc1155.ts
@@ -44,7 +44,7 @@ function transferSingleToDatum(
   network: string
 ): CdeErc1155TransferDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.Erc1155Transfer,
     blockNumber: event.blockNumber,
     payload: {
@@ -68,7 +68,7 @@ function transferBatchToDatum(
   network: string
 ): CdeErc1155TransferDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.Erc1155Transfer,
     blockNumber: event.blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/erc20.ts
+++ b/packages/engine/paima-funnel/src/cde/erc20.ts
@@ -22,16 +22,16 @@ export default async function getCdeData(
     }),
     DEFAULT_FUNNEL_TIMEOUT
   )) as unknown as ERC20Transfer[];
-  return events.map((e: ERC20Transfer) => transferToCdeDatum(e, extension.cdeId, network));
+  return events.map((e: ERC20Transfer) => transferToCdeDatum(e, extension.cdeName, network));
 }
 
 function transferToCdeDatum(
   event: ERC20Transfer,
-  cdeId: number,
+  cdeName: string,
   network: string
 ): CdeErc20TransferDatum {
   return {
-    cdeId: cdeId,
+    cdeName: cdeName,
     cdeDatumType: ChainDataExtensionDatumType.ERC20Transfer,
     blockNumber: event.blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/erc20Deposit.ts
+++ b/packages/engine/paima-funnel/src/cde/erc20Deposit.ts
@@ -32,7 +32,7 @@ function transferToCdeDatum(
   }
   return [
     {
-      cdeId: extension.cdeId,
+      cdeName: extension.cdeName,
       cdeDatumType: ChainDataExtensionDatumType.ERC20Deposit,
       blockNumber: event.blockNumber,
       payload: {

--- a/packages/engine/paima-funnel/src/cde/erc6551Registry.ts
+++ b/packages/engine/paima-funnel/src/cde/erc6551Registry.ts
@@ -72,7 +72,7 @@ function toDatum(
   network: string
 ): CdeErc6551RegistryDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.ERC6551Registry,
     blockNumber: event.blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/erc721.ts
+++ b/packages/engine/paima-funnel/src/cde/erc721.ts
@@ -17,7 +17,8 @@ export default async function getCdeData(
   // https://github.com/dethcrypto/TypeChain/issues/767
   const events = (await timeout(
     extension.contract.getPastEvents('Transfer', {
-      fromBlock: extension.dynamic && extension.startBlockHeight == fromBlock ? fromBlock - 1 : fromBlock,
+      fromBlock:
+        extension.dynamic && extension.startBlockHeight == fromBlock ? fromBlock - 1 : fromBlock,
       toBlock: toBlock,
     }),
     DEFAULT_FUNNEL_TIMEOUT
@@ -29,7 +30,7 @@ function transferToTransferDatum(
   event: Transfer,
   extension: ChainDataExtensionErc721,
   network: string,
-  fromBlock: number,
+  fromBlock: number
 ): CdeErc721TransferDatum {
   return {
     cdeId: extension.cdeId,
@@ -69,7 +70,7 @@ function transferToCdeData(
   event: Transfer,
   extension: ChainDataExtensionErc721,
   network: string,
-  fromBlock: number,
+  fromBlock: number
 ): ChainDataExtensionDatum[] {
   const transferDatum = transferToTransferDatum(event, extension, network, fromBlock);
   const fromAddr = event.returnValues.from;

--- a/packages/engine/paima-funnel/src/cde/erc721.ts
+++ b/packages/engine/paima-funnel/src/cde/erc721.ts
@@ -17,23 +17,24 @@ export default async function getCdeData(
   // https://github.com/dethcrypto/TypeChain/issues/767
   const events = (await timeout(
     extension.contract.getPastEvents('Transfer', {
-      fromBlock: fromBlock,
+      fromBlock: extension.dynamic && extension.startBlockHeight == fromBlock ? fromBlock - 1 : fromBlock,
       toBlock: toBlock,
     }),
     DEFAULT_FUNNEL_TIMEOUT
   )) as unknown as Transfer[];
-  return events.map((e: Transfer) => transferToCdeData(e, extension, network)).flat();
+  return events.map((e: Transfer) => transferToCdeData(e, extension, network, fromBlock)).flat();
 }
 
 function transferToTransferDatum(
   event: Transfer,
   extension: ChainDataExtensionErc721,
-  network: string
+  network: string,
+  fromBlock: number,
 ): CdeErc721TransferDatum {
   return {
     cdeId: extension.cdeId,
     cdeDatumType: ChainDataExtensionDatumType.ERC721Transfer,
-    blockNumber: event.blockNumber,
+    blockNumber: event.blockNumber === fromBlock - 1 ? fromBlock : event.blockNumber,
     payload: {
       from: event.returnValues.from.toLowerCase(),
       to: event.returnValues.to.toLowerCase(),
@@ -47,12 +48,13 @@ function transferToTransferDatum(
 function transferToMintDatum(
   event: Transfer,
   extension: ChainDataExtensionErc721,
-  network: string
+  network: string,
+  fromBlock: number
 ): CdeErc721MintDatum {
   return {
     cdeId: extension.cdeId,
     cdeDatumType: ChainDataExtensionDatumType.ERC721Mint,
-    blockNumber: event.blockNumber,
+    blockNumber: event.blockNumber === fromBlock - 1 ? fromBlock : event.blockNumber,
     payload: {
       tokenId: event.returnValues.tokenId,
       mintData: '',
@@ -66,12 +68,13 @@ function transferToMintDatum(
 function transferToCdeData(
   event: Transfer,
   extension: ChainDataExtensionErc721,
-  network: string
+  network: string,
+  fromBlock: number,
 ): ChainDataExtensionDatum[] {
-  const transferDatum = transferToTransferDatum(event, extension, network);
+  const transferDatum = transferToTransferDatum(event, extension, network, fromBlock);
   const fromAddr = event.returnValues.from;
   if (fromAddr.match(/^0x0+$/g)) {
-    const mintDatum = transferToMintDatum(event, extension, network);
+    const mintDatum = transferToMintDatum(event, extension, network, fromBlock);
     return [mintDatum, transferDatum];
   } else {
     return [transferDatum];

--- a/packages/engine/paima-funnel/src/cde/erc721.ts
+++ b/packages/engine/paima-funnel/src/cde/erc721.ts
@@ -31,7 +31,7 @@ function transferToTransferDatum(
   network: string
 ): CdeErc721TransferDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.ERC721Transfer,
     blockNumber: event.blockNumber,
     payload: {
@@ -50,7 +50,7 @@ function transferToMintDatum(
   network: string
 ): CdeErc721MintDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.ERC721Mint,
     blockNumber: event.blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/generic.ts
+++ b/packages/engine/paima-funnel/src/cde/generic.ts
@@ -33,7 +33,7 @@ function eventToCdeDatum(
   network: string
 ): CdeGenericDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.Generic,
     blockNumber: event.blockNumber,
     scheduledPrefix: extension.scheduledPrefix,

--- a/packages/engine/paima-funnel/src/cde/minaGeneric.ts
+++ b/packages/engine/paima-funnel/src/cde/minaGeneric.ts
@@ -96,7 +96,7 @@ export async function getCdeData(
 
     const events = grouped.flatMap(perBlock =>
       perBlock.eventsData.map(txEvent => ({
-        cdeId: extension.cdeId,
+        cdeName: extension.cdeName,
         cdeDatumType,
         blockNumber: getBlockNumber(Number.parseInt(perBlock.blockInfo.timestamp, 10)),
         payload: txEvent,

--- a/packages/engine/paima-funnel/src/cde/paimaErc721.ts
+++ b/packages/engine/paima-funnel/src/cde/paimaErc721.ts
@@ -69,7 +69,7 @@ function transferToTransferDatum(
   network: string
 ): CdeErc721TransferDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.ERC721Transfer,
     blockNumber: event.blockNumber,
     payload: {
@@ -87,7 +87,7 @@ function mintedToMintDatum(
   network: string
 ): CdeErc721MintDatum {
   return {
-    cdeId: extension.cdeId,
+    cdeName: extension.cdeName,
     cdeDatumType: ChainDataExtensionDatumType.ERC721Mint,
     blockNumber: event.blockNumber,
     payload: {

--- a/packages/engine/paima-funnel/src/cde/reading.ts
+++ b/packages/engine/paima-funnel/src/cde/reading.ts
@@ -10,6 +10,7 @@ import getCdeErc721Data from './erc721.js';
 import getCdePaimaErc721Data from './paimaErc721.js';
 import getCdeErc6551RegistryData from './erc6551Registry.js';
 import getCdeErc1155Data from './erc1155.js';
+import getCdeDynamicPrimitive from './dynamic.js';
 import assertNever from 'assert-never';
 
 export async function getUngroupedCdeData(
@@ -58,6 +59,8 @@ async function getSpecificCdeData(
       return await getCdeErc1155Data(extension, fromBlock, toBlock, network);
     case ChainDataExtensionType.ERC6551Registry:
       return await getCdeErc6551RegistryData(extension, fromBlock, toBlock, network);
+    case ChainDataExtensionType.DynamicPrimitive:
+      return await getCdeDynamicPrimitive(extension, fromBlock, toBlock, network);
     // these are not used by the block funnel
     case ChainDataExtensionType.CardanoPool:
     case ChainDataExtensionType.CardanoProjectedNFT:

--- a/packages/engine/paima-funnel/src/cde/reading.ts
+++ b/packages/engine/paima-funnel/src/cde/reading.ts
@@ -10,7 +10,7 @@ import getCdeErc721Data from './erc721.js';
 import getCdePaimaErc721Data from './paimaErc721.js';
 import getCdeErc6551RegistryData from './erc6551Registry.js';
 import getCdeErc1155Data from './erc1155.js';
-import getCdeDynamicPrimitive from './dynamic.js';
+import getCdeDynamicEvmPrimitive from './dynamic.js';
 import assertNever from 'assert-never';
 
 export async function getUngroupedCdeData(
@@ -59,8 +59,8 @@ async function getSpecificCdeData(
       return await getCdeErc1155Data(extension, fromBlock, toBlock, network);
     case ChainDataExtensionType.ERC6551Registry:
       return await getCdeErc6551RegistryData(extension, fromBlock, toBlock, network);
-    case ChainDataExtensionType.DynamicPrimitive:
-      return await getCdeDynamicPrimitive(extension, fromBlock, toBlock, network);
+    case ChainDataExtensionType.DynamicEvmPrimitive:
+      return await getCdeDynamicEvmPrimitive(extension, fromBlock, toBlock, network);
     // these are not used by the block funnel
     case ChainDataExtensionType.CardanoPool:
     case ChainDataExtensionType.CardanoProjectedNFT:

--- a/packages/engine/paima-funnel/src/funnels/BaseFunnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/BaseFunnel.ts
@@ -8,7 +8,7 @@ import type { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
 export type FunnelSharedData = {
   readonly web3: Web3;
   readonly paimaL2Contract: PaimaL2Contract;
-  readonly extensions: ChainDataExtension[];
+  extensions: ChainDataExtension[];
   readonly extensionsValid: boolean;
   readonly cacheManager: FunnelCacheManager;
 };

--- a/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
+++ b/packages/engine/paima-funnel/src/funnels/FunnelCache.ts
@@ -82,7 +82,7 @@ export type CarpFunnelCacheEntryState = {
   epoch: number | undefined;
   cursors:
     | {
-        [cdeId: number]: { cursor: string; finished: boolean };
+        [cdeName: string]: { cursor: string; finished: boolean };
       }
     | undefined;
 };
@@ -112,13 +112,13 @@ export class CarpFunnelCacheEntry implements FunnelCacheEntry {
     }
   }
 
-  public updateCursor(cdeId: number, presyncCursor: { cursor: string; finished: boolean }): void {
+  public updateCursor(cdeName: string, presyncCursor: { cursor: string; finished: boolean }): void {
     if (this.state) {
       if (!this.state.cursors) {
         this.state.cursors = {};
       }
 
-      this.state.cursors[cdeId] = presyncCursor;
+      this.state.cursors[cdeName] = presyncCursor;
     }
   }
 
@@ -187,7 +187,7 @@ export type MinaFunnelCacheEntryState = {
   pg: pg.Client;
   cursors:
     | {
-        [cdeId: number]: { cursor: string; finished: boolean };
+        [cdeName: string]: { cursor: string; finished: boolean };
       }
     | undefined;
 };
@@ -211,13 +211,13 @@ export class MinaFunnelCacheEntry implements FunnelCacheEntry {
     }
   }
 
-  public updateCursor(cdeId: number, presyncCursor: { cursor: string; finished: boolean }): void {
+  public updateCursor(cdeName: string, presyncCursor: { cursor: string; finished: boolean }): void {
     if (this.state) {
       if (!this.state.cursors) {
         this.state.cursors = {};
       }
 
-      this.state.cursors[cdeId] = presyncCursor;
+      this.state.cursors[cdeName] = presyncCursor;
     }
   }
 

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -1,5 +1,5 @@
 import type { EvmConfig } from '@paima/utils';
-import { ENV, GlobalConfig, doLog, timeout } from '@paima/utils';
+import { ChainDataExtensionType, ENV, GlobalConfig, doLog, timeout } from '@paima/utils';
 import type { ChainFunnel, ReadPresyncDataFrom } from '@paima/runtime';
 import type { ChainData, PresyncChainData } from '@paima/sm';
 import { getBaseChainDataMulti, getBaseChainDataSingle } from '../../reading.js';
@@ -10,7 +10,6 @@ import type { FunnelSharedData } from '../BaseFunnel.js';
 import { RpcCacheEntry, RpcRequestState } from '../FunnelCache.js';
 import type { PoolClient } from 'pg';
 import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
-import { filterResultsAfterDynamicPrimitive } from '../../index.js';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
 
@@ -47,7 +46,6 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       doLog(`Block funnel ${this.config.chainId}: #${toBlock}`);
       return await this.internalReadDataSingle(fromBlock);
     } else {
-      doLog(`Block funnel ${this.config.chainId}: #${fromBlock}-${toBlock}`);
       return await this.internalReadDataMulti(fromBlock, toBlock);
     }
   }
@@ -122,6 +120,26 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       return [];
     }
     try {
+      const dynamicPrimitives = await getUngroupedCdeData(
+        this.sharedData.web3,
+        this.sharedData.extensions.filter(extension => extension.network === this.chainName && extension.cdeType === ChainDataExtensionType.DynamicPrimitive),
+        fromBlock,
+        toBlock,
+        this.chainName
+      );
+
+      const firstDynamicBlock = dynamicPrimitives
+        .filter(
+          extData =>
+            extData.length > 0
+        )
+        // we just get the first one, since these are sorted.
+        .reduce((min, extData) => Math.min(min, extData[0].blockNumber), toBlock + 1);
+
+      toBlock = Math.min(toBlock, firstDynamicBlock);
+
+      doLog(`Block funnel ${this.config.chainId}: #${fromBlock}-${toBlock}`);
+
       const [baseChainData, ungroupedCdeData] = await Promise.all([
         getBaseChainDataMulti(
           this.sharedData.web3,
@@ -133,21 +151,18 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
         ),
         getUngroupedCdeData(
           this.sharedData.web3,
-          this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+          this.sharedData.extensions.filter(extension => extension.network === this.chainName && extension.cdeType !== ChainDataExtensionType.DynamicPrimitive),
           fromBlock,
           toBlock,
           this.chainName
         ),
       ]);
 
-      let filteredBaseChainData = filterResultsAfterDynamicPrimitive(
-        ungroupedCdeData,
-        baseChainData,
-        toBlock
-      );
+      ungroupedCdeData.push(...dynamicPrimitives);
+
 
       const cdeData = groupCdeData(this.chainName, fromBlock, toBlock, ungroupedCdeData);
-      return composeChainData(filteredBaseChainData, cdeData);
+      return composeChainData(baseChainData, cdeData);
     } catch (err) {
       doLog(`[funnel] at ${fromBlock}-${toBlock} caught ${err}`);
       throw err;

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -1,5 +1,5 @@
 import type { EvmConfig } from '@paima/utils';
-import { ENV, GlobalConfig, doLog, timeout } from '@paima/utils';
+import { ChainDataExtensionDatumType, ENV, GlobalConfig, doLog, timeout } from '@paima/utils';
 import type { ChainFunnel, ReadPresyncDataFrom } from '@paima/runtime';
 import type { ChainData, PresyncChainData } from '@paima/sm';
 import { getBaseChainDataMulti, getBaseChainDataSingle } from '../../reading.js';
@@ -139,8 +139,38 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
           this.chainName
         ),
       ]);
+
+      // If we have a dynamic primitive, then technically we may have missed an
+      // event in the range.
+      //
+      // Here we invalidate everything after that point, so that in the next
+      // funnel call we start from that point.
+      //
+      // TODO: there are two possible ways of optimizing this:
+      //
+      //  1. Cache this information for the next request.
+      //  2. Build the dynamic contract here and get the extra data for the new extensions.
+      //
+      // First option is probably much easier to implement. Second option
+      // has the issue that we can't update the shared data here, so it probably would
+      // inovlve duplicating the logic.
+      const firstDynamicBlock = ungroupedCdeData
+        .filter(
+          extData =>
+            extData.length > 0 &&
+            extData[0].cdeDatumType === ChainDataExtensionDatumType.DynamicPrimitive
+        )
+        // we just get the first one, since these are sorted.
+        .reduce((min, extData) => Math.min(min, extData[0].blockNumber), toBlock + 1);
+
+      let filteredBaseChainData = baseChainData;
+
+      if (firstDynamicBlock <= toBlock) {
+        filteredBaseChainData = baseChainData.filter(ext => ext.blockNumber <= firstDynamicBlock);
+      }
+
       const cdeData = groupCdeData(this.chainName, fromBlock, toBlock, ungroupedCdeData);
-      return composeChainData(baseChainData, cdeData);
+      return composeChainData(filteredBaseChainData, cdeData);
     } catch (err) {
       doLog(`[funnel] at ${fromBlock}-${toBlock} caught ${err}`);
       throw err;

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -122,17 +122,18 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
     try {
       const dynamicPrimitives = await getUngroupedCdeData(
         this.sharedData.web3,
-        this.sharedData.extensions.filter(extension => extension.network === this.chainName && extension.cdeType === ChainDataExtensionType.DynamicPrimitive),
+        this.sharedData.extensions.filter(
+          extension =>
+            extension.network === this.chainName &&
+            extension.cdeType === ChainDataExtensionType.DynamicPrimitive
+        ),
         fromBlock,
         toBlock,
         this.chainName
       );
 
       const firstDynamicBlock = dynamicPrimitives
-        .filter(
-          extData =>
-            extData.length > 0
-        )
+        .filter(extData => extData.length > 0)
         // we just get the first one, since these are sorted.
         .reduce((min, extData) => Math.min(min, extData[0].blockNumber), toBlock + 1);
 
@@ -151,7 +152,11 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
         ),
         getUngroupedCdeData(
           this.sharedData.web3,
-          this.sharedData.extensions.filter(extension => extension.network === this.chainName && extension.cdeType !== ChainDataExtensionType.DynamicPrimitive),
+          this.sharedData.extensions.filter(
+            extension =>
+              extension.network === this.chainName &&
+              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+          ),
           fromBlock,
           toBlock,
           this.chainName
@@ -159,7 +164,6 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       ]);
 
       ungroupedCdeData.push(...dynamicPrimitives);
-
 
       const cdeData = groupCdeData(this.chainName, fromBlock, toBlock, ungroupedCdeData);
       return composeChainData(baseChainData, cdeData);

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -1,7 +1,15 @@
 import type { EvmConfig } from '@paima/utils';
-import { ChainDataExtensionType, ENV, GlobalConfig, doLog, timeout } from '@paima/utils';
+import {
+  ChainDataExtensionType,
+  ENV,
+  GlobalConfig,
+  doLog,
+  getErc721Contract,
+  timeout,
+} from '@paima/utils';
 import type { ChainFunnel, ReadPresyncDataFrom } from '@paima/runtime';
-import type { ChainData, PresyncChainData } from '@paima/sm';
+import type { CdeDynamicPrimitiveDatum, ChainDataExtensionDatum } from '@paima/sm';
+import { CdeEntryTypeName, type ChainData, type PresyncChainData } from '@paima/sm';
 import { getBaseChainDataMulti, getBaseChainDataSingle } from '../../reading.js';
 import { getUngroupedCdeData } from '../../cde/reading.js';
 import { composeChainData, groupCdeData } from '../../utils.js';
@@ -46,6 +54,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       doLog(`Block funnel ${this.config.chainId}: #${toBlock}`);
       return await this.internalReadDataSingle(fromBlock);
     } else {
+      doLog(`Block funnel ${this.config.chainId}: #${fromBlock}-${toBlock}`);
       return await this.internalReadDataMulti(fromBlock, toBlock);
     }
   }
@@ -83,6 +92,8 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       return [];
     }
     try {
+      const dynamicPrimitives = await this.fetchDynamicPrimitives(blockNumber, blockNumber);
+
       const [baseChainData, cdeData] = await Promise.all([
         getBaseChainDataSingle(
           this.sharedData.web3,
@@ -93,7 +104,12 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
         ),
         getUngroupedCdeData(
           this.sharedData.web3,
-          this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+          this.sharedData.extensions.filter(
+            extension =>
+              extension.network === this.chainName &&
+              // these are fetched above
+              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+          ),
           blockNumber,
           blockNumber,
           this.chainName
@@ -103,7 +119,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       return [
         {
           ...baseChainData,
-          extensionDatums: cdeData.flat(),
+          extensionDatums: cdeData.concat(dynamicPrimitives).flat(),
         },
       ];
     } catch (err) {
@@ -120,26 +136,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       return [];
     }
     try {
-      const dynamicPrimitives = await getUngroupedCdeData(
-        this.sharedData.web3,
-        this.sharedData.extensions.filter(
-          extension =>
-            extension.network === this.chainName &&
-            extension.cdeType === ChainDataExtensionType.DynamicPrimitive
-        ),
-        fromBlock,
-        toBlock,
-        this.chainName
-      );
-
-      const firstDynamicBlock = dynamicPrimitives
-        .filter(extData => extData.length > 0)
-        // we just get the first one, since these are sorted.
-        .reduce((min, extData) => Math.min(min, extData[0].blockNumber), toBlock + 1);
-
-      toBlock = Math.min(toBlock, firstDynamicBlock);
-
-      doLog(`Block funnel ${this.config.chainId}: #${fromBlock}-${toBlock}`);
+      const dynamicPrimitives = await this.fetchDynamicPrimitives(fromBlock, toBlock);
 
       const [baseChainData, ungroupedCdeData] = await Promise.all([
         getBaseChainDataMulti(
@@ -155,6 +152,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
           this.sharedData.extensions.filter(
             extension =>
               extension.network === this.chainName &&
+              // these are fetched above
               extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
           ),
           fromBlock,
@@ -196,13 +194,18 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
         return {};
       }
 
-      const ungroupedCdeData = await getUngroupedCdeData(
-        this.sharedData.web3,
-        this.sharedData.extensions.filter(extension => extension.network === this.chainName),
-        fromBlock,
-        toBlock,
-        this.chainName
-      );
+      const dynamicDatums = await this.fetchDynamicPrimitives(fromBlock, toBlock);
+
+      const ungroupedCdeData = (
+        await getUngroupedCdeData(
+          this.sharedData.web3,
+          this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+          fromBlock,
+          toBlock,
+          this.chainName
+        )
+      ).concat(dynamicDatums);
+
       return {
         [this.chainName]: groupCdeData(this.chainName, fromBlock, toBlock, ungroupedCdeData),
       };
@@ -210,6 +213,47 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       doLog(`[paima-funnel::readPresyncData] Exception occurred while reading blocks: ${err}`);
       throw err;
     }
+  }
+
+  private async fetchDynamicPrimitives(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<ChainDataExtensionDatum[][]> {
+    const dynamicPrimitives = await getUngroupedCdeData(
+      this.sharedData.web3,
+      this.sharedData.extensions.filter(
+        extension =>
+          extension.network === this.chainName &&
+          extension.cdeType === ChainDataExtensionType.DynamicPrimitive
+      ),
+      fromBlock,
+      toBlock,
+      this.chainName
+    );
+
+    for (const exts of dynamicPrimitives) {
+      for (const _ext of exts) {
+        const ext: CdeDynamicPrimitiveDatum = _ext as CdeDynamicPrimitiveDatum;
+        // this would propagate the change to further funnels in the pipeline,
+        // which is needed to set the proper cdeId.
+        this.sharedData.extensions.push({
+          name: '',
+          startBlockHeight: ext.blockNumber,
+          type: CdeEntryTypeName.ERC721,
+          contractAddress: ext.payload.contractAddress,
+          scheduledPrefix: ext.scheduledPrefix,
+          burnScheduledPrefix: ext.scheduledPrefix,
+          cdeId: this.sharedData.extensions.length,
+          network: this.chainName,
+          // not relevant
+          hash: 0,
+          cdeType: ChainDataExtensionType.ERC721,
+          contract: getErc721Contract(ext.payload.contractAddress, this.sharedData.web3),
+        });
+      }
+    }
+
+    return dynamicPrimitives;
   }
 
   public static async recoverState(

--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -3,7 +3,7 @@ import { ChainDataExtensionType, ENV, GlobalConfig, doLog, timeout } from '@paim
 import type { ChainFunnel, ReadPresyncDataFrom } from '@paima/runtime';
 import { type ChainData, type PresyncChainData } from '@paima/sm';
 import {
-  fetchDynamicPrimitives,
+  fetchDynamicEvmPrimitives,
   getBaseChainDataMulti,
   getBaseChainDataSingle,
 } from '../../reading.js';
@@ -88,7 +88,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       return [];
     }
     try {
-      const dynamicDatums = await fetchDynamicPrimitives(
+      const dynamicDatums = await fetchDynamicEvmPrimitives(
         blockNumber,
         blockNumber,
         this.sharedData.web3,
@@ -110,7 +110,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
             extension =>
               extension.network === this.chainName &&
               // these are fetched above
-              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+              extension.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive
           ),
           blockNumber,
           blockNumber,
@@ -138,7 +138,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       return [];
     }
     try {
-      const dynamicDatums = await fetchDynamicPrimitives(
+      const dynamicDatums = await fetchDynamicEvmPrimitives(
         fromBlock,
         toBlock,
         this.sharedData.web3,
@@ -161,7 +161,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
             extension =>
               extension.network === this.chainName &&
               // these are fetched above
-              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+              extension.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive
           ),
           fromBlock,
           toBlock,
@@ -202,7 +202,7 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
         return {};
       }
 
-      const dynamicDatums = await fetchDynamicPrimitives(
+      const dynamicDatums = await fetchDynamicEvmPrimitives(
         fromBlock,
         toBlock,
         this.sharedData.web3,

--- a/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/carp/funnel.ts
@@ -224,13 +224,13 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
     }
 
     const cache = this.cache;
-    const mapCursorPaginatedData = (cdeId: number) => (datums: any) => {
+    const mapCursorPaginatedData = (cdeName: string) => (datums: any) => {
       // we are providing the entire indexed range, so if carp
       // returns nothing we know the presync is finished for this
       // CDE.
       const finished = datums.length === 0 || datums.length < this.config.paginationLimit;
 
-      cache.updateCursor(cdeId, {
+      cache.updateCursor(cdeName, {
         cursor: datums[datums.length - 1] ? datums[datums.length - 1].paginationCursor.cursor : '',
         finished,
       });
@@ -251,7 +251,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
             }
 
             if (cursors) {
-              const cursor = cursors[extension.cdeId];
+              const cursor = cursors[extension.cdeName];
 
               if (!cursor) {
                 return true;
@@ -268,7 +268,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                 const cursors = this.cache.getState().cursors;
                 const startingSlot = this.cache.getState().startingSlot - 1;
 
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = getCdePoolData(
                   this.carpUrl,
@@ -282,10 +282,10 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                   cursor ? (JSON.parse(cursor.cursor) as BlockTxPair) : undefined,
                   this.config.paginationLimit,
                   this.chainName
-                ).then(mapCursorPaginatedData(extension.cdeId));
+                ).then(mapCursorPaginatedData(extension.cdeName));
 
                 return data.then(data => ({
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 }));
@@ -294,7 +294,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                 const cursors = this.cache.getState().cursors;
                 const startingSlot = this.cache.getState().startingSlot - 1;
 
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = getCdeProjectedNFTData(
                   this.carpUrl,
@@ -308,10 +308,10 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                   cursor ? (JSON.parse(cursor.cursor) as BlockTxPair) : undefined,
                   this.config.paginationLimit,
                   this.chainName
-                ).then(mapCursorPaginatedData(extension.cdeId));
+                ).then(mapCursorPaginatedData(extension.cdeName));
 
                 return data.then(data => ({
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 }));
@@ -320,7 +320,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                 const cursors = this.cache.getState().cursors;
                 const startingSlot = this.cache.getState().startingSlot - 1;
 
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = getCdeDelayedAsset(
                   this.carpUrl,
@@ -333,10 +333,10 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                   cursor ? (JSON.parse(cursor.cursor) as BlockTxPair) : undefined,
                   this.config.paginationLimit,
                   this.chainName
-                ).then(mapCursorPaginatedData(extension.cdeId));
+                ).then(mapCursorPaginatedData(extension.cdeName));
 
                 return data.then(data => ({
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 }));
@@ -345,7 +345,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                 const cursors = this.cache.getState().cursors;
                 const startingSlot = this.cache.getState().startingSlot - 1;
 
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = getCdeTransferData(
                   this.carpUrl,
@@ -358,10 +358,10 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                   cursor ? (JSON.parse(cursor.cursor) as BlockTxPair) : undefined,
                   this.config.paginationLimit,
                   this.chainName
-                ).then(mapCursorPaginatedData(extension.cdeId));
+                ).then(mapCursorPaginatedData(extension.cdeName));
 
                 return data.then(data => ({
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 }));
@@ -370,7 +370,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                 const cursors = this.cache.getState().cursors;
                 const startingSlot = this.cache.getState().startingSlot - 1;
 
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = getCdeMintBurnData(
                   this.carpUrl,
@@ -383,10 +383,10 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
                   cursor ? (JSON.parse(cursor.cursor) as BlockTxPair) : undefined,
                   this.config.paginationLimit,
                   this.chainName
-                ).then(mapCursorPaginatedData(extension.cdeId));
+                ).then(mapCursorPaginatedData(extension.cdeName));
 
                 return data.then(data => ({
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 }));
@@ -408,7 +408,7 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
           network: this.chainName,
           networkType: ConfigNetworkType.CARDANO,
           carpCursor: {
-            cdeId: event.cdeId,
+            cdeName: event.cdeName,
             cursor: event.paginationCursor.cursor,
             finished: event.paginationCursor.finished,
           },
@@ -460,16 +460,16 @@ export class CarpFunnel extends BaseFunnel implements ChainFunnel {
 
       const extensions = sharedData.extensions
         .filter(extensions => extensions.network === chainName)
-        .map(extension => extension.cdeId)
-        .reduce((set, cdeId) => {
-          set.add(cdeId);
+        .map(extension => extension.cdeName)
+        .reduce((set, cdeName) => {
+          set.add(cdeName);
           return set;
         }, new Set());
 
       cursors
-        .filter(cursor => extensions.has(cursor.cde_id))
+        .filter(cursor => extensions.has(cursor.cde_name))
         .forEach(cursor => {
-          newEntry.updateCursor(cursor.cde_id, {
+          newEntry.updateCursor(cursor.cde_name, {
             cursor: cursor.cursor,
             finished: cursor.finished,
           });

--- a/packages/engine/paima-funnel/src/funnels/emulated/utils.ts
+++ b/packages/engine/paima-funnel/src/funnels/emulated/utils.ts
@@ -54,8 +54,8 @@ export function emulateCde(
     .flat()
     .sort((a, b) => {
       const bhDiff = a.blockNumber - b.blockNumber;
-      const cdeIdDiff = a.cdeId - b.cdeId;
-      return bhDiff ? bhDiff : cdeIdDiff;
+      const cdeNameDiff = a.cdeName.localeCompare(b.cdeName);
+      return bhDiff ? bhDiff : cdeNameDiff;
     })
     .map(cdeDatum => ({ ...cdeDatum, blockNumber }));
 }

--- a/packages/engine/paima-funnel/src/funnels/mina/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/mina/funnel.ts
@@ -216,10 +216,10 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
       return data;
     }
 
-    const mapCursorPaginatedData = (cdeId: number) => (datums: any) => {
+    const mapCursorPaginatedData = (cdeName: string) => (datums: any) => {
       const finished = datums.length === 0 || datums.length < this.config.paginationLimit;
 
-      this.cache.updateCursor(cdeId, {
+      this.cache.updateCursor(cdeName, {
         cursor: datums[datums.length - 1] ? datums[datums.length - 1].paginationCursor.cursor : '',
         finished,
       });
@@ -244,7 +244,7 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
               }
 
               if (cursors) {
-                const cursor = cursors[extension.cdeId];
+                const cursor = cursors[extension.cdeName];
 
                 if (!cursor) {
                   return true;
@@ -257,7 +257,7 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
             })
             .map(async extension => {
               if (extension.cdeType === ChainDataExtensionType.MinaEventGeneric) {
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = await getEventCdeData({
                   pg: cache.pg,
@@ -274,15 +274,15 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
                   isPresync: true,
                   cursor: cursor?.cursor,
                   limit: this.config.paginationLimit,
-                }).then(mapCursorPaginatedData(extension.cdeId));
+                }).then(mapCursorPaginatedData(extension.cdeName));
 
                 return {
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 };
               } else if (extension.cdeType === ChainDataExtensionType.MinaActionGeneric) {
-                const cursor = cursors && cursors[extension.cdeId];
+                const cursor = cursors && cursors[extension.cdeName];
 
                 const data = await getActionCdeData({
                   pg: cache.pg,
@@ -295,10 +295,10 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
                   isPresync: true,
                   cursor: cursor?.cursor,
                   limit: this.config.paginationLimit,
-                }).then(mapCursorPaginatedData(extension.cdeId));
+                }).then(mapCursorPaginatedData(extension.cdeName));
 
                 return {
-                  cdeId: extension.cdeId,
+                  cdeName: extension.cdeName,
                   cdeType: extension.cdeType,
                   data,
                 };
@@ -318,7 +318,7 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
             network: this.chainName,
             networkType: ConfigNetworkType.MINA,
             minaCursor: {
-              cdeId: event.cdeId,
+              cdeName: event.cdeName,
               cursor: event.paginationCursor.cursor,
               finished: event.paginationCursor.finished,
             },
@@ -365,16 +365,16 @@ export class MinaFunnel extends BaseFunnel implements ChainFunnel {
 
       const extensions = sharedData.extensions
         .filter(extensions => extensions.network === chainName)
-        .map(extension => extension.cdeId)
-        .reduce((set, cdeId) => {
-          set.add(cdeId);
+        .map(extension => extension.cdeName)
+        .reduce((set, cdeName) => {
+          set.add(cdeName);
           return set;
         }, new Set());
 
       cursors
-        .filter(cursor => extensions.has(cursor.cde_id))
+        .filter(cursor => extensions.has(cursor.cde_name))
         .forEach(cursor => {
-          newEntry.updateCursor(cursor.cde_id, {
+          newEntry.updateCursor(cursor.cde_name, {
             cursor: cursor.cursor,
             finished: cursor.finished,
           });

--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -7,19 +7,9 @@ import {
   delay,
   InternalEventType,
   ChainDataExtensionType,
-  getErc721Contract,
 } from '@paima/utils';
 import type { ChainFunnel, ReadPresyncDataFrom } from '@paima/runtime';
-import {
-  CdeDynamicPrimitiveDatum,
-  CdeEntryTypeName,
-  ChainDataExtensionDatum,
-  ChainDataExtensionDynamicPrimitive,
-  type ChainData,
-  type ChainDataExtension,
-  type EvmPresyncChainData,
-  type PresyncChainData,
-} from '@paima/sm';
+import { type ChainData, type EvmPresyncChainData, type PresyncChainData } from '@paima/sm';
 import { getUngroupedCdeData } from '../../cde/reading.js';
 import { composeChainData, groupCdeData } from '../../utils.js';
 import { BaseFunnel } from '../BaseFunnel.js';

--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -12,6 +12,7 @@ import type { PoolClient } from 'pg';
 import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
 import { getMultipleBlockData } from '../../reading.js';
 import { getLatestProcessedCdeBlockheight } from '@paima/db';
+import { filterResultsAfterDynamicPrimitive } from '../../index.js';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
 
@@ -395,7 +396,13 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
         cdeData = groupCdeData(this.chainName, mappedFrom, mappedTo, ungroupedCdeData);
       }
 
-      return composeChainData(baseChainData, cdeData);
+      let filteredBaseChainData = filterResultsAfterDynamicPrimitive(
+        ungroupedCdeData,
+        baseChainData,
+        toBlock
+      );
+
+      return composeChainData(filteredBaseChainData, cdeData);
     } catch (err) {
       doLog(`[funnel] at ${fromBlock}-${toBlock} caught ${err}`);
       throw err;

--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -18,7 +18,7 @@ import type { EvmFunnelCacheEntryState } from '../FunnelCache.js';
 import { EvmFunnelCacheEntry, RpcCacheEntry, RpcRequestState } from '../FunnelCache.js';
 import type { PoolClient } from 'pg';
 import { FUNNEL_PRESYNC_FINISHED } from '@paima/utils';
-import { fetchDynamicPrimitives, getMultipleBlockData } from '../../reading.js';
+import { fetchDynamicEvmPrimitives, getMultipleBlockData } from '../../reading.js';
 import { getLatestProcessedCdeBlockheight } from '@paima/db';
 
 const GET_BLOCK_NUMBER_TIMEOUT = 5000;
@@ -327,7 +327,7 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
       return [];
     }
     try {
-      const dynamicPrimitives = await fetchDynamicPrimitives(
+      const DynamicEvmPrimitives = await fetchDynamicEvmPrimitives(
         blockNumber,
         blockNumber,
         this.web3,
@@ -341,13 +341,13 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
           this.sharedData.extensions.filter(
             extension =>
               extension.network === this.chainName &&
-              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+              extension.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive
           ),
           blockNumber,
           blockNumber,
           this.chainName
         )
-      ).concat(dynamicPrimitives);
+      ).concat(DynamicEvmPrimitives);
 
       for (const extensionData of cdeData) {
         for (const data of extensionData) {
@@ -380,7 +380,7 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
     }
 
     try {
-      const dynamicPrimitives = await fetchDynamicPrimitives(
+      const DynamicEvmPrimitives = await fetchDynamicEvmPrimitives(
         fromBlock,
         toBlock,
         this.web3,
@@ -394,13 +394,13 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
           this.sharedData.extensions.filter(
             extension =>
               extension.network === this.chainName &&
-              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+              extension.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive
           ),
           fromBlock,
           toBlock,
           this.chainName
         )
-      ).concat(dynamicPrimitives);
+      ).concat(DynamicEvmPrimitives);
 
       let mappedFrom: number | undefined;
       let mappedTo: number | undefined;
@@ -465,7 +465,7 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
 
       doLog(`EVM CDE funnel presync ${this.config.chainId}: #${fromBlock}-${toBlock}`);
 
-      const dynamicDatums = await fetchDynamicPrimitives(
+      const dynamicDatums = await fetchDynamicEvmPrimitives(
         fromBlock,
         toBlock,
         this.web3,
@@ -479,7 +479,7 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
           this.sharedData.extensions.filter(
             extension =>
               extension.network === this.chainName &&
-              extension.cdeType !== ChainDataExtensionType.DynamicPrimitive
+              extension.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive
           ),
           fromBlock,
           toBlock,

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -91,7 +91,7 @@ export class FunnelFactory implements IFunnelFactory {
     return this.dirtyExtensions;
   }
 
-  async markExtensionsAsDirty(): Promise<void> {
+  public markExtensionsAsDirty(): void {
     this.dirtyExtensions = true;
   }
 

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -1,6 +1,5 @@
 import type { PoolClient } from 'pg';
 import {
-  ChainDataExtensionDatumType,
   ENV,
   GlobalConfig,
   getPaimaL2Contract,
@@ -9,7 +8,7 @@ import {
 } from '@paima/utils';
 import { loadChainDataExtensions } from '@paima/runtime';
 import type { ChainFunnel, IFunnelFactory } from '@paima/runtime';
-import type { ChainData, ChainDataExtension, ChainDataExtensionDatum } from '@paima/sm';
+import type { ChainDataExtension } from '@paima/sm';
 import { wrapToEmulatedBlocksFunnel } from './funnels/emulated/utils.js';
 import { BlockFunnel } from './funnels/block/funnel.js';
 import type { FunnelSharedData } from './funnels/BaseFunnel.js';
@@ -21,15 +20,9 @@ import type Web3 from 'web3';
 import { wrapToMinaFunnel } from './funnels/mina/funnel.js';
 
 export class FunnelFactory implements IFunnelFactory {
-  private dirtyExtensions = false;
-
   private constructor(public sharedData: FunnelSharedData) {}
 
   public static async initialize(db: PoolClient): Promise<FunnelFactory> {
-    return new FunnelFactory(await FunnelFactory.initializeSharedData(db));
-  }
-
-  public static async initializeSharedData(db: PoolClient): Promise<FunnelSharedData> {
     const configs = await GlobalConfig.getInstance();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, mainConfig] = await GlobalConfig.mainEvmConfig();
@@ -66,13 +59,13 @@ export class FunnelFactory implements IFunnelFactory {
       db
     );
 
-    return {
+    return new FunnelFactory({
       web3,
       paimaL2Contract,
       extensions,
       extensionsValid,
       cacheManager: new FunnelCacheManager(),
-    };
+    });
   }
 
   public clearCache(): void {
@@ -87,23 +80,9 @@ export class FunnelFactory implements IFunnelFactory {
     return this.sharedData.extensionsValid;
   }
 
-  public extensionsNeedReload(): boolean {
-    return this.dirtyExtensions;
-  }
-
-  public markExtensionsAsDirty(): void {
-    this.dirtyExtensions = true;
-  }
-
   async generateFunnel(dbTx: PoolClient): Promise<ChainFunnel> {
-    if (this.dirtyExtensions) {
-      this.sharedData = await FunnelFactory.initializeSharedData(dbTx);
-      this.dirtyExtensions = false;
-    }
-
     // start with a base funnel
     // and wrap it with dynamic decorators as needed
-
     let chainFunnel: ChainFunnel = await BlockFunnel.recoverState(this.sharedData, dbTx);
     for (const [chainName, config] of await GlobalConfig.otherEvmConfig()) {
       chainFunnel = await wrapToParallelEvmFunnel(

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -1,5 +1,4 @@
 import type { PoolClient } from 'pg';
-
 import {
   ChainDataExtensionDatumType,
   ENV,
@@ -32,6 +31,7 @@ export class FunnelFactory implements IFunnelFactory {
 
   public static async initializeSharedData(db: PoolClient): Promise<FunnelSharedData> {
     const configs = await GlobalConfig.getInstance();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, mainConfig] = await GlobalConfig.mainEvmConfig();
 
     const nodeUrl = mainConfig.chainUri;
@@ -156,7 +156,7 @@ export function filterResultsAfterDynamicPrimitive(
   ungroupedCdeData: ChainDataExtensionDatum[][],
   baseChainData: ChainData[],
   toBlock: number
-) {
+): ChainData[] {
   const firstDynamicBlock = ungroupedCdeData
     .filter(
       extData =>

--- a/packages/engine/paima-funnel/src/index.ts
+++ b/packages/engine/paima-funnel/src/index.ts
@@ -137,39 +137,3 @@ export class FunnelFactory implements IFunnelFactory {
     return chainFunnel;
   }
 }
-
-// If we have a dynamic primitive, then technically we may have missed an
-// event in the range.
-//
-// Here we invalidate everything after that point, so that in the next
-// funnel call we start from that point.
-//
-// TODO: there are two possible ways of optimizing this:
-//
-//  1. Cache this information for the next request.
-//  2. Build the dynamic contract here and get the extra data for the new extensions.
-//
-// First option is probably much easier to implement. Second option
-// has the issue that we can't update the shared data here, so it probably would
-// inovlve duplicating the logic.
-export function filterResultsAfterDynamicPrimitive(
-  ungroupedCdeData: ChainDataExtensionDatum[][],
-  baseChainData: ChainData[],
-  toBlock: number
-): ChainData[] {
-  const firstDynamicBlock = ungroupedCdeData
-    .filter(
-      extData =>
-        extData.length > 0 &&
-        extData[0].cdeDatumType === ChainDataExtensionDatumType.DynamicPrimitive
-    )
-    // we just get the first one, since these are sorted.
-    .reduce((min, extData) => Math.min(min, extData[0].blockNumber), toBlock + 1);
-
-  let filteredBaseChainData = baseChainData;
-
-  if (firstDynamicBlock <= toBlock) {
-    filteredBaseChainData = baseChainData.filter(ext => ext.blockNumber <= firstDynamicBlock);
-  }
-  return filteredBaseChainData;
-}

--- a/packages/engine/paima-funnel/src/reading.ts
+++ b/packages/engine/paima-funnel/src/reading.ts
@@ -8,6 +8,7 @@ import {
   doLog,
   ChainDataExtensionType,
   getErc721Contract,
+  DYNAMIC_PRIMITIVE_NAME_SEPARATOR,
 } from '@paima/utils';
 import type { PaimaL2Contract } from '@paima/utils';
 import { TimeoutError } from '@paima/runtime';
@@ -180,7 +181,7 @@ export async function fetchDynamicEvmPrimitives(
     for (const _ext of exts) {
       const ext: CdeDynamicEvmPrimitiveDatum = _ext as CdeDynamicEvmPrimitiveDatum;
 
-      const cdeName = `${ext.cdeName}-${
+      const cdeName = `${ext.cdeName}${DYNAMIC_PRIMITIVE_NAME_SEPARATOR}${
         sharedData.extensions.filter(
           e =>
             e.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive &&

--- a/packages/engine/paima-funnel/src/reading.ts
+++ b/packages/engine/paima-funnel/src/reading.ts
@@ -13,7 +13,7 @@ import type { PaimaL2Contract } from '@paima/utils';
 import { TimeoutError } from '@paima/runtime';
 import {
   CdeEntryTypeName,
-  type CdeDynamicPrimitiveDatum,
+  type CdeDynamicEvmPrimitiveDatum,
   type ChainData,
   type ChainDataExtensionDatum,
 } from '@paima/sm';
@@ -155,28 +155,28 @@ async function getPaimaEvents(
 // change the set of primitives. Otherwise we would miss the events for those.
 // If there is an event that triggers a dynamic primitive here, then an
 // extension will be added to the list with a starting block at that point.
-export async function fetchDynamicPrimitives(
+export async function fetchDynamicEvmPrimitives(
   fromBlock: number,
   toBlock: number,
   web3: Web3,
   sharedData: FunnelSharedData,
   network: string
 ): Promise<ChainDataExtensionDatum[][]> {
-  const dynamicPrimitives = await getUngroupedCdeData(
+  const DynamicEvmPrimitives = await getUngroupedCdeData(
     web3,
     sharedData.extensions.filter(
       extension =>
         extension.network === network &&
-        extension.cdeType === ChainDataExtensionType.DynamicPrimitive
+        extension.cdeType === ChainDataExtensionType.DynamicEvmPrimitive
     ),
     fromBlock,
     toBlock,
     network
   );
 
-  for (const exts of dynamicPrimitives) {
+  for (const exts of DynamicEvmPrimitives) {
     for (const _ext of exts) {
-      const ext: CdeDynamicPrimitiveDatum = _ext as CdeDynamicPrimitiveDatum;
+      const ext: CdeDynamicEvmPrimitiveDatum = _ext as CdeDynamicEvmPrimitiveDatum;
 
       // this would propagate the change to further funnels in the pipeline,
       // which is needed to set the proper cdeId.
@@ -197,5 +197,5 @@ export async function fetchDynamicPrimitives(
     }
   }
 
-  return dynamicPrimitives;
+  return DynamicEvmPrimitives;
 }

--- a/packages/engine/paima-funnel/src/reading.ts
+++ b/packages/engine/paima-funnel/src/reading.ts
@@ -23,6 +23,7 @@ import type { PaimaGameInteraction } from '@paima/utils';
 import { extractSubmittedData } from './paima-l2-processing.js';
 import type { FunnelSharedData } from './funnels/BaseFunnel.js';
 import { getUngroupedCdeData } from './cde/reading.js';
+import { generateDynamicPrimitiveName } from '@paima/utils-backend';
 
 export async function getBaseChainDataMulti(
   web3: Web3,
@@ -181,13 +182,13 @@ export async function fetchDynamicEvmPrimitives(
     for (const _ext of exts) {
       const ext: CdeDynamicEvmPrimitiveDatum = _ext as CdeDynamicEvmPrimitiveDatum;
 
-      const cdeName = `${ext.cdeName}${DYNAMIC_PRIMITIVE_NAME_SEPARATOR}${
-        sharedData.extensions.filter(
-          e =>
-            e.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive &&
-            e.cdeName.startsWith(ext.cdeName)
-        ).length
-      }`;
+      const id = sharedData.extensions.filter(
+        e =>
+          e.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive &&
+          e.cdeName.startsWith(ext.cdeName)
+      ).length;
+
+      const cdeName = generateDynamicPrimitiveName(ext.cdeName, id);
 
       // this would propagate the change to further funnels in the pipeline,
       // which is needed to set the proper cdeName.

--- a/packages/engine/paima-funnel/src/reading.ts
+++ b/packages/engine/paima-funnel/src/reading.ts
@@ -177,6 +177,7 @@ export async function fetchDynamicPrimitives(
   for (const exts of dynamicPrimitives) {
     for (const _ext of exts) {
       const ext: CdeDynamicPrimitiveDatum = _ext as CdeDynamicPrimitiveDatum;
+
       // this would propagate the change to further funnels in the pipeline,
       // which is needed to set the proper cdeId.
       sharedData.extensions.push({
@@ -185,7 +186,7 @@ export async function fetchDynamicPrimitives(
         type: CdeEntryTypeName.ERC721,
         contractAddress: ext.payload.contractAddress,
         scheduledPrefix: ext.scheduledPrefix,
-        burnScheduledPrefix: ext.scheduledPrefix,
+        burnScheduledPrefix: ext.burnScheduledPrefix,
         cdeId: sharedData.extensions.length,
         network: network,
         // not relevant

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -29,8 +29,8 @@ import type {
   TChainDataExtensionErc721Config,
   TChainDataExtensionGenericConfig,
   CdeConfig,
-  TChainDataExtensionDynamicPrimitiveConfig,
-  ChainDataExtensionDynamicPrimitive,
+  TChainDataExtensionDynamicEvmPrimitiveConfig,
+  ChainDataExtensionDynamicEvmPrimitive,
 } from '@paima/sm';
 import {
   CdeBaseConfig,
@@ -48,7 +48,7 @@ import {
   ChainDataExtensionGenericConfig,
   ChainDataExtensionMinaEventGenericConfig,
   ChainDataExtensionMinaActionGenericConfig,
-  ChainDataExtensionDynamicPrimitiveConfig,
+  ChainDataExtensionDynamicEvmPrimitiveConfig,
 } from '@paima/sm';
 import { loadAbi } from './utils.js';
 import assertNever from 'assert-never';
@@ -153,10 +153,10 @@ export function parseCdeConfigFile(
           Type.Intersect([ChainDataExtensionErc6551RegistryConfig, networkTagType]),
           entry
         );
-      case CdeEntryTypeName.DynamicPrimitive:
+      case CdeEntryTypeName.DynamicEvmPrimitive:
         return checkOrError(
           entry.name,
-          Type.Intersect([ChainDataExtensionDynamicPrimitiveConfig, networkTagType]),
+          Type.Intersect([ChainDataExtensionDynamicEvmPrimitiveConfig, networkTagType]),
           entry
         );
       case CdeEntryTypeName.CardanoDelegation:
@@ -342,9 +342,9 @@ async function instantiateExtension(
           return getErc6551RegistryContract(contractAddress, web3s[network]);
         })(),
       };
-    case CdeEntryTypeName.DynamicPrimitive:
+    case CdeEntryTypeName.DynamicEvmPrimitive:
       return {
-        ...(await instantiateCdeDynamicPrimitive(config, index, web3s[network])),
+        ...(await instantiateCdeDynamicEvmPrimitive(config, index, web3s[network])),
         network,
       };
     case CdeEntryTypeName.CardanoDelegation:
@@ -461,11 +461,11 @@ async function instantiateCdeGeneric(
   }
 }
 
-async function instantiateCdeDynamicPrimitive(
-  config: TChainDataExtensionDynamicPrimitiveConfig,
+async function instantiateCdeDynamicEvmPrimitive(
+  config: TChainDataExtensionDynamicEvmPrimitiveConfig,
   index: number,
   web3: Web3
-): Promise<ChainDataExtensionDynamicPrimitive> {
+): Promise<ChainDataExtensionDynamicEvmPrimitive> {
   const eventSignature = config.eventSignature;
   const eventMatch = eventSignature.match(/^[A-Za-z0-9_]+/); // ex: MyEvent(address,uint256) → "MyEvent"
   if (!eventMatch) {
@@ -485,7 +485,7 @@ async function instantiateCdeDynamicPrimitive(
       ...rest,
       cdeId: index,
       hash: hashConfig(config),
-      cdeType: ChainDataExtensionType.DynamicPrimitive,
+      cdeType: ChainDataExtensionType.DynamicEvmPrimitive,
       contract,
       eventSignature,
       eventName,

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -84,7 +84,7 @@ export async function loadChainDataExtensions(
           name: Type.String(),
           type: Type.Enum(CdeEntryTypeName),
         }),
-        { ...YAML.parse(ext.config), dynamic: true }
+        { ...YAML.parse(ext.config) }
       )
     );
   } catch (err) {
@@ -267,7 +267,7 @@ export function hashConfig(config: any): number {
 
 // Do type-specific initialization and construct contract objects
 async function instantiateExtension(
-  config: Static<typeof CdeConfig>['extensions'][0] & { dynamic?: boolean },
+  config: Static<typeof CdeConfig>['extensions'][0],
   index: number,
   web3s: { [network: string]: Web3 }
 ): Promise<ChainDataExtension> {
@@ -281,7 +281,6 @@ async function instantiateExtension(
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.ERC20,
         contract: getErc20Contract(config.contractAddress, web3s[network]),
-        dynamic: config.dynamic ?? false,
       };
     case CdeEntryTypeName.ERC721:
       if (await isPaimaErc721(config, web3s[network])) {
@@ -301,7 +300,6 @@ async function instantiateExtension(
           hash: hashConfig(config),
           cdeType: ChainDataExtensionType.ERC721,
           contract: getErc721Contract(config.contractAddress, web3s[network]),
-          dynamic: config.dynamic ?? false,
         };
       }
     case CdeEntryTypeName.ERC20Deposit:

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -84,7 +84,7 @@ export async function loadChainDataExtensions(
           name: Type.String(),
           type: Type.Enum(CdeEntryTypeName),
         }),
-        { ...YAML.parse(ext.config) }
+        { ...YAML.parse(ext.config), name: ext.cde_name }
       )
     );
   } catch (err) {
@@ -277,7 +277,7 @@ async function instantiateExtension(
       return {
         ...config,
         network,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.ERC20,
         contract: getErc20Contract(config.contractAddress, web3s[network]),
@@ -287,7 +287,7 @@ async function instantiateExtension(
         return {
           ...config,
           network,
-          cdeId: index,
+          cdeName: config.name,
           hash: hashConfig(config),
           cdeType: ChainDataExtensionType.PaimaERC721,
           contract: getPaimaErc721Contract(config.contractAddress, web3s[network]),
@@ -296,7 +296,7 @@ async function instantiateExtension(
         return {
           ...config,
           network,
-          cdeId: index,
+          cdeName: config.name,
           hash: hashConfig(config),
           cdeType: ChainDataExtensionType.ERC721,
           contract: getErc721Contract(config.contractAddress, web3s[network]),
@@ -306,7 +306,7 @@ async function instantiateExtension(
       return {
         ...config,
         network,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.ERC20Deposit,
         contract: getErc20Contract(config.contractAddress, web3s[network]),
@@ -315,7 +315,7 @@ async function instantiateExtension(
       return {
         ...config,
         network,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.ERC1155,
         contract: getErc1155Contract(config.contractAddress, web3s[network]),
@@ -330,7 +330,7 @@ async function instantiateExtension(
       return {
         ...config,
         network,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.ERC6551Registry,
         contractAddress,
@@ -351,7 +351,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultCardanoNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.CardanoPool,
       };
@@ -359,7 +359,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultCardanoNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.CardanoProjectedNFT,
       };
@@ -367,7 +367,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultCardanoNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.CardanoAssetUtxo,
       };
@@ -375,7 +375,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultCardanoNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.CardanoTransfer,
       };
@@ -383,7 +383,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultCardanoNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.CardanoMintBurn,
       };
@@ -391,7 +391,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultMinaNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.MinaEventGeneric,
       };
@@ -399,7 +399,7 @@ async function instantiateExtension(
       return {
         ...config,
         network: config.network || defaultMinaNetworkName,
-        cdeId: index,
+        cdeName: config.name,
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.MinaActionGeneric,
       };
@@ -445,7 +445,7 @@ async function instantiateCdeGeneric(
     const { abiPath: _, ...rest } = config; // want to remove abi path since it's no longer relevant at runtime
     return {
       ...rest,
-      cdeId: index,
+      cdeName: config.name,
       hash: hashConfig(config),
       cdeType: ChainDataExtensionType.Generic,
       contract,
@@ -483,7 +483,7 @@ async function instantiateCdeDynamicEvmPrimitive(
     const { abiPath: _, ...rest } = config; // want to remove abi path since it's no longer relevant at runtime
     return {
       ...rest,
-      cdeId: index,
+      cdeName: config.name,
       hash: hashConfig(config),
       cdeType: ChainDataExtensionType.DynamicEvmPrimitive,
       contract,

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -261,7 +261,7 @@ function checkOrError<T extends TSchema>(
   return decoded;
 }
 
-function hashConfig(config: any): number {
+export function hashConfig(config: any): number {
   // fnv returns an unsigned int, but postgres doesn't support unsigned ints
   const unsignedInt = fnv.fast1a32(stableStringify(config));
   // map unsigned into signed in. Obviously this isn't lossless, but it's still good enough for collision avoidance

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -54,7 +54,7 @@ import { loadAbi } from './utils.js';
 import assertNever from 'assert-never';
 import fnv from 'fnv-plus';
 import stableStringify from 'json-stable-stringify';
-import { PoolClient } from 'pg';
+import type { PoolClient } from 'pg';
 import { getDynamicExtensions } from '@paima/db';
 
 type ValidationResult = [config: ChainDataExtension[], validated: boolean];
@@ -93,10 +93,7 @@ export async function loadChainDataExtensions(
   }
 
   try {
-    const config = parseCdeConfigFile(
-      configFileData,
-      dynamicExtensions as any as (typeof CdeBaseConfig)['extensions']
-    );
+    const config = parseCdeConfigFile(configFileData, dynamicExtensions);
     const instantiatedExtensions = await Promise.all(
       config.extensions.map((e, i) => instantiateExtension(e, i, web3s))
     );

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -72,7 +72,7 @@ export async function loadChainDataExtensions(
     return [[], true];
   }
 
-  let dynamicExtensions: (typeof CdeBaseConfig)['extensions'];
+  let dynamicExtensions: { name: string; type: CdeEntryTypeName }[];
 
   try {
     const dbResult = await getDynamicExtensions.run(undefined, db);
@@ -109,7 +109,7 @@ const networkTagType = Type.Partial(Type.Object({ network: Type.String() }));
 // Validate the overall structure of the config file and extract the relevant data
 export function parseCdeConfigFile(
   configFileData: string,
-  extraExtensions: (typeof CdeBaseConfig)['extensions']
+  extraExtensions: { name: string; type: CdeEntryTypeName }[]
 ): Static<typeof CdeConfig> {
   // Parse the YAML content into an object
   const configObject = YAML.parse(configFileData);

--- a/packages/engine/paima-runtime/src/cde-config/loading.ts
+++ b/packages/engine/paima-runtime/src/cde-config/loading.ts
@@ -84,7 +84,7 @@ export async function loadChainDataExtensions(
           name: Type.String(),
           type: Type.Enum(CdeEntryTypeName),
         }),
-        YAML.parse(ext.config)
+        { ...YAML.parse(ext.config), dynamic: true }
       )
     );
   } catch (err) {
@@ -267,7 +267,7 @@ export function hashConfig(config: any): number {
 
 // Do type-specific initialization and construct contract objects
 async function instantiateExtension(
-  config: Static<typeof CdeConfig>['extensions'][0],
+  config: Static<typeof CdeConfig>['extensions'][0] & { dynamic?: boolean },
   index: number,
   web3s: { [network: string]: Web3 }
 ): Promise<ChainDataExtension> {
@@ -281,6 +281,7 @@ async function instantiateExtension(
         hash: hashConfig(config),
         cdeType: ChainDataExtensionType.ERC20,
         contract: getErc20Contract(config.contractAddress, web3s[network]),
+        dynamic: config.dynamic ?? false,
       };
     case CdeEntryTypeName.ERC721:
       if (await isPaimaErc721(config, web3s[network])) {
@@ -300,6 +301,7 @@ async function instantiateExtension(
           hash: hashConfig(config),
           cdeType: ChainDataExtensionType.ERC721,
           contract: getErc721Contract(config.contractAddress, web3s[network]),
+          dynamic: config.dynamic ?? false,
         };
       }
     case CdeEntryTypeName.ERC20Deposit:

--- a/packages/engine/paima-runtime/src/cde-config/validation.ts
+++ b/packages/engine/paima-runtime/src/cde-config/validation.ts
@@ -14,7 +14,7 @@ export async function validatePersistentCdeConfig(
   DBConn: Pool,
   smStarted: boolean
 ): Promise<boolean> {
-  const persistentConfig = (await getChainDataExtensions.run(undefined, DBConn));
+  const persistentConfig = await getChainDataExtensions.run(undefined, DBConn);
 
   // Checking cases if config is specified and if it needs to be saved
   if (persistentConfig.length === 0 && config.length > 0) {

--- a/packages/engine/paima-runtime/src/cde-config/validation.ts
+++ b/packages/engine/paima-runtime/src/cde-config/validation.ts
@@ -33,7 +33,7 @@ export async function validatePersistentCdeConfig(
 
   // Verifying all CDEs match between persistent config and read yaml config
   for (const cde of config) {
-    const persistent = persistentConfig.find(row => row.cde_id === cde.cdeId);
+    const persistent = persistentConfig.find(row => row.cde_name === cde.cdeName);
     if (!persistent) {
       return false;
     }
@@ -52,7 +52,6 @@ async function storeCdeConfig(config: ChainDataExtension[], DBConn: PoolClient):
     for (const cde of config) {
       await registerChainDataExtension.run(
         {
-          cde_id: cde.cdeId,
           cde_type: cde.cdeType,
           cde_name: cde.name,
           cde_hash: cde.hash,

--- a/packages/engine/paima-runtime/src/cde-config/validation.ts
+++ b/packages/engine/paima-runtime/src/cde-config/validation.ts
@@ -37,7 +37,7 @@ export async function validatePersistentCdeConfig(
     if (!persistent) {
       return false;
     }
-    if (persistent.cde_hash !== cde.hash) {
+    if (persistent.cde_hash && persistent.cde_hash !== cde.hash) {
       return false;
     }
   }

--- a/packages/engine/paima-runtime/src/cde-config/validation.ts
+++ b/packages/engine/paima-runtime/src/cde-config/validation.ts
@@ -14,10 +14,7 @@ export async function validatePersistentCdeConfig(
   DBConn: Pool,
   smStarted: boolean
 ): Promise<boolean> {
-  const persistentConfig = (await getChainDataExtensions.run(undefined, DBConn)).filter(
-    // filter dynamic primitives
-    ext => !!ext.cde_hash
-  );
+  const persistentConfig = (await getChainDataExtensions.run(undefined, DBConn));
 
   // Checking cases if config is specified and if it needs to be saved
   if (persistentConfig.length === 0 && config.length > 0) {

--- a/packages/engine/paima-runtime/src/cde-config/validation.ts
+++ b/packages/engine/paima-runtime/src/cde-config/validation.ts
@@ -14,7 +14,10 @@ export async function validatePersistentCdeConfig(
   DBConn: Pool,
   smStarted: boolean
 ): Promise<boolean> {
-  const persistentConfig = await getChainDataExtensions.run(undefined, DBConn);
+  const persistentConfig = (await getChainDataExtensions.run(undefined, DBConn)).filter(
+    // filter dynamic primitives
+    ext => !!ext.cde_hash
+  );
 
   // Checking cases if config is specified and if it needs to be saved
   if (persistentConfig.length === 0 && config.length > 0) {

--- a/packages/engine/paima-runtime/src/index.ts
+++ b/packages/engine/paima-runtime/src/index.ts
@@ -101,7 +101,7 @@ async function runInitializationProcedures(
     return false;
   }
 
-  const [chainName, config] = await GlobalConfig.mainEvmConfig();
+  const [chainName] = await GlobalConfig.mainEvmConfig();
 
   const smStarted =
     (await gameStateMachine.presyncStarted(chainName)) || (await gameStateMachine.syncStarted());

--- a/packages/engine/paima-runtime/src/runtime-loops.ts
+++ b/packages/engine/paima-runtime/src/runtime-loops.ts
@@ -58,7 +58,10 @@ async function runPresync(
 
   let presyncBlockHeight = await getPresyncStartBlockheight(
     gameStateMachine,
-    // TODO: may need to change this?
+    // If there is a dynamic primitive created in the presync, this collection
+    // won't have it since the reload has not happened yet.  That said, if this
+    // is the case then the earliest cde doesn't matter since we just continue
+    // from the previous point, so it doesn't make any difference.
     funnelFactory.getExtensions(),
     startBlockHeight
   );

--- a/packages/engine/paima-runtime/src/types.ts
+++ b/packages/engine/paima-runtime/src/types.ts
@@ -32,7 +32,6 @@ export interface IFunnelFactory {
   clearCache: () => void;
 
   generateFunnel(dbTx: PoolClient): Promise<ChainFunnel>;
-  markExtensionsAsDirty(): void;
 }
 
 export interface PaimaRuntime {

--- a/packages/engine/paima-runtime/src/types.ts
+++ b/packages/engine/paima-runtime/src/types.ts
@@ -32,7 +32,7 @@ export interface IFunnelFactory {
   clearCache: () => void;
 
   generateFunnel(dbTx: PoolClient): Promise<ChainFunnel>;
-  markExtensionsAsDirty(): Promise<void>;
+  markExtensionsAsDirty(): void;
 }
 
 export interface PaimaRuntime {

--- a/packages/engine/paima-runtime/src/types.ts
+++ b/packages/engine/paima-runtime/src/types.ts
@@ -32,6 +32,7 @@ export interface IFunnelFactory {
   clearCache: () => void;
 
   generateFunnel(dbTx: PoolClient): Promise<ChainFunnel>;
+  markExtensionsAsDirty(): Promise<void>;
 }
 
 export interface PaimaRuntime {

--- a/packages/engine/paima-sm/src/cde-cardano-delayed-asset.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-delayed-asset.ts
@@ -5,7 +5,7 @@ import type { CdeCardanoAssetUtxoDatum } from './types.js';
 export default async function processDatum(
   cdeDatum: CdeCardanoAssetUtxoDatum
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const address = cdeDatum.payload.address;
   const amount = cdeDatum.payload.amount;
   const tx_id = cdeDatum.payload.txId;
@@ -22,7 +22,7 @@ export default async function processDatum(
       [
         cdeInsertCardanoAssetUtxo,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           address: address,
           tx_id: tx_id,
           output_index: output_index,

--- a/packages/engine/paima-sm/src/cde-cardano-mint-burn.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-mint-burn.ts
@@ -7,7 +7,7 @@ export default async function processDatum(
   cdeDatum: CdeCardanoMintBurnDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const prefix = cdeDatum.scheduledPrefix;
   const txId = cdeDatum.payload.txId;
   const assets = JSON.stringify(cdeDatum.payload.assets);
@@ -23,7 +23,7 @@ export default async function processDatum(
     [
       cdeCardanoMintBurnInsert,
       {
-        cde_id: cdeId,
+        cde_name: cdeName,
         tx_id: txId,
         metadata: metadata,
         assets: cdeDatum.payload.assets,

--- a/packages/engine/paima-sm/src/cde-cardano-pool.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-pool.ts
@@ -7,7 +7,7 @@ export default async function processDatum(
   cdeDatum: CdeCardanoPoolDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const prefix = cdeDatum.scheduledPrefix;
   const address = cdeDatum.payload.address;
   const pool = cdeDatum.payload.pool;
@@ -20,7 +20,7 @@ export default async function processDatum(
     [
       cdeCardanoPoolInsertData,
       {
-        cde_id: cdeId,
+        cde_name: cdeName,
         address: cdeDatum.payload.address,
         pool: cdeDatum.payload.pool,
         epoch: cdeDatum.payload.epoch,

--- a/packages/engine/paima-sm/src/cde-cardano-projected-nft.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-projected-nft.ts
@@ -11,7 +11,7 @@ export default async function processDatum(
   cdeDatum: CdeCardanoProjectedNFTDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const prefix = cdeDatum.scheduledPrefix;
   const ownerAddress = cdeDatum.payload.ownerAddress;
   const previousTxHash = cdeDatum.payload.previousTxHash;
@@ -34,7 +34,7 @@ export default async function processDatum(
       [
         cdeCardanoProjectedNftInsertData,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           owner_address: ownerAddress,
           current_tx_hash: currentTxHash,
           current_tx_output_index: currentOutputIndex,
@@ -54,7 +54,7 @@ export default async function processDatum(
     [
       cdeCardanoProjectedNftUpdateData,
       {
-        cde_id: cdeId,
+        cde_name: cdeName,
         owner_address: ownerAddress,
         new_tx_hash: currentTxHash,
         new_tx_output_index: currentOutputIndex,

--- a/packages/engine/paima-sm/src/cde-cardano-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-cardano-transfer.ts
@@ -7,7 +7,7 @@ export default async function processDatum(
   cdeDatum: CdeCardanoTransferDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const prefix = cdeDatum.scheduledPrefix;
   const txId = cdeDatum.payload.txId;
   const rawTx = cdeDatum.payload.rawTx;
@@ -23,7 +23,7 @@ export default async function processDatum(
     [
       cdeCardanoTransferInsert,
       {
-        cde_id: cdeId,
+        cde_name: cdeName,
         tx_id: txId,
         raw_tx: rawTx,
         metadata: metadata,

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -23,7 +23,7 @@ export default async function processDatum(
 
   const config = {
     name: cdeDatum.cdeName,
-    type: type,
+    type: cdeDatum.payload.type,
     contractAddress: cdeDatum.payload.contractAddress,
     startBlockHeight: cdeDatum.blockNumber + 1,
     scheduledPrefix: cdeDatum.scheduledPrefix,

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -1,0 +1,55 @@
+import {
+  getChainDataExtensions,
+  insertDynamicExtension,
+  registerChainDataExtension,
+} from '@paima/db';
+import type { SQLUpdate } from '@paima/db';
+import type { CdeDynamicPrimitiveDatum } from './types.js';
+import { ChainDataExtensionType } from '@paima/utils';
+import type { PoolClient } from 'pg';
+import YAML from 'yaml';
+
+export default async function processDatum(
+  readonlyDBConn: PoolClient,
+  cdeDatum: CdeDynamicPrimitiveDatum,
+  _inPresync: boolean,
+  reloadExtensions: () => void
+): Promise<SQLUpdate[]> {
+  const extensions = await getChainDataExtensions.run(undefined, readonlyDBConn);
+
+  const cdeId =
+    extensions.map(ext => ext.cde_id).reduce((cde_id1, cde_id2) => Math.max(cde_id1, cde_id2)) + 1;
+
+  const updateList: SQLUpdate[] = [
+    [
+      registerChainDataExtension,
+      {
+        cde_id: cdeId,
+        cde_type: ChainDataExtensionType.ERC721,
+        cde_name: cdeDatum.cdeName,
+        // the hash is not verified for these
+        cde_hash: 0,
+        start_blockheight: cdeDatum.blockNumber + 1,
+        scheduled_prefix: cdeDatum.scheduledPrefix,
+      },
+    ],
+    [
+      insertDynamicExtension,
+      {
+        cde_id: cdeId,
+        config: YAML.stringify({
+          name: cdeDatum.cdeName,
+          type: 'erc721',
+          contractAddress: cdeDatum.payload.contractAddress,
+          startBlockHeight: cdeDatum.blockNumber + 1,
+          scheduledPrefix: cdeDatum.scheduledPrefix,
+          network: cdeDatum.network,
+        }),
+      },
+    ],
+  ];
+
+  reloadExtensions();
+
+  return updateList;
+}

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -10,9 +10,6 @@ export default async function processDatum(
 ): Promise<SQLUpdate[]> {
   let type;
   switch (cdeDatum.payload.type) {
-    case CdeEntryTypeName.ERC20:
-      type = ChainDataExtensionType.ERC20;
-      break;
     case CdeEntryTypeName.ERC721:
       type = ChainDataExtensionType.ERC721;
       break;

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -1,6 +1,6 @@
 import { insertDynamicExtension, registerChainDataExtension } from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
-import type { CdeDynamicPrimitiveDatum } from './types.js';
+import { CdeEntryTypeName, type CdeDynamicPrimitiveDatum } from './types.js';
 import { ChainDataExtensionType } from '@paima/utils';
 import YAML from 'yaml';
 
@@ -9,9 +9,21 @@ export default async function processDatum(
   _inPresync: boolean,
   reloadExtensions: () => void
 ): Promise<SQLUpdate[]> {
+  let type;
+  switch (cdeDatum.payload.type) {
+    case CdeEntryTypeName.ERC20:
+      type = ChainDataExtensionType.ERC20;
+      break;
+    case CdeEntryTypeName.ERC721:
+      type = ChainDataExtensionType.ERC721;
+      break;
+    default:
+      throw new Error(`Unsupported dynamic primitive type: ${cdeDatum.payload.type}`);
+  }
+
   const config = {
     name: cdeDatum.cdeName,
-    type: 'erc721',
+    type: type,
     contractAddress: cdeDatum.payload.contractAddress,
     startBlockHeight: cdeDatum.blockNumber + 1,
     scheduledPrefix: cdeDatum.scheduledPrefix,
@@ -22,7 +34,7 @@ export default async function processDatum(
     [
       registerChainDataExtension,
       {
-        cde_type: ChainDataExtensionType.ERC721,
+        cde_type: type,
         cde_name: cdeDatum.cdeName,
         start_blockheight: cdeDatum.blockNumber + 1,
         scheduled_prefix: cdeDatum.scheduledPrefix,

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -23,6 +23,7 @@ export default async function processDatum(
     contractAddress: cdeDatum.payload.contractAddress,
     startBlockHeight: cdeDatum.blockNumber,
     scheduledPrefix: cdeDatum.scheduledPrefix,
+    burnScheduledPrefix: cdeDatum.burnScheduledPrefix,
     network: cdeDatum.network,
   };
 

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -6,8 +6,7 @@ import YAML from 'yaml';
 
 export default async function processDatum(
   cdeDatum: CdeDynamicPrimitiveDatum,
-  _inPresync: boolean,
-  reloadExtensions: () => void
+  _inPresync: boolean
 ): Promise<SQLUpdate[]> {
   let type;
   switch (cdeDatum.payload.type) {
@@ -25,7 +24,7 @@ export default async function processDatum(
     name: cdeDatum.cdeName,
     type: cdeDatum.payload.type,
     contractAddress: cdeDatum.payload.contractAddress,
-    startBlockHeight: cdeDatum.blockNumber + 1,
+    startBlockHeight: cdeDatum.blockNumber,
     scheduledPrefix: cdeDatum.scheduledPrefix,
     network: cdeDatum.network,
   };
@@ -36,7 +35,7 @@ export default async function processDatum(
       {
         cde_type: type,
         cde_name: cdeDatum.cdeName,
-        start_blockheight: cdeDatum.blockNumber + 1,
+        start_blockheight: cdeDatum.blockNumber,
         scheduled_prefix: cdeDatum.scheduledPrefix,
       },
     ],
@@ -47,8 +46,6 @@ export default async function processDatum(
       },
     ],
   ];
-
-  reloadExtensions();
 
   return updateList;
 }

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -20,6 +20,15 @@ export default async function processDatum(
   const cdeId =
     extensions.map(ext => ext.cde_id).reduce((cde_id1, cde_id2) => Math.max(cde_id1, cde_id2)) + 1;
 
+  const config = {
+    name: cdeDatum.cdeName,
+    type: 'erc721',
+    contractAddress: cdeDatum.payload.contractAddress,
+    startBlockHeight: cdeDatum.blockNumber + 1,
+    scheduledPrefix: cdeDatum.scheduledPrefix,
+    network: cdeDatum.network,
+  };
+
   const updateList: SQLUpdate[] = [
     [
       registerChainDataExtension,
@@ -27,8 +36,6 @@ export default async function processDatum(
         cde_id: cdeId,
         cde_type: ChainDataExtensionType.ERC721,
         cde_name: cdeDatum.cdeName,
-        // the hash is not verified for these
-        cde_hash: 0,
         start_blockheight: cdeDatum.blockNumber + 1,
         scheduled_prefix: cdeDatum.scheduledPrefix,
       },
@@ -37,14 +44,7 @@ export default async function processDatum(
       insertDynamicExtension,
       {
         cde_id: cdeId,
-        config: YAML.stringify({
-          name: cdeDatum.cdeName,
-          type: 'erc721',
-          contractAddress: cdeDatum.payload.contractAddress,
-          startBlockHeight: cdeDatum.blockNumber + 1,
-          scheduledPrefix: cdeDatum.scheduledPrefix,
-          network: cdeDatum.network,
-        }),
+        config: YAML.stringify(config),
       },
     ],
   ];

--- a/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-dynamic-primitive.ts
@@ -1,25 +1,14 @@
-import {
-  getChainDataExtensions,
-  insertDynamicExtension,
-  registerChainDataExtension,
-} from '@paima/db';
+import { insertDynamicExtension, registerChainDataExtension } from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
 import type { CdeDynamicPrimitiveDatum } from './types.js';
 import { ChainDataExtensionType } from '@paima/utils';
-import type { PoolClient } from 'pg';
 import YAML from 'yaml';
 
 export default async function processDatum(
-  readonlyDBConn: PoolClient,
   cdeDatum: CdeDynamicPrimitiveDatum,
   _inPresync: boolean,
   reloadExtensions: () => void
 ): Promise<SQLUpdate[]> {
-  const extensions = await getChainDataExtensions.run(undefined, readonlyDBConn);
-
-  const cdeId =
-    extensions.map(ext => ext.cde_id).reduce((cde_id1, cde_id2) => Math.max(cde_id1, cde_id2)) + 1;
-
   const config = {
     name: cdeDatum.cdeName,
     type: 'erc721',
@@ -33,7 +22,6 @@ export default async function processDatum(
     [
       registerChainDataExtension,
       {
-        cde_id: cdeId,
         cde_type: ChainDataExtensionType.ERC721,
         cde_name: cdeDatum.cdeName,
         start_blockheight: cdeDatum.blockNumber + 1,
@@ -43,7 +31,6 @@ export default async function processDatum(
     [
       insertDynamicExtension,
       {
-        cde_id: cdeId,
         config: YAML.stringify(config),
       },
     ],

--- a/packages/engine/paima-sm/src/cde-erc1155-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-erc1155-transfer.ts
@@ -17,7 +17,7 @@ export default async function processErc1155TransferDatum(
   cdeDatum: CdeErc1155TransferDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const { cdeId, scheduledPrefix, burnScheduledPrefix, payload, blockNumber } = cdeDatum;
+  const { cdeName, scheduledPrefix, burnScheduledPrefix, payload, blockNumber } = cdeDatum;
   const { operator, from, to, ids, values } = payload;
   const isMint = from == '0x0000000000000000000000000000000000000000';
   const isBurn = /^0x0+(dead)?$/i.test(to);
@@ -60,7 +60,7 @@ export default async function processErc1155TransferDatum(
       updateList.push([
         cdeErc1155ModifyBalance,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           token_id,
           wallet_address: from.toLowerCase(),
           value: (-value).toString(),
@@ -70,7 +70,7 @@ export default async function processErc1155TransferDatum(
       updateList.push([
         cdeErc1155DeleteIfZero,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           token_id,
           wallet_address: from.toLowerCase(),
         } satisfies ICdeErc1155DeleteIfZeroParams,
@@ -82,7 +82,7 @@ export default async function processErc1155TransferDatum(
       updateList.push([
         cdeErc1155ModifyBalance,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           token_id,
           wallet_address: to.toLowerCase(),
           value: value.toString(),
@@ -93,7 +93,7 @@ export default async function processErc1155TransferDatum(
       updateList.push([
         cdeErc1155Burn,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           token_id,
           wallet_address: from.toLowerCase(),
           value: value.toString(),

--- a/packages/engine/paima-sm/src/cde-erc20-deposit.ts
+++ b/packages/engine/paima-sm/src/cde-erc20-deposit.ts
@@ -15,13 +15,13 @@ export default async function processErc20Datum(
   cdeDatum: CdeErc20DepositDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const { from, value } = cdeDatum.payload;
 
   const fromAddr = from.toLowerCase();
 
   const fromRow = await cdeErc20DepositGetTotalDeposited.run(
-    { cde_id: cdeId, wallet_address: fromAddr },
+    { cde_name: cdeName, wallet_address: fromAddr },
     readonlyDBConn
   );
 
@@ -40,7 +40,7 @@ export default async function processErc20Datum(
       updateList.push([
         cdeErc20DepositUpdateTotalDeposited,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           wallet_address: fromAddr,
           total_deposited: newTotal.toString(10),
         },
@@ -49,7 +49,7 @@ export default async function processErc20Datum(
       updateList.push([
         cdeErc20DepositInsertTotalDeposited,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           wallet_address: fromAddr,
           total_deposited: value,
         },

--- a/packages/engine/paima-sm/src/cde-erc20-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-erc20-transfer.ts
@@ -9,18 +9,18 @@ export default async function processErc20Datum(
   readonlyDBConn: PoolClient,
   cdeDatum: CdeErc20TransferDatum
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const { from, to, value } = cdeDatum.payload;
 
   const fromAddr = from.toLowerCase();
   const toAddr = to.toLowerCase();
 
   const fromRow = await cdeErc20GetBalance.run(
-    { cde_id: cdeId, wallet_address: fromAddr },
+    { cde_name: cdeName, wallet_address: fromAddr },
     readonlyDBConn
   );
   const toRow = await cdeErc20GetBalance.run(
-    { cde_id: cdeId, wallet_address: toAddr },
+    { cde_name: cdeName, wallet_address: toAddr },
     readonlyDBConn
   );
 
@@ -34,7 +34,7 @@ export default async function processErc20Datum(
       updateList.push([
         cdeErc20UpdateBalance,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           wallet_address: fromAddr,
           balance: fromNewBalance.toString(10),
         },
@@ -47,7 +47,7 @@ export default async function processErc20Datum(
       updateList.push([
         cdeErc20UpdateBalance,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           wallet_address: toAddr,
           balance: toNewBalance.toString(10),
         },
@@ -56,7 +56,7 @@ export default async function processErc20Datum(
       updateList.push([
         cdeErc20InsertBalance,
         {
-          cde_id: cdeId,
+          cde_name: cdeName,
           wallet_address: toAddr,
           balance: value,
         },

--- a/packages/engine/paima-sm/src/cde-erc6551-registry.ts
+++ b/packages/engine/paima-sm/src/cde-erc6551-registry.ts
@@ -9,7 +9,7 @@ export default async function processErc721Datum(
     [
       cdeErc6551InsertRegistry,
       {
-        cde_id: cdeDatum.cdeId,
+        cde_name: cdeDatum.cdeName,
         block_height: cdeDatum.blockNumber,
         account_created: cdeDatum.payload.accountCreated,
         implementation: cdeDatum.payload.implementation,

--- a/packages/engine/paima-sm/src/cde-erc721-transfer.ts
+++ b/packages/engine/paima-sm/src/cde-erc721-transfer.ts
@@ -17,7 +17,7 @@ export default async function processErc721Datum(
   cdeDatum: CdeErc721TransferDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const { to, tokenId } = cdeDatum.payload;
   const toAddr = to.toLowerCase();
 
@@ -26,10 +26,10 @@ export default async function processErc721Datum(
   const updateList: SQLUpdate[] = [];
   try {
     const ownerRow = await cdeErc721GetOwner.run(
-      { cde_id: cdeId, token_id: tokenId },
+      { cde_name: cdeName, token_id: tokenId },
       readonlyDBConn
     );
-    const newOwnerData = { cde_id: cdeId, token_id: tokenId, nft_owner: toAddr };
+    const newOwnerData = { cde_name: cdeName, token_id: tokenId, nft_owner: toAddr };
     if (ownerRow.length > 0) {
       if (isBurn) {
         if (cdeDatum.burnScheduledPrefix) {
@@ -46,9 +46,9 @@ export default async function processErc721Datum(
         // burn address
         updateList.push([
           cdeErc721BurnInsert,
-          { cde_id: cdeId, token_id: tokenId, nft_owner: ownerRow[0].nft_owner },
+          { cde_name: cdeName, token_id: tokenId, nft_owner: ownerRow[0].nft_owner },
         ]);
-        updateList.push([cdeErc721Delete, { cde_id: cdeId, token_id: tokenId }]);
+        updateList.push([cdeErc721Delete, { cde_name: cdeName, token_id: tokenId }]);
       } else {
         updateList.push([cdeErc721UpdateOwner, newOwnerData]);
       }

--- a/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
@@ -1,4 +1,8 @@
-import { insertDynamicExtension, registerChainDataExtension } from '@paima/db';
+import {
+  insertDynamicExtension,
+  registerChainDataExtension,
+  registerDynamicChainDataExtension,
+} from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
 import { CdeEntryTypeName, type CdeDynamicEvmPrimitiveDatum } from './types.js';
 import { ChainDataExtensionType } from '@paima/utils';
@@ -18,7 +22,6 @@ export default async function processDatum(
   }
 
   const config = {
-    name: cdeDatum.cdeName,
     type: cdeDatum.payload.type,
     contractAddress: cdeDatum.payload.contractAddress,
     startBlockHeight: cdeDatum.blockNumber,
@@ -29,10 +32,10 @@ export default async function processDatum(
 
   const updateList: SQLUpdate[] = [
     [
-      registerChainDataExtension,
+      registerDynamicChainDataExtension,
       {
+        base_name: cdeDatum.cdeName,
         cde_type: type,
-        cde_name: cdeDatum.cdeName,
         start_blockheight: cdeDatum.blockNumber,
         scheduled_prefix: cdeDatum.scheduledPrefix,
       },
@@ -40,6 +43,7 @@ export default async function processDatum(
     [
       insertDynamicExtension,
       {
+        base_name: cdeDatum.cdeName,
         config: YAML.stringify(config),
       },
     ],

--- a/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
@@ -30,11 +30,13 @@ export default async function processDatum(
     network: cdeDatum.network,
   };
 
+  const baseName = `${cdeDatum.cdeName}##`;
+
   const updateList: SQLUpdate[] = [
     [
       registerDynamicChainDataExtension,
       {
-        base_name: `${cdeDatum.cdeName}##`,
+        base_name: baseName,
         cde_type: type,
         start_blockheight: cdeDatum.blockNumber,
         scheduled_prefix: cdeDatum.scheduledPrefix,
@@ -43,8 +45,9 @@ export default async function processDatum(
     [
       insertDynamicExtension,
       {
-        base_name: `${cdeDatum.cdeName}##`,
-        config: YAML.stringify(config),
+        base_name: baseName,
+        parent_name: cdeDatum.cdeName,
+        config: JSON.stringify(config),
       },
     ],
   ];

--- a/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
@@ -1,12 +1,7 @@
-import {
-  insertDynamicExtension,
-  registerChainDataExtension,
-  registerDynamicChainDataExtension,
-} from '@paima/db';
+import { insertDynamicExtension, registerDynamicChainDataExtension } from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
 import { CdeEntryTypeName, type CdeDynamicEvmPrimitiveDatum } from './types.js';
-import { ChainDataExtensionType } from '@paima/utils';
-import YAML from 'yaml';
+import { ChainDataExtensionType, DYNAMIC_PRIMITIVE_NAME_SEPARATOR } from '@paima/utils';
 
 export default async function processDatum(
   cdeDatum: CdeDynamicEvmPrimitiveDatum,
@@ -30,7 +25,7 @@ export default async function processDatum(
     network: cdeDatum.network,
   };
 
-  const baseName = `${cdeDatum.cdeName}##`;
+  const baseName = `${cdeDatum.cdeName}${DYNAMIC_PRIMITIVE_NAME_SEPARATOR}`;
 
   const updateList: SQLUpdate[] = [
     [

--- a/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
@@ -1,11 +1,11 @@
 import { insertDynamicExtension, registerChainDataExtension } from '@paima/db';
 import type { SQLUpdate } from '@paima/db';
-import { CdeEntryTypeName, type CdeDynamicPrimitiveDatum } from './types.js';
+import { CdeEntryTypeName, type CdeDynamicEvmPrimitiveDatum } from './types.js';
 import { ChainDataExtensionType } from '@paima/utils';
 import YAML from 'yaml';
 
 export default async function processDatum(
-  cdeDatum: CdeDynamicPrimitiveDatum,
+  cdeDatum: CdeDynamicEvmPrimitiveDatum,
   _inPresync: boolean
 ): Promise<SQLUpdate[]> {
   let type;

--- a/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
+++ b/packages/engine/paima-sm/src/cde-evm-dynamic-primitive.ts
@@ -34,7 +34,7 @@ export default async function processDatum(
     [
       registerDynamicChainDataExtension,
       {
-        base_name: cdeDatum.cdeName,
+        base_name: `${cdeDatum.cdeName}##`,
         cde_type: type,
         start_blockheight: cdeDatum.blockNumber,
         scheduled_prefix: cdeDatum.scheduledPrefix,
@@ -43,7 +43,7 @@ export default async function processDatum(
     [
       insertDynamicExtension,
       {
-        base_name: cdeDatum.cdeName,
+        base_name: `${cdeDatum.cdeName}##`,
         config: YAML.stringify(config),
       },
     ],

--- a/packages/engine/paima-sm/src/cde-generic.ts
+++ b/packages/engine/paima-sm/src/cde-generic.ts
@@ -11,7 +11,7 @@ export default async function processDatum(
   cdeDatum: CdeGenericDatum | CdeMinaEventGenericDatum | CdeMinaActionGenericDatum,
   inPresync: boolean
 ): Promise<SQLUpdate[]> {
-  const cdeId = cdeDatum.cdeId;
+  const cdeName = cdeDatum.cdeName;
   const blockHeight = cdeDatum.blockNumber;
   const payload = cdeDatum.payload;
   const prefix = cdeDatum.scheduledPrefix;
@@ -26,7 +26,7 @@ export default async function processDatum(
 
   updateList.push([
     cdeGenericInsertData,
-    { cde_id: cdeId, block_height: blockHeight, event_data: payload },
+    { cde_name: cdeName, block_height: blockHeight, event_data: payload },
   ]);
 
   return updateList;

--- a/packages/engine/paima-sm/src/cde-processing.ts
+++ b/packages/engine/paima-sm/src/cde-processing.ts
@@ -15,7 +15,7 @@ import processCardanoProjectedNFT from './cde-cardano-projected-nft.js';
 import processCardanoAssetUtxoDatum from './cde-cardano-delayed-asset.js';
 import processCardanoTransferDatum from './cde-cardano-transfer.js';
 import processCardanoMintBurnDatum from './cde-cardano-mint-burn.js';
-import processDynamicPrimitive from './cde-dynamic-primitive.js';
+import processDynamicEvmPrimitive from './cde-evm-dynamic-primitive.js';
 import assertNever from 'assert-never';
 import type { SQLUpdate } from '@paima/db';
 
@@ -53,8 +53,8 @@ export async function cdeTransitionFunction(
       return await processGenericDatum(cdeDatum, inPresync);
     case ChainDataExtensionDatumType.MinaActionGeneric:
       return await processGenericDatum(cdeDatum, inPresync);
-    case ChainDataExtensionDatumType.DynamicPrimitive:
-      return await processDynamicPrimitive(cdeDatum, inPresync);
+    case ChainDataExtensionDatumType.DynamicEvmPrimitive:
+      return await processDynamicEvmPrimitive(cdeDatum, inPresync);
     default:
       assertNever(cdeDatum);
   }

--- a/packages/engine/paima-sm/src/cde-processing.ts
+++ b/packages/engine/paima-sm/src/cde-processing.ts
@@ -15,13 +15,15 @@ import processCardanoProjectedNFT from './cde-cardano-projected-nft.js';
 import processCardanoAssetUtxoDatum from './cde-cardano-delayed-asset.js';
 import processCardanoTransferDatum from './cde-cardano-transfer.js';
 import processCardanoMintBurnDatum from './cde-cardano-mint-burn.js';
+import processDynamicPrimitive from './cde-dynamic-primitive.js';
 import assertNever from 'assert-never';
 import type { SQLUpdate } from '@paima/db';
 
 export async function cdeTransitionFunction(
   readonlyDBConn: PoolClient,
   cdeDatum: ChainDataExtensionDatum,
-  inPresync: boolean
+  inPresync: boolean,
+  reloadExtensions: () => void
 ): Promise<SQLUpdate[]> {
   switch (cdeDatum.cdeDatumType) {
     case ChainDataExtensionDatumType.ERC20Transfer:
@@ -52,6 +54,8 @@ export async function cdeTransitionFunction(
       return await processGenericDatum(cdeDatum, inPresync);
     case ChainDataExtensionDatumType.MinaActionGeneric:
       return await processGenericDatum(cdeDatum, inPresync);
+    case ChainDataExtensionDatumType.DynamicPrimitive:
+      return await processDynamicPrimitive(readonlyDBConn, cdeDatum, inPresync, reloadExtensions);
     default:
       assertNever(cdeDatum);
   }

--- a/packages/engine/paima-sm/src/cde-processing.ts
+++ b/packages/engine/paima-sm/src/cde-processing.ts
@@ -22,8 +22,7 @@ import type { SQLUpdate } from '@paima/db';
 export async function cdeTransitionFunction(
   readonlyDBConn: PoolClient,
   cdeDatum: ChainDataExtensionDatum,
-  inPresync: boolean,
-  reloadExtensions: () => void
+  inPresync: boolean
 ): Promise<SQLUpdate[]> {
   switch (cdeDatum.cdeDatumType) {
     case ChainDataExtensionDatumType.ERC20Transfer:
@@ -55,7 +54,7 @@ export async function cdeTransitionFunction(
     case ChainDataExtensionDatumType.MinaActionGeneric:
       return await processGenericDatum(cdeDatum, inPresync);
     case ChainDataExtensionDatumType.DynamicPrimitive:
-      return await processDynamicPrimitive(cdeDatum, inPresync, reloadExtensions);
+      return await processDynamicPrimitive(cdeDatum, inPresync);
     default:
       assertNever(cdeDatum);
   }

--- a/packages/engine/paima-sm/src/cde-processing.ts
+++ b/packages/engine/paima-sm/src/cde-processing.ts
@@ -55,7 +55,7 @@ export async function cdeTransitionFunction(
     case ChainDataExtensionDatumType.MinaActionGeneric:
       return await processGenericDatum(cdeDatum, inPresync);
     case ChainDataExtensionDatumType.DynamicPrimitive:
-      return await processDynamicPrimitive(readonlyDBConn, cdeDatum, inPresync, reloadExtensions);
+      return await processDynamicPrimitive(cdeDatum, inPresync, reloadExtensions);
     default:
       assertNever(cdeDatum);
   }

--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -102,11 +102,7 @@ const SM: GameStateMachineInitializer = {
       getReadWriteDbConn: (): Pool => {
         return DBConn;
       },
-      presyncProcess: async (
-        dbTx: PoolClient,
-        latestCdeData: PresyncChainData,
-        reloadExtensions: () => void
-      ): Promise<void> => {
+      presyncProcess: async (dbTx: PoolClient, latestCdeData: PresyncChainData): Promise<void> => {
         if (
           latestCdeData.networkType === ConfigNetworkType.EVM ||
           latestCdeData.networkType === ConfigNetworkType.EVM_OTHER
@@ -116,8 +112,7 @@ const SM: GameStateMachineInitializer = {
             latestCdeData.network,
             latestCdeData.extensionDatums,
             dbTx,
-            true,
-            reloadExtensions
+            true
           );
           if (cdeDataLength > 0) {
             doLog(
@@ -129,8 +124,7 @@ const SM: GameStateMachineInitializer = {
             latestCdeData.carpCursor,
             latestCdeData.extensionDatums,
             dbTx,
-            true,
-            reloadExtensions
+            true
           );
           if (cdeDataLength > 0) {
             doLog(
@@ -142,8 +136,7 @@ const SM: GameStateMachineInitializer = {
             latestCdeData.minaCursor,
             latestCdeData.extensionDatums,
             dbTx,
-            true,
-            reloadExtensions
+            true
           );
           if (cdeDataLength > 0) {
             doLog(
@@ -194,11 +187,7 @@ const SM: GameStateMachineInitializer = {
         }
       },
       // Core function which triggers state transitions
-      process: async (
-        dbTx: PoolClient,
-        latestChainData: ChainData,
-        reloadExtensions: () => void
-      ): Promise<void> => {
+      process: async (dbTx: PoolClient, latestChainData: ChainData): Promise<void> => {
         // Acquire correct STF based on router (based on block height)
         const gameStateTransition = gameStateTransitionRouter(latestChainData.blockNumber);
         // Save blockHeight and randomness seed
@@ -229,8 +218,7 @@ const SM: GameStateMachineInitializer = {
             network,
             extensionsPerNetwork[network],
             dbTx,
-            false,
-            reloadExtensions
+            false
           );
         }
 
@@ -278,15 +266,14 @@ async function processCdeDataBase(
   cdeData: ChainDataExtensionDatum[] | undefined,
   dbTx: PoolClient,
   inPresync: boolean,
-  markProcessed: () => Promise<void>,
-  reloadExtensions: () => void
+  markProcessed: () => Promise<void>
 ): Promise<number> {
   if (!cdeData) {
     return 0;
   }
 
   for (const datum of cdeData) {
-    const sqlQueries = await cdeTransitionFunction(dbTx, datum, inPresync, reloadExtensions);
+    const sqlQueries = await cdeTransitionFunction(dbTx, datum, inPresync);
     try {
       for (const [query, params] of sqlQueries) {
         await query.run(params, dbTx);
@@ -311,59 +298,45 @@ async function processCdeData(
   network: string,
   cdeData: ChainDataExtensionDatum[] | undefined,
   dbTx: PoolClient,
-  inPresync: boolean,
-  reloadExtensions: () => void
+  inPresync: boolean
 ): Promise<number> {
   const [mainNetwork, _] = await GlobalConfig.mainEvmConfig();
-  return await processCdeDataBase(
-    cdeData,
-    dbTx,
-    inPresync,
-    async () => {
-      // During the presync,
-      //     we know that the block_height is for that network in particular,
-      //     since the block heights are not mapped in that phase.
-      // During the sync,
-      //     the blockHeight we are processing here is for the main network instead,
-      //     which doesn't make sense for cde's from other networks.
-      // To tackle this, we have 2 options:
-      //     1. Store the original block in ChainDataExtensionDatum
-      //        and then use it to update here
-      //     2. (what we picked) Through the internal events (see EvmLastBlock)
-      if (inPresync || network == mainNetwork) {
-        await markCdeBlockheightProcessed.run({ block_height: blockHeight, network }, dbTx);
-      }
-      return;
-    },
-    reloadExtensions
-  );
+  return await processCdeDataBase(cdeData, dbTx, inPresync, async () => {
+    // During the presync,
+    //     we know that the block_height is for that network in particular,
+    //     since the block heights are not mapped in that phase.
+    // During the sync,
+    //     the blockHeight we are processing here is for the main network instead,
+    //     which doesn't make sense for cde's from other networks.
+    // To tackle this, we have 2 options:
+    //     1. Store the original block in ChainDataExtensionDatum
+    //        and then use it to update here
+    //     2. (what we picked) Through the internal events (see EvmLastBlock)
+    if (inPresync || network == mainNetwork) {
+      await markCdeBlockheightProcessed.run({ block_height: blockHeight, network }, dbTx);
+    }
+    return;
+  });
 }
 
 async function processPaginatedCdeData(
   paginationCursor: { cdeId: number; cursor: string; finished: boolean },
   cdeData: ChainDataExtensionDatum[] | undefined,
   dbTx: PoolClient,
-  inPresync: boolean,
-  reloadExtensions: () => void
+  inPresync: boolean
 ): Promise<number> {
-  return await processCdeDataBase(
-    cdeData,
-    dbTx,
-    inPresync,
-    async () => {
-      await updatePaginationCursor.run(
-        {
-          cde_id: paginationCursor.cdeId,
-          cursor: paginationCursor.cursor,
-          finished: paginationCursor.finished,
-        },
-        dbTx
-      );
+  return await processCdeDataBase(cdeData, dbTx, inPresync, async () => {
+    await updatePaginationCursor.run(
+      {
+        cde_id: paginationCursor.cdeId,
+        cursor: paginationCursor.cursor,
+        finished: paginationCursor.finished,
+      },
+      dbTx
+    );
 
-      return;
-    },
-    reloadExtensions
-  );
+    return;
+  });
 }
 
 // Process all of the scheduled data inputs by running each of them through the game STF,

--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -30,6 +30,7 @@ import {
   updateCardanoEpoch,
   updatePaginationCursor,
   updateMinaCheckpoint,
+  getChainDataExtensions,
 } from '@paima/db';
 import Prando from '@paima/prando';
 
@@ -320,7 +321,7 @@ async function processCdeData(
 }
 
 async function processPaginatedCdeData(
-  paginationCursor: { cdeId: number; cursor: string; finished: boolean },
+  paginationCursor: { cdeName: string; cursor: string; finished: boolean },
   cdeData: ChainDataExtensionDatum[] | undefined,
   dbTx: PoolClient,
   inPresync: boolean
@@ -328,7 +329,7 @@ async function processPaginatedCdeData(
   return await processCdeDataBase(cdeData, dbTx, inPresync, async () => {
     await updatePaginationCursor.run(
       {
-        cde_id: paginationCursor.cdeId,
+        cde_name: paginationCursor.cdeName,
         cursor: paginationCursor.cursor,
         finished: paginationCursor.finished,
       },

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -540,13 +540,15 @@ export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
   ChainDataExtensionConfigBase,
   Type.Object({
     type: Type.Literal(CdeEntryTypeName.DynamicPrimitive),
-    targetType: Type.Literal(CdeEntryTypeName.ERC721),
     contractAddress: EvmAddress,
-    scheduledPrefix: Type.String(),
-    burnScheduledPrefix: Type.Optional(Type.String()),
     abiPath: Type.String(),
     eventSignature: Type.String(),
-    fields: Type.Object({
+    targetConfig: Type.Pick(ChainDataExtensionErc721Config, [
+      'scheduledPrefix',
+      'burnScheduledPrefix',
+      'type',
+    ]),
+    dynamicFields: Type.Object({
       contractAddress: Type.String(),
     }),
   }),

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -539,10 +539,7 @@ export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
   ChainDataExtensionConfigBase,
   Type.Object({
     type: Type.Literal(CdeEntryTypeName.DynamicPrimitive),
-    targetType: Type.Union([
-      Type.Literal(CdeEntryTypeName.ERC721),
-      Type.Literal(CdeEntryTypeName.ERC20),
-    ]),
+    targetType: Type.Literal(CdeEntryTypeName.ERC721),
     contractAddress: EvmAddress,
     scheduledPrefix: Type.String(),
     abiPath: Type.String(),

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -340,7 +340,6 @@ export type ChainDataExtensionErc20 = ChainDataExtensionBase &
   Static<typeof ChainDataExtensionErc20Config> & {
     cdeType: ChainDataExtensionType.ERC20;
     contract: ERC20Contract;
-    dynamic: boolean;
   };
 
 export const ChainDataExtensionErc721Config = Type.Intersect([
@@ -358,7 +357,6 @@ export type ChainDataExtensionErc721 = ChainDataExtensionBase &
   Static<typeof ChainDataExtensionErc721Config> & {
     cdeType: ChainDataExtensionType.ERC721;
     contract: ERC721Contract;
-    dynamic: boolean;
   };
 
 /** same as ERC721, but with a different type flag (see isPaimaErc721) */
@@ -649,12 +647,8 @@ export interface GameStateMachine {
   getReadonlyDbConn: () => Pool;
   getPersistentReadonlyDbConn: () => Client;
   getReadWriteDbConn: () => Pool;
-  process: (dbTx: PoolClient, chainData: ChainData, reloadExtensions: () => void) => Promise<void>;
-  presyncProcess: (
-    dbTx: PoolClient,
-    latestCdeData: PresyncChainData,
-    reloadExtensions: () => void
-  ) => Promise<void>;
+  process: (dbTx: PoolClient, chainData: ChainData) => Promise<void>;
+  presyncProcess: (dbTx: PoolClient, latestCdeData: PresyncChainData) => Promise<void>;
   markPresyncMilestone: (blockHeight: number, network: string) => Promise<void>;
   dryRun: (gameInput: string, userAddress: string) => Promise<boolean>;
 }

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -279,6 +279,7 @@ export interface CdeDynamicPrimitiveDatum extends CdeDatumBase {
   cdeDatumType: ChainDataExtensionDatumType.DynamicPrimitive;
   payload: CdeDatumDynamicPrimitivePayload;
   scheduledPrefix: string;
+  burnScheduledPrefix?: string | undefined;
   cdeName: string;
 }
 
@@ -542,6 +543,7 @@ export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
     targetType: Type.Literal(CdeEntryTypeName.ERC721),
     contractAddress: EvmAddress,
     scheduledPrefix: Type.String(),
+    burnScheduledPrefix: Type.Optional(Type.String()),
     abiPath: Type.String(),
     eventSignature: Type.String(),
     fields: Type.Object({

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -542,6 +542,9 @@ export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
     scheduledPrefix: Type.String(),
     abiPath: Type.String(),
     eventSignature: Type.String(),
+    fields: Type.Object({
+      contractAddress: Type.String(),
+    }),
   }),
 ]);
 export type TChainDataExtensionDynamicPrimitiveConfig = Static<

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -164,6 +164,7 @@ interface CdeDatumCardanoMintBurnPayload {
 
 interface CdeDatumDynamicPrimitivePayload {
   contractAddress: string;
+  type: CdeEntryTypeName;
 }
 
 type ChainDataExtensionPayload =
@@ -538,6 +539,10 @@ export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
   ChainDataExtensionConfigBase,
   Type.Object({
     type: Type.Literal(CdeEntryTypeName.DynamicPrimitive),
+    targetType: Type.Union([
+      Type.Literal(CdeEntryTypeName.ERC721),
+      Type.Literal(CdeEntryTypeName.ERC20),
+    ]),
     contractAddress: EvmAddress,
     scheduledPrefix: Type.String(),
     abiPath: Type.String(),

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -162,7 +162,7 @@ interface CdeDatumCardanoMintBurnPayload {
   outputAddresses: { [address: string]: { policyId: string; assetName: string; amount: string }[] };
 }
 
-interface CdeDatumDynamicPrimitivePayload {
+interface CdeDatumDynamicEvmPrimitivePayload {
   contractAddress: string;
   type: CdeEntryTypeName;
 }
@@ -178,7 +178,7 @@ type ChainDataExtensionPayload =
   | CdeDatumErc6551RegistryPayload
   | CdeDatumCardanoPoolPayload
   | CdeDatumCardanoProjectedNFTPayload
-  | CdeDatumDynamicPrimitivePayload;
+  | CdeDatumDynamicEvmPrimitivePayload;
 
 interface CdeDatumBase {
   cdeId: number;
@@ -275,9 +275,9 @@ export interface CdeMinaActionGenericDatum extends CdeDatumBase {
   paginationCursor: { cursor: string; finished: boolean };
   scheduledPrefix: string;
 }
-export interface CdeDynamicPrimitiveDatum extends CdeDatumBase {
-  cdeDatumType: ChainDataExtensionDatumType.DynamicPrimitive;
-  payload: CdeDatumDynamicPrimitivePayload;
+export interface CdeDynamicEvmPrimitiveDatum extends CdeDatumBase {
+  cdeDatumType: ChainDataExtensionDatumType.DynamicEvmPrimitive;
+  payload: CdeDatumDynamicEvmPrimitivePayload;
   scheduledPrefix: string;
   burnScheduledPrefix?: string | undefined;
   cdeName: string;
@@ -298,7 +298,7 @@ export type ChainDataExtensionDatum =
   | CdeCardanoMintBurnDatum
   | CdeMinaEventGenericDatum
   | CdeMinaActionGenericDatum
-  | CdeDynamicPrimitiveDatum;
+  | CdeDynamicEvmPrimitiveDatum;
 
 export enum CdeEntryTypeName {
   Generic = 'generic',
@@ -314,7 +314,7 @@ export enum CdeEntryTypeName {
   CardanoMintBurn = 'cardano-mint-burn',
   MinaEventGeneric = 'mina-event-generic',
   MinaActionGeneric = 'mina-action-generic',
-  DynamicPrimitive = 'dynamic-primitive',
+  DynamicEvmPrimitive = 'dynamic-evm-primitive',
 }
 
 const EvmAddress = Type.Transform(Type.RegExp('0x[0-9a-fA-F]{40}'))
@@ -536,10 +536,10 @@ export type ChainDataExtensionMinaActionGeneric = ChainDataExtensionBase &
     cdeType: ChainDataExtensionType.MinaActionGeneric;
   };
 
-export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
+export const ChainDataExtensionDynamicEvmPrimitiveConfig = Type.Intersect([
   ChainDataExtensionConfigBase,
   Type.Object({
-    type: Type.Literal(CdeEntryTypeName.DynamicPrimitive),
+    type: Type.Literal(CdeEntryTypeName.DynamicEvmPrimitive),
     contractAddress: EvmAddress,
     abiPath: Type.String(),
     eventSignature: Type.String(),
@@ -553,12 +553,12 @@ export const ChainDataExtensionDynamicPrimitiveConfig = Type.Intersect([
     }),
   }),
 ]);
-export type TChainDataExtensionDynamicPrimitiveConfig = Static<
-  typeof ChainDataExtensionDynamicPrimitiveConfig
+export type TChainDataExtensionDynamicEvmPrimitiveConfig = Static<
+  typeof ChainDataExtensionDynamicEvmPrimitiveConfig
 >;
-export type ChainDataExtensionDynamicPrimitive = ChainDataExtensionBase &
-  Omit<Static<typeof ChainDataExtensionDynamicPrimitiveConfig>, 'abiPath'> & {
-    cdeType: ChainDataExtensionType.DynamicPrimitive;
+export type ChainDataExtensionDynamicEvmPrimitive = ChainDataExtensionBase &
+  Omit<Static<typeof ChainDataExtensionDynamicEvmPrimitiveConfig>, 'abiPath'> & {
+    cdeType: ChainDataExtensionType.DynamicEvmPrimitive;
     contract: Contract;
     eventSignatureHash: string;
     eventName: string;
@@ -581,7 +581,7 @@ export const CdeConfig = Type.Object({
         ChainDataExtensionCardanoMintBurnConfig,
         ChainDataExtensionMinaEventGenericConfig,
         ChainDataExtensionMinaActionGenericConfig,
-        ChainDataExtensionDynamicPrimitiveConfig,
+        ChainDataExtensionDynamicEvmPrimitiveConfig,
       ]),
       Type.Partial(Type.Object({ network: Type.String() })),
     ])
@@ -616,7 +616,7 @@ export type ChainDataExtension = (
   | ChainDataExtensionCardanoMintBurn
   | ChainDataExtensionMinaEventGeneric
   | ChainDataExtensionMinaActionGeneric
-  | ChainDataExtensionDynamicPrimitive
+  | ChainDataExtensionDynamicEvmPrimitive
 ) & { network: string | undefined };
 
 export type GameStateTransitionFunctionRouter = (

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -58,14 +58,14 @@ export interface EvmPresyncChainData {
 export interface CardanoPresyncChainData {
   network: string;
   networkType: ConfigNetworkType.CARDANO;
-  carpCursor: { cdeId: number; cursor: string; finished: boolean };
+  carpCursor: { cdeName: string; cursor: string; finished: boolean };
   extensionDatums: ChainDataExtensionDatum[];
 }
 
 export interface MinaPresyncChainData {
   network: string;
   networkType: ConfigNetworkType.MINA;
-  minaCursor: { cdeId: number; cursor: string; finished: boolean };
+  minaCursor: { cdeName: string; cursor: string; finished: boolean };
   extensionDatums: ChainDataExtensionDatum[];
 }
 
@@ -181,7 +181,7 @@ type ChainDataExtensionPayload =
   | CdeDatumDynamicEvmPrimitivePayload;
 
 interface CdeDatumBase {
-  cdeId: number;
+  cdeName: string;
   cdeDatumType: ChainDataExtensionDatumType;
   blockNumber: number;
   payload: ChainDataExtensionPayload;
@@ -280,7 +280,6 @@ export interface CdeDynamicEvmPrimitiveDatum extends CdeDatumBase {
   payload: CdeDatumDynamicEvmPrimitivePayload;
   scheduledPrefix: string;
   burnScheduledPrefix?: string | undefined;
-  cdeName: string;
 }
 
 export type ChainDataExtensionDatum =
@@ -326,7 +325,7 @@ const ChainDataExtensionConfigBase = Type.Object({
   startBlockHeight: Type.Number(),
 });
 interface ChainDataExtensionBase {
-  cdeId: number;
+  cdeName: string;
   hash: number; // hash of the CDE config that created this type
 }
 

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -340,6 +340,7 @@ export type ChainDataExtensionErc20 = ChainDataExtensionBase &
   Static<typeof ChainDataExtensionErc20Config> & {
     cdeType: ChainDataExtensionType.ERC20;
     contract: ERC20Contract;
+    dynamic: boolean;
   };
 
 export const ChainDataExtensionErc721Config = Type.Intersect([
@@ -357,6 +358,7 @@ export type ChainDataExtensionErc721 = ChainDataExtensionBase &
   Static<typeof ChainDataExtensionErc721Config> & {
     cdeType: ChainDataExtensionType.ERC721;
     contract: ERC721Contract;
+    dynamic: boolean;
   };
 
 /** same as ERC721, but with a different type flag (see isPaimaErc721) */

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -122,8 +122,7 @@ export const runPaimaEngine = async (): Promise<void> => {
     // Import & initialize state machine
     const stateMachine = gameSM();
     const funnelFactory = await FunnelFactory.initialize(
-      config.chainUri,
-      config.paimaL2ContractAddress
+      await stateMachine.getReadonlyDbConn().connect()
     );
     const engine = paimaRuntime.initialize(funnelFactory, stateMachine, ENV.GAME_NODE_VERSION);
 

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -111,7 +111,8 @@ export const runPaimaEngine = async (): Promise<void> => {
     process.exit(0);
   }
 
-  const [, config] = await GlobalConfig.mainEvmConfig();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, config] = await GlobalConfig.mainEvmConfig();
 
   // Check that packed game code is available
   if (checkForPackedGameCode()) {

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -37,7 +37,7 @@ CREATE TABLE chain_data_extensions (
   cde_id INTEGER PRIMARY KEY,
   cde_type INTEGER NOT NULL,
   cde_name TEXT NOT NULL,
-  cde_hash integer NOT NULL,
+  cde_hash INTEGER,
   start_blockheight INTEGER NOT NULL,
   scheduled_prefix TEXT
 );

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -34,68 +34,67 @@ CREATE TABLE cde_tracking_cardano (
 );
 
 CREATE TABLE chain_data_extensions (
-  cde_id INTEGER PRIMARY KEY,
+  cde_name TEXT PRIMARY KEY,
   cde_type INTEGER NOT NULL,
-  cde_name TEXT NOT NULL,
   cde_hash INTEGER,
   start_blockheight INTEGER NOT NULL,
   scheduled_prefix TEXT
 );
 
 CREATE TABLE cde_erc20_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   balance TEXT NOT NULL,
-  PRIMARY KEY (cde_id, wallet_address)
+  PRIMARY KEY (cde_name, wallet_address)
 );
 
 CREATE TABLE cde_erc721_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   nft_owner TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id)
+  PRIMARY KEY (cde_name, token_id)
 );
 
 CREATE TABLE cde_erc721_burn (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   nft_owner TEXT NOT NULL,
-  PRIMARY KEY(cde_id, token_id)
+  PRIMARY KEY(cde_name, token_id)
 );
 
 CREATE TABLE cde_erc1155_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   balance TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id, wallet_address)
+  PRIMARY KEY (cde_name, token_id, wallet_address)
 );
 
 CREATE TABLE cde_erc1155_burn (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   balance TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id, wallet_address)
+  PRIMARY KEY (cde_name, token_id, wallet_address)
 );
 
 CREATE TABLE cde_erc20_deposit_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   total_deposited TEXT NOT NULL,
-  PRIMARY KEY (cde_id, wallet_address)
+  PRIMARY KEY (cde_name, wallet_address)
 );
 
 CREATE TABLE cde_generic_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   id SERIAL,
   block_height INTEGER NOT NULL,
   event_data JSON NOT NULL,
-  PRIMARY KEY (cde_id, id)
+  PRIMARY KEY (cde_name, id)
 );
 
 CREATE TABLE cde_erc6551_registry_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   block_height INTEGER NOT NULL,
   account_created TEXT NOT NULL,
   implementation TEXT NOT NULL,
@@ -103,7 +102,7 @@ CREATE TABLE cde_erc6551_registry_data (
   token_id TEXT NOT NULL,
   chain_id TEXT NOT NULL,
   salt TEXT NOT NULL,
-  PRIMARY KEY (cde_id, account_created)
+  PRIMARY KEY (cde_name, account_created)
 );
 
 CREATE TABLE emulated_block_heights (
@@ -177,11 +176,11 @@ CREATE OR REPLACE TRIGGER wallet_connect_insert_or_update
 
 
 CREATE TABLE cde_cardano_pool_delegation (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   epoch INTEGER NOT NULL,
   address TEXT NOT NULL,
   pool TEXT,
-  PRIMARY KEY (cde_id, epoch, address)
+  PRIMARY KEY (cde_name, epoch, address)
 );
 
 CREATE TABLE cardano_last_epoch (
@@ -190,7 +189,7 @@ CREATE TABLE cardano_last_epoch (
 );
 
 CREATE TABLE cde_cardano_projected_nft (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   id SERIAL,
   owner_address TEXT NOT NULL,
   previous_tx_hash TEXT,
@@ -203,11 +202,11 @@ CREATE TABLE cde_cardano_projected_nft (
   status TEXT NOT NULL,
   plutus_datum TEXT NOT NULL,
   for_how_long BIGINT,
-  PRIMARY KEY (cde_id, id)
+  PRIMARY KEY (cde_name, id)
 );
 
 CREATE TABLE cde_cardano_asset_utxos (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   address TEXT NOT NULL,
   tx_id TEXT NOT NULL,
   output_index INTEGER NOT NULL,
@@ -215,31 +214,31 @@ CREATE TABLE cde_cardano_asset_utxos (
   cip14_fingerprint TEXT NOT NULL,
   policy_id TEXT NOT NULL,
   asset_name TEXT NOT NULL,
-  PRIMARY KEY(cde_id,tx_id,output_index,cip14_fingerprint)
+  PRIMARY KEY(cde_name,tx_id,output_index,cip14_fingerprint)
 );
 
 CREATE TABLE cde_tracking_cursor_pagination (
-  cde_id INTEGER PRIMARY KEY,
+  cde_name TEXT PRIMARY KEY,
   cursor TEXT NOT NULL,
   finished BOOLEAN NOT NULL
 );
 
 CREATE TABLE cde_cardano_transfer (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   tx_id TEXT NOT NULL,
   raw_tx TEXT NOT NULL,
   metadata TEXT,
-  PRIMARY KEY (cde_id, tx_id)
+  PRIMARY KEY (cde_name, tx_id)
 );
 
 CREATE TABLE cde_cardano_mint_burn(
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   tx_id TEXT NOT NULL,
   metadata TEXT NOT NULL,
   assets JSONB NOT NULL,
   input_addresses JSONB NOT NULL,
   output_addresses JSONB NOT NULL,
-  PRIMARY KEY (cde_id, tx_id)
+  PRIMARY KEY (cde_name, tx_id)
 );
 
 CREATE TABLE mina_checkpoint (
@@ -258,7 +257,7 @@ CREATE TABLE achievement_progress(
 );
 
 CREATE TABLE cde_dynamic_primitive_config (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   config TEXT NOT NULL,
-  PRIMARY KEY(cde_id)
+  PRIMARY KEY(cde_name)
 );

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -256,3 +256,9 @@ CREATE TABLE achievement_progress(
   total INTEGER,
   PRIMARY KEY (wallet, name)
 );
+
+CREATE TABLE cde_dynamic_primitive_config (
+  cde_id INTEGER NOT NULL,
+  config TEXT NOT NULL,
+  PRIMARY KEY(cde_id)
+);

--- a/packages/node-sdk/paima-db/migrations/up.sql
+++ b/packages/node-sdk/paima-db/migrations/up.sql
@@ -258,6 +258,7 @@ CREATE TABLE achievement_progress(
 
 CREATE TABLE cde_dynamic_primitive_config (
   cde_name TEXT NOT NULL,
+  parent TEXT NOT NULL,
   config TEXT NOT NULL,
   PRIMARY KEY(cde_name)
 );

--- a/packages/node-sdk/paima-db/src/index.ts
+++ b/packages/node-sdk/paima-db/src/index.ts
@@ -60,6 +60,8 @@ export type * from './sql/cde-cardano-transfer.queries.js';
 export { cdeCardanoMintBurnInsert } from './sql/cde-cardano-mint-burn.queries.js';
 export type * from './sql/mina-checkpoints.queries.js';
 export * from './sql/mina-checkpoints.queries.js';
+export type * from './sql/dynamic-primitives.queries.js';
+export * from './sql/dynamic-primitives.queries.js';
 
 export {
   tx,

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -120,7 +120,7 @@ const TABLE_DATA_CDE_TRACKING_CARDANO: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_TRACKING_CURSOR_PAGINATION = `
 CREATE TABLE cde_tracking_cursor_pagination (
-  cde_id INTEGER PRIMARY KEY,
+  cde_name TEXT PRIMARY KEY,
   cursor TEXT NOT NULL,
   finished BOOLEAN NOT NULL
 );
@@ -128,9 +128,9 @@ CREATE TABLE cde_tracking_cursor_pagination (
 
 const TABLE_DATA_CDE_TRACKING_CURSOR_PAGINATION: TableData = {
   tableName: 'cde_tracking_cursor_pagination',
-  primaryKeyColumns: ['cde_id'],
+  primaryKeyColumns: ['cde_name'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['cursor', 'text', 'NO', ''],
     ['finished', 'boolean', 'NO', ''],
   ]),
@@ -140,9 +140,8 @@ const TABLE_DATA_CDE_TRACKING_CURSOR_PAGINATION: TableData = {
 
 const QUERY_CREATE_TABLE_CDE = `
 CREATE TABLE chain_data_extensions (
-  cde_id INTEGER PRIMARY KEY,
+  cde_name TEXT PRIMARY KEY,
   cde_type INTEGER NOT NULL,
-  cde_name TEXT NOT NULL,
   cde_hash INTEGER,
   start_blockheight INTEGER NOT NULL,
   scheduled_prefix TEXT
@@ -151,9 +150,8 @@ CREATE TABLE chain_data_extensions (
 
 const TABLE_DATA_CDE: TableData = {
   tableName: 'chain_data_extensions',
-  primaryKeyColumns: ['cde_id'],
+  primaryKeyColumns: ['cde_name'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
     ['cde_type', 'integer', 'NO', ''],
     ['cde_name', 'text', 'NO', ''],
     ['cde_hash', 'integer', 'YES', ''],
@@ -166,18 +164,18 @@ const TABLE_DATA_CDE: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC20 = `
 CREATE TABLE cde_erc20_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   balance TEXT NOT NULL,
-  PRIMARY KEY (cde_id, wallet_address)
+  PRIMARY KEY (cde_name, wallet_address)
 );
 `;
 
 const TABLE_DATA_CDE_ERC20: TableData = {
   tableName: 'cde_erc20_data',
-  primaryKeyColumns: ['cde_id', 'wallet_address'],
+  primaryKeyColumns: ['cde_name', 'wallet_address'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['wallet_address', 'text', 'NO', ''],
     ['balance', 'text', 'NO', ''],
   ]),
@@ -187,18 +185,18 @@ const TABLE_DATA_CDE_ERC20: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC721 = `
 CREATE TABLE cde_erc721_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   nft_owner TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id)
+  PRIMARY KEY (cde_name, token_id)
 );
 `;
 
 const TABLE_DATA_CDE_ERC721: TableData = {
   tableName: 'cde_erc721_data',
-  primaryKeyColumns: ['cde_id', 'token_id'],
+  primaryKeyColumns: ['cde_name', 'token_id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['token_id', 'text', 'NO', ''],
     ['nft_owner', 'text', 'NO', ''],
   ]),
@@ -208,18 +206,18 @@ const TABLE_DATA_CDE_ERC721: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC721_BURN = `
 CREATE TABLE cde_erc721_burn (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   nft_owner TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id)
+  PRIMARY KEY (cde_name, token_id)
 );
 `;
 
 const TABLE_DATA_CDE_ERC721_BURN: TableData = {
   tableName: 'cde_erc721_burn',
-  primaryKeyColumns: ['cde_id', 'token_id'],
+  primaryKeyColumns: ['cde_name', 'token_id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['token_id', 'text', 'NO', ''],
     ['nft_owner', 'text', 'NO', ''],
   ]),
@@ -229,19 +227,19 @@ const TABLE_DATA_CDE_ERC721_BURN: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC1155_DATA = `
 CREATE TABLE cde_erc1155_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   balance TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id, wallet_address)
+  PRIMARY KEY (cde_name, token_id, wallet_address)
 );
 `;
 
 const TABLE_DATA_CDE_ERC1155_DATA: TableData = {
   tableName: 'cde_erc1155_data',
-  primaryKeyColumns: ['cde_id', 'token_id'],
+  primaryKeyColumns: ['cde_name', 'token_id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['token_id', 'text', 'NO', ''],
     ['wallet_address', 'text', 'NO', ''],
     ['balance', 'text', 'NO', ''],
@@ -252,19 +250,19 @@ const TABLE_DATA_CDE_ERC1155_DATA: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC1155_BURN = `
 CREATE TABLE cde_erc1155_burn (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   token_id TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   balance TEXT NOT NULL,
-  PRIMARY KEY (cde_id, token_id, wallet_address)
+  PRIMARY KEY (cde_name, token_id, wallet_address)
 );
 `;
 
 const TABLE_DATA_CDE_ERC1155_BURN: TableData = {
   tableName: 'cde_erc1155_burn',
-  primaryKeyColumns: ['cde_id', 'token_id'],
+  primaryKeyColumns: ['cde_name', 'token_id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['token_id', 'text', 'NO', ''],
     ['wallet_address', 'text', 'NO', ''],
     ['balance', 'text', 'NO', ''],
@@ -275,18 +273,18 @@ const TABLE_DATA_CDE_ERC1155_BURN: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC20_DEPOSIT = `
 CREATE TABLE cde_erc20_deposit_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   wallet_address TEXT NOT NULL,
   total_deposited TEXT NOT NULL,
-  PRIMARY KEY (cde_id, wallet_address)
+  PRIMARY KEY (cde_name, wallet_address)
 );
 `;
 
 const TABLE_DATA_CDE_ERC20_DEPOSIT: TableData = {
   tableName: 'cde_erc20_deposit_data',
-  primaryKeyColumns: ['cde_id', 'wallet_address'],
+  primaryKeyColumns: ['cde_name', 'wallet_address'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['wallet_address', 'text', 'NO', ''],
     ['total_deposited', 'text', 'NO', ''],
   ]),
@@ -296,19 +294,19 @@ const TABLE_DATA_CDE_ERC20_DEPOSIT: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_GENERIC_DATA = `
 CREATE TABLE cde_generic_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   id SERIAL,
   block_height INTEGER NOT NULL,
   event_data JSON NOT NULL,
-  PRIMARY KEY (cde_id, id)
+  PRIMARY KEY (cde_name, id)
 );
 `;
 
 const TABLE_DATA_CDE_GENERIC_DATA: TableData = {
   tableName: 'cde_generic_data',
-  primaryKeyColumns: ['cde_id', 'id'],
+  primaryKeyColumns: ['cde_name', 'id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['id', 'integer', 'NO', ''],
     ['block_height', 'integer', 'NO', ''],
     ['event_data', 'json', 'NO', ''],
@@ -319,7 +317,7 @@ const TABLE_DATA_CDE_GENERIC_DATA: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_ERC6551_REGISTRY = `
 CREATE TABLE cde_erc6551_registry_data (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   block_height INTEGER NOT NULL,
   account_created TEXT NOT NULL,
   implementation TEXT NOT NULL,
@@ -327,15 +325,15 @@ CREATE TABLE cde_erc6551_registry_data (
   token_id TEXT NOT NULL,
   chain_id TEXT NOT NULL,
   salt TEXT NOT NULL,
-  PRIMARY KEY (cde_id, account_created)
+  PRIMARY KEY (cde_name, account_created)
 );
 `;
 
 const TABLE_DATA_CDE_ERC6551_REGISTRY: TableData = {
   tableName: 'cde_erc6551_registry_data',
-  primaryKeyColumns: ['cde_id', 'account_created'],
+  primaryKeyColumns: ['cde_name', 'account_created'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['block_height', 'integer', 'NO', ''],
     ['account_created', 'text', 'NO', ''],
     ['implementation', 'text', 'NO', ''],
@@ -350,19 +348,19 @@ const TABLE_DATA_CDE_ERC6551_REGISTRY: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_CARDANO_POOL = `
 CREATE TABLE cde_cardano_pool_delegation (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   epoch INTEGER NOT NULL,
   address TEXT NOT NULL,
   pool TEXT,
-  PRIMARY KEY (cde_id, epoch, address)
+  PRIMARY KEY (cde_name, epoch, address)
 );
 `;
 
 const TABLE_DATA_CDE_CARDANO_POOL: TableData = {
   tableName: 'cde_cardano_pool_delegation',
-  primaryKeyColumns: ['cde_id', 'epoch', 'address'],
+  primaryKeyColumns: ['cde_name', 'epoch', 'address'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['epoch', 'integer', 'NO', ''],
     ['address', 'text', 'NO', ''],
     ['pool', 'text', 'YES', ''],
@@ -373,7 +371,7 @@ const TABLE_DATA_CDE_CARDANO_POOL: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_CARDANO_PROJECTED_NFT = `
 CREATE TABLE cde_cardano_projected_nft (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   id SERIAL,
   owner_address TEXT NOT NULL,
   previous_tx_hash TEXT,
@@ -386,15 +384,15 @@ CREATE TABLE cde_cardano_projected_nft (
   status TEXT NOT NULL,
   plutus_datum TEXT NOT NULL,
   for_how_long BIGINT,
-  PRIMARY KEY (cde_id, id)
+  PRIMARY KEY (cde_name, id)
 )
 `;
 
 const TABLE_DATA_CDE_CARDANO_PROJECTED_NFT: TableData = {
   tableName: 'cde_cardano_projected_nft',
-  primaryKeyColumns: ['cde_id', 'id'],
+  primaryKeyColumns: ['cde_name', 'id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['id', 'integer', 'NO', ''],
     ['owner_address', 'text', 'NO', ''],
     ['previous_tx_hash', 'text', 'YES', ''],
@@ -432,7 +430,7 @@ const TABLE_DATA_CARDANO_LAST_EPOCH: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_CARDANO_ASSET_UTXOS = `
 CREATE TABLE cde_cardano_asset_utxos (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   address TEXT NOT NULL,
   tx_id TEXT NOT NULL,
   output_index INTEGER NOT NULL,
@@ -440,7 +438,7 @@ CREATE TABLE cde_cardano_asset_utxos (
   cip14_fingerprint TEXT NOT NULL,
   policy_id text NOT NULL,
   asset_name text NOT NULL,
-  PRIMARY KEY(cde_id,tx_id,output_index,cip14_fingerprint)
+  PRIMARY KEY(cde_name,tx_id,output_index,cip14_fingerprint)
 );
 `;
 
@@ -450,9 +448,9 @@ CREATE INDEX CDE_CARDANO_ASSET_UTXOS_ADDRESS_INDEX ON "cde_cardano_asset_utxos" 
 
 const TABLE_DATA_CDE_CARDANO_ASSET_UTXOS: TableData = {
   tableName: 'cde_cardano_asset_utxos',
-  primaryKeyColumns: ['cde_id', 'tx_id', 'output_index'],
+  primaryKeyColumns: ['cde_name', 'tx_id', 'output_index'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['address', 'text', 'NO', ''],
     ['tx_id', 'text', 'NO', ''],
     ['output_index', 'integer', 'NO', ''],
@@ -471,19 +469,19 @@ const TABLE_DATA_CDE_CARDANO_ASSET_UTXOS: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_CARDANO_TRANSFER = `
 CREATE TABLE cde_cardano_transfer (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   tx_id TEXT NOT NULL,
   raw_tx TEXT NOT NULL,
   metadata TEXT,
-  PRIMARY KEY (cde_id, tx_id)
+  PRIMARY KEY (cde_name, tx_id)
 )
 `;
 
 const TABLE_DATA_CDE_CARDANO_TRANSFER: TableData = {
   tableName: 'cde_cardano_transfer',
-  primaryKeyColumns: ['cde_id', 'tx_id'],
+  primaryKeyColumns: ['cde_name', 'tx_id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['tx_id', 'text', 'NO', ''],
     ['raw_tx', 'text', 'NO', ''],
     ['metadata', 'text', 'YES', ''],
@@ -494,21 +492,21 @@ const TABLE_DATA_CDE_CARDANO_TRANSFER: TableData = {
 
 const QUERY_CREATE_TABLE_CDE_CARDANO_MINT_BURN = `
 CREATE TABLE cde_cardano_mint_burn(
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   tx_id TEXT NOT NULL,
   metadata TEXT NOT NULL,
   assets JSONB NOT NULL,
   input_addresses JSONB NOT NULL,
   output_addresses JSONB NOT NULL,
-  PRIMARY KEY (cde_id, tx_id)
+  PRIMARY KEY (cde_name, tx_id)
 )
 `;
 
 const TABLE_DATA_CDE_CARDANO_MINT_BURN: TableData = {
   tableName: 'cde_cardano_mint_burn',
-  primaryKeyColumns: ['cde_id', 'tx_id'],
+  primaryKeyColumns: ['cde_name', 'tx_id'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['tx_id', 'text', 'NO', ''],
     ['metadata', 'text', 'NO', ''],
     ['assets', 'jsonb', 'NO', ''],
@@ -678,17 +676,17 @@ CREATE OR REPLACE TRIGGER wallet_connect_insert_or_update
 
 const QUERY_CREATE_TABLE_CDE_DYNAMIC_PRIMITIVE_CONFIG = `
 CREATE TABLE cde_dynamic_primitive_config (
-  cde_id INTEGER NOT NULL,
+  cde_name TEXT NOT NULL,
   config TEXT NOT NULL,
-  PRIMARY KEY(cde_id)
+  PRIMARY KEY(cde_name)
 );
 `;
 
 const TABLE_DATA_CDE_DYNAMIC_PRIMITIVE_CONFIG: TableData = {
   tableName: 'cde_dynamic_primitive_config',
-  primaryKeyColumns: ['cde_id'],
+  primaryKeyColumns: ['cde_name'],
   columnData: packTuples([
-    ['cde_id', 'integer', 'NO', ''],
+    ['cde_name', 'text', 'NO', ''],
     ['config', 'text', 'NO', ''],
   ]),
   serialColumns: [],

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -676,6 +676,25 @@ CREATE OR REPLACE TRIGGER wallet_connect_insert_or_update
   for each row execute procedure notify_wallet_connect('from_id', 'to_id');
 `;
 
+const QUERY_CREATE_TABLE_CDE_DYNAMIC_PRIMITIVE_CONFIG = `
+CREATE TABLE cde_dynamic_primitive_config (
+  cde_id INTEGER NOT NULL,
+  config TEXT NOT NULL,
+  PRIMARY KEY(cde_id)
+);
+`;
+
+const TABLE_DATA_CDE_DYNAMIC_PRIMITIVE_CONFIG: TableData = {
+  tableName: 'cde_dynamic_primitive_config',
+  primaryKeyColumns: ['cde_id'],
+  columnData: packTuples([
+    ['cde_id', 'integer', 'NO', ''],
+    ['config', 'text', 'NO', ''],
+  ]),
+  serialColumns: [],
+  creationQuery: QUERY_CREATE_TABLE_CDE_DYNAMIC_PRIMITIVE_CONFIG,
+};
+
 export const FUNCTIONS: string[] = [
   FUNCTION_NOTIFY_WALLET_CONNECT,
   FUNCTION_TRIGGER_ADDRESSES,
@@ -709,4 +728,5 @@ export const TABLES: TableData[] = [
   TABLE_DATA_CDE_CARDANO_MINT_BURN,
   TABLE_DATA_MINA_CHECKPOINT,
   TABLE_DATA_ACHIEVEMENT_PROGRESS,
+  TABLE_DATA_CDE_DYNAMIC_PRIMITIVE_CONFIG,
 ];

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -677,6 +677,7 @@ CREATE OR REPLACE TRIGGER wallet_connect_insert_or_update
 const QUERY_CREATE_TABLE_CDE_DYNAMIC_PRIMITIVE_CONFIG = `
 CREATE TABLE cde_dynamic_primitive_config (
   cde_name TEXT NOT NULL,
+  parent TEXT NOT NULL,
   config TEXT NOT NULL,
   PRIMARY KEY(cde_name)
 );
@@ -687,6 +688,7 @@ const TABLE_DATA_CDE_DYNAMIC_PRIMITIVE_CONFIG: TableData = {
   primaryKeyColumns: ['cde_name'],
   columnData: packTuples([
     ['cde_name', 'text', 'NO', ''],
+    ['parent', 'text', 'NO', ''],
     ['config', 'text', 'NO', ''],
   ]),
   serialColumns: [],

--- a/packages/node-sdk/paima-db/src/paima-tables.ts
+++ b/packages/node-sdk/paima-db/src/paima-tables.ts
@@ -143,7 +143,7 @@ CREATE TABLE chain_data_extensions (
   cde_id INTEGER PRIMARY KEY,
   cde_type INTEGER NOT NULL,
   cde_name TEXT NOT NULL,
-  cde_hash integer NOT NULL,
+  cde_hash INTEGER,
   start_blockheight INTEGER NOT NULL,
   scheduled_prefix TEXT
 );
@@ -156,7 +156,7 @@ const TABLE_DATA_CDE: TableData = {
     ['cde_id', 'integer', 'NO', ''],
     ['cde_type', 'integer', 'NO', ''],
     ['cde_name', 'text', 'NO', ''],
-    ['cde_hash', 'integer', 'NO', ''],
+    ['cde_hash', 'integer', 'YES', ''],
     ['start_blockheight', 'integer', 'NO', ''],
     ['scheduled_prefix', 'text', 'YES', ''],
   ]),

--- a/packages/node-sdk/paima-db/src/postgres-metadata.ts
+++ b/packages/node-sdk/paima-db/src/postgres-metadata.ts
@@ -133,7 +133,5 @@ async function checkTableColumn(
   const flagNullable = row.is_nullable === column.columnNullable;
 
   const result = flagDefault && flagType && flagNullable;
-  if (!result) {
-  }
   return result;
 }

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-asset-utxos.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-asset-utxos.queries.ts
@@ -15,7 +15,7 @@ export interface ICdeCardanoAssetUtxosByAddressResult {
   address: string;
   amount: string;
   asset_name: string;
-  cde_id: number;
+  cde_name: string;
   cip14_fingerprint: string;
   output_index: number;
   policy_id: string;
@@ -47,7 +47,7 @@ export interface ICdeInsertCardanoAssetUtxoParams {
   address: string;
   amount: NumberOrString;
   asset_name?: string | null | void;
-  cde_id: number;
+  cde_name: string;
   cip14_fingerprint: string;
   output_index: number;
   policy_id: string;
@@ -63,13 +63,13 @@ export interface ICdeInsertCardanoAssetUtxoQuery {
   result: ICdeInsertCardanoAssetUtxoResult;
 }
 
-const cdeInsertCardanoAssetUtxoIR: any = {"usedParamSet":{"cde_id":true,"address":true,"tx_id":true,"output_index":true,"amount":true,"cip14_fingerprint":true,"policy_id":true,"asset_name":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":172,"b":179}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":186,"b":194}]},{"name":"tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":201,"b":207}]},{"name":"output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":214,"b":227}]},{"name":"amount","required":true,"transform":{"type":"scalar"},"locs":[{"a":234,"b":241}]},{"name":"cip14_fingerprint","required":true,"transform":{"type":"scalar"},"locs":[{"a":248,"b":266}]},{"name":"policy_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":273,"b":283}]},{"name":"asset_name","required":false,"transform":{"type":"scalar"},"locs":[{"a":290,"b":300}]}],"statement":"INSERT INTO cde_cardano_asset_utxos(\n    cde_id,\n    address,\n    tx_id,\n    output_index, \n    amount,\n    cip14_fingerprint,\n    policy_id,\n    asset_name\n) VALUES (\n    :cde_id!,\n    :address!,\n    :tx_id!,\n    :output_index!,\n    :amount!,\n    :cip14_fingerprint!,\n    :policy_id!,\n    :asset_name\n)"};
+const cdeInsertCardanoAssetUtxoIR: any = {"usedParamSet":{"cde_name":true,"address":true,"tx_id":true,"output_index":true,"amount":true,"cip14_fingerprint":true,"policy_id":true,"asset_name":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":174,"b":183}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":190,"b":198}]},{"name":"tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":205,"b":211}]},{"name":"output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":218,"b":231}]},{"name":"amount","required":true,"transform":{"type":"scalar"},"locs":[{"a":238,"b":245}]},{"name":"cip14_fingerprint","required":true,"transform":{"type":"scalar"},"locs":[{"a":252,"b":270}]},{"name":"policy_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":277,"b":287}]},{"name":"asset_name","required":false,"transform":{"type":"scalar"},"locs":[{"a":294,"b":304}]}],"statement":"INSERT INTO cde_cardano_asset_utxos(\n    cde_name,\n    address,\n    tx_id,\n    output_index, \n    amount,\n    cip14_fingerprint,\n    policy_id,\n    asset_name\n) VALUES (\n    :cde_name!,\n    :address!,\n    :tx_id!,\n    :output_index!,\n    :amount!,\n    :cip14_fingerprint!,\n    :policy_id!,\n    :asset_name\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_cardano_asset_utxos(
- *     cde_id,
+ *     cde_name,
  *     address,
  *     tx_id,
  *     output_index, 
@@ -78,7 +78,7 @@ const cdeInsertCardanoAssetUtxoIR: any = {"usedParamSet":{"cde_id":true,"address
  *     policy_id,
  *     asset_name
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :address!,
  *     :tx_id!,
  *     :output_index!,

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-asset-utxos.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-asset-utxos.sql
@@ -6,7 +6,7 @@ WHERE
 
 /* @name  cdeInsertCardanoAssetUtxo */
 INSERT INTO cde_cardano_asset_utxos(
-    cde_id,
+    cde_name,
     address,
     tx_id,
     output_index, 
@@ -15,7 +15,7 @@ INSERT INTO cde_cardano_asset_utxos(
     policy_id,
     asset_name
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :address!,
     :tx_id!,
     :output_index!,

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-mint-burn.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-mint-burn.queries.ts
@@ -6,7 +6,7 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
 /** 'CdeCardanoMintBurnInsert' parameters type */
 export interface ICdeCardanoMintBurnInsertParams {
   assets: Json;
-  cde_id: number;
+  cde_name: string;
   input_addresses: Json;
   metadata: string;
   output_addresses: Json;
@@ -22,20 +22,20 @@ export interface ICdeCardanoMintBurnInsertQuery {
   result: ICdeCardanoMintBurnInsertResult;
 }
 
-const cdeCardanoMintBurnInsertIR: any = {"usedParamSet":{"cde_id":true,"tx_id":true,"metadata":true,"assets":true,"input_addresses":true,"output_addresses":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":128,"b":135}]},{"name":"tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":140,"b":146}]},{"name":"metadata","required":true,"transform":{"type":"scalar"},"locs":[{"a":151,"b":160}]},{"name":"assets","required":true,"transform":{"type":"scalar"},"locs":[{"a":165,"b":172}]},{"name":"input_addresses","required":true,"transform":{"type":"scalar"},"locs":[{"a":177,"b":193}]},{"name":"output_addresses","required":true,"transform":{"type":"scalar"},"locs":[{"a":198,"b":215}]}],"statement":"INSERT INTO cde_cardano_mint_burn (\n  cde_id,\n  tx_id,\n  metadata,\n  assets,\n  input_addresses,\n  output_addresses\n) VALUES (\n  :cde_id!,\n  :tx_id!,\n  :metadata!,\n  :assets!,\n  :input_addresses!,\n  :output_addresses!\n)"};
+const cdeCardanoMintBurnInsertIR: any = {"usedParamSet":{"cde_name":true,"tx_id":true,"metadata":true,"assets":true,"input_addresses":true,"output_addresses":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":130,"b":139}]},{"name":"tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":144,"b":150}]},{"name":"metadata","required":true,"transform":{"type":"scalar"},"locs":[{"a":155,"b":164}]},{"name":"assets","required":true,"transform":{"type":"scalar"},"locs":[{"a":169,"b":176}]},{"name":"input_addresses","required":true,"transform":{"type":"scalar"},"locs":[{"a":181,"b":197}]},{"name":"output_addresses","required":true,"transform":{"type":"scalar"},"locs":[{"a":202,"b":219}]}],"statement":"INSERT INTO cde_cardano_mint_burn (\n  cde_name,\n  tx_id,\n  metadata,\n  assets,\n  input_addresses,\n  output_addresses\n) VALUES (\n  :cde_name!,\n  :tx_id!,\n  :metadata!,\n  :assets!,\n  :input_addresses!,\n  :output_addresses!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_cardano_mint_burn (
- *   cde_id,
+ *   cde_name,
  *   tx_id,
  *   metadata,
  *   assets,
  *   input_addresses,
  *   output_addresses
  * ) VALUES (
- *   :cde_id!,
+ *   :cde_name!,
  *   :tx_id!,
  *   :metadata!,
  *   :assets!,

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-mint-burn.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-mint-burn.sql
@@ -1,13 +1,13 @@
 /* @name cdeCardanoMintBurnInsert */
 INSERT INTO cde_cardano_mint_burn (
-  cde_id,
+  cde_name,
   tx_id,
   metadata,
   assets,
   input_addresses,
   output_addresses
 ) VALUES (
-  :cde_id!,
+  :cde_name!,
   :tx_id!,
   :metadata!,
   :assets!,

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.queries.ts
@@ -9,7 +9,7 @@ export interface ICdeCardanoPoolGetAddressDelegationParams {
 /** 'CdeCardanoPoolGetAddressDelegation' return type */
 export interface ICdeCardanoPoolGetAddressDelegationResult {
   address: string;
-  cde_id: number;
+  cde_name: string;
   epoch: number;
   pool: string | null;
 }
@@ -36,7 +36,7 @@ export const cdeCardanoPoolGetAddressDelegation = new PreparedQuery<ICdeCardanoP
 /** 'CdeCardanoPoolInsertData' parameters type */
 export interface ICdeCardanoPoolInsertDataParams {
   address: string;
-  cde_id: number;
+  cde_name: string;
   epoch: number;
   pool: string;
 }
@@ -50,22 +50,22 @@ export interface ICdeCardanoPoolInsertDataQuery {
   result: ICdeCardanoPoolInsertDataResult;
 }
 
-const cdeCardanoPoolInsertDataIR: any = {"usedParamSet":{"cde_id":true,"address":true,"pool":true,"epoch":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":101,"b":108}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":115,"b":123}]},{"name":"pool","required":true,"transform":{"type":"scalar"},"locs":[{"a":130,"b":135},{"a":212,"b":217}]},{"name":"epoch","required":true,"transform":{"type":"scalar"},"locs":[{"a":142,"b":148}]}],"statement":"INSERT INTO cde_cardano_pool_delegation(\n    cde_id,\n    address,\n    pool,\n    epoch\n) VALUES (\n    :cde_id!,\n    :address!,\n    :pool!,\n    :epoch!\n) ON CONFLICT (cde_id, epoch, address) DO\n  UPDATE SET pool = :pool!"};
+const cdeCardanoPoolInsertDataIR: any = {"usedParamSet":{"cde_name":true,"address":true,"pool":true,"epoch":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":103,"b":112}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":119,"b":127}]},{"name":"pool","required":true,"transform":{"type":"scalar"},"locs":[{"a":134,"b":139},{"a":218,"b":223}]},{"name":"epoch","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":152}]}],"statement":"INSERT INTO cde_cardano_pool_delegation(\n    cde_name,\n    address,\n    pool,\n    epoch\n) VALUES (\n    :cde_name!,\n    :address!,\n    :pool!,\n    :epoch!\n) ON CONFLICT (cde_name, epoch, address) DO\n  UPDATE SET pool = :pool!"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_cardano_pool_delegation(
- *     cde_id,
+ *     cde_name,
  *     address,
  *     pool,
  *     epoch
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :address!,
  *     :pool!,
  *     :epoch!
- * ) ON CONFLICT (cde_id, epoch, address) DO
+ * ) ON CONFLICT (cde_name, epoch, address) DO
  *   UPDATE SET pool = :pool!
  * ```
  */
@@ -86,15 +86,15 @@ export interface IRemoveOldEntriesQuery {
   result: IRemoveOldEntriesResult;
 }
 
-const removeOldEntriesIR: any = {"usedParamSet":{"address":true},"params":[{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":179,"b":187},{"a":238,"b":246}]}],"statement":"DELETE FROM cde_cardano_pool_delegation\nWHERE (cde_id, epoch, address) NOT IN (\n    SELECT\n        cde_id, epoch, address\n    FROM cde_cardano_pool_delegation\n    WHERE address = :address!\n    ORDER BY epoch DESC\n\tLIMIT 2\n)\nAND address = :address!"};
+const removeOldEntriesIR: any = {"usedParamSet":{"address":true},"params":[{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":183,"b":191},{"a":242,"b":250}]}],"statement":"DELETE FROM cde_cardano_pool_delegation\nWHERE (cde_name, epoch, address) NOT IN (\n    SELECT\n        cde_name, epoch, address\n    FROM cde_cardano_pool_delegation\n    WHERE address = :address!\n    ORDER BY epoch DESC\n\tLIMIT 2\n)\nAND address = :address!"};
 
 /**
  * Query generated from SQL:
  * ```
  * DELETE FROM cde_cardano_pool_delegation
- * WHERE (cde_id, epoch, address) NOT IN (
+ * WHERE (cde_name, epoch, address) NOT IN (
  *     SELECT
- *         cde_id, epoch, address
+ *         cde_name, epoch, address
  *     FROM cde_cardano_pool_delegation
  *     WHERE address = :address!
  *     ORDER BY epoch DESC

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-pool-delegation.sql
@@ -5,24 +5,24 @@ ORDER BY epoch;
 
 /* @name cdeCardanoPoolInsertData */
 INSERT INTO cde_cardano_pool_delegation(
-    cde_id,
+    cde_name,
     address,
     pool,
     epoch
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :address!,
     :pool!,
     :epoch!
-) ON CONFLICT (cde_id, epoch, address) DO
+) ON CONFLICT (cde_name, epoch, address) DO
   UPDATE SET pool = :pool!;
 
 
 /* @name removeOldEntries */
 DELETE FROM cde_cardano_pool_delegation
-WHERE (cde_id, epoch, address) NOT IN (
+WHERE (cde_name, epoch, address) NOT IN (
     SELECT
-        cde_id, epoch, address
+        cde_name, epoch, address
     FROM cde_cardano_pool_delegation
     WHERE address = :address!
     ORDER BY epoch DESC

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-projected-nft.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-projected-nft.queries.ts
@@ -12,7 +12,7 @@ export interface ICdeCardanoGetProjectedNftParams {
 export interface ICdeCardanoGetProjectedNftResult {
   amount: string;
   asset_name: string;
-  cde_id: number;
+  cde_name: string;
   current_tx_hash: string;
   current_tx_output_index: number | null;
   for_how_long: string | null;
@@ -47,7 +47,7 @@ export const cdeCardanoGetProjectedNft = new PreparedQuery<ICdeCardanoGetProject
 export interface ICdeCardanoProjectedNftInsertDataParams {
   amount: NumberOrString;
   asset_name: string;
-  cde_id: number;
+  cde_name: string;
   current_tx_hash: string;
   current_tx_output_index: number;
   for_how_long: NumberOrString;
@@ -66,13 +66,13 @@ export interface ICdeCardanoProjectedNftInsertDataQuery {
   result: ICdeCardanoProjectedNftInsertDataResult;
 }
 
-const cdeCardanoProjectedNftInsertDataIR: any = {"usedParamSet":{"cde_id":true,"owner_address":true,"current_tx_hash":true,"current_tx_output_index":true,"policy_id":true,"asset_name":true,"amount":true,"status":true,"plutus_datum":true,"for_how_long":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":234,"b":241}]},{"name":"owner_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":257,"b":271}]},{"name":"current_tx_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":287,"b":303}]},{"name":"current_tx_output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":319,"b":343}]},{"name":"policy_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":359,"b":369}]},{"name":"asset_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":385,"b":396}]},{"name":"amount","required":true,"transform":{"type":"scalar"},"locs":[{"a":412,"b":419}]},{"name":"status","required":true,"transform":{"type":"scalar"},"locs":[{"a":435,"b":442}]},{"name":"plutus_datum","required":true,"transform":{"type":"scalar"},"locs":[{"a":458,"b":471}]},{"name":"for_how_long","required":true,"transform":{"type":"scalar"},"locs":[{"a":487,"b":500}]}],"statement":"INSERT INTO cde_cardano_projected_nft(\n    cde_id,\n    owner_address,\n    current_tx_hash,\n    current_tx_output_index,\n    policy_id,\n    asset_name,\n    amount,\n    status,\n    plutus_datum,\n    for_how_long\n) VALUES (\n             :cde_id!,\n             :owner_address!,\n             :current_tx_hash!,\n             :current_tx_output_index!,\n             :policy_id!,\n             :asset_name!,\n             :amount!,\n             :status!,\n             :plutus_datum!,\n             :for_how_long!\n         )"};
+const cdeCardanoProjectedNftInsertDataIR: any = {"usedParamSet":{"cde_name":true,"owner_address":true,"current_tx_hash":true,"current_tx_output_index":true,"policy_id":true,"asset_name":true,"amount":true,"status":true,"plutus_datum":true,"for_how_long":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":236,"b":245}]},{"name":"owner_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":261,"b":275}]},{"name":"current_tx_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":291,"b":307}]},{"name":"current_tx_output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":323,"b":347}]},{"name":"policy_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":363,"b":373}]},{"name":"asset_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":389,"b":400}]},{"name":"amount","required":true,"transform":{"type":"scalar"},"locs":[{"a":416,"b":423}]},{"name":"status","required":true,"transform":{"type":"scalar"},"locs":[{"a":439,"b":446}]},{"name":"plutus_datum","required":true,"transform":{"type":"scalar"},"locs":[{"a":462,"b":475}]},{"name":"for_how_long","required":true,"transform":{"type":"scalar"},"locs":[{"a":491,"b":504}]}],"statement":"INSERT INTO cde_cardano_projected_nft(\n    cde_name,\n    owner_address,\n    current_tx_hash,\n    current_tx_output_index,\n    policy_id,\n    asset_name,\n    amount,\n    status,\n    plutus_datum,\n    for_how_long\n) VALUES (\n             :cde_name!,\n             :owner_address!,\n             :current_tx_hash!,\n             :current_tx_output_index!,\n             :policy_id!,\n             :asset_name!,\n             :amount!,\n             :status!,\n             :plutus_datum!,\n             :for_how_long!\n         )"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_cardano_projected_nft(
- *     cde_id,
+ *     cde_name,
  *     owner_address,
  *     current_tx_hash,
  *     current_tx_output_index,
@@ -83,7 +83,7 @@ const cdeCardanoProjectedNftInsertDataIR: any = {"usedParamSet":{"cde_id":true,"
  *     plutus_datum,
  *     for_how_long
  * ) VALUES (
- *              :cde_id!,
+ *              :cde_name!,
  *              :owner_address!,
  *              :current_tx_hash!,
  *              :current_tx_output_index!,
@@ -103,7 +103,7 @@ export const cdeCardanoProjectedNftInsertData = new PreparedQuery<ICdeCardanoPro
 export interface ICdeCardanoProjectedNftUpdateDataParams {
   amount: NumberOrString;
   asset_name: string;
-  cde_id: number;
+  cde_name: string;
   for_how_long: NumberOrString;
   new_tx_hash: string;
   new_tx_output_index: number;
@@ -127,7 +127,7 @@ export interface ICdeCardanoProjectedNftUpdateDataQuery {
   result: ICdeCardanoProjectedNftUpdateDataResult;
 }
 
-const cdeCardanoProjectedNftUpdateDataIR: any = {"usedParamSet":{"owner_address":true,"previous_tx_hash":true,"previous_tx_output_index":true,"new_tx_hash":true,"new_tx_output_index":true,"status":true,"plutus_datum":true,"for_how_long":true,"cde_id":true,"policy_id":true,"asset_name":true,"amount":true},"params":[{"name":"owner_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":57,"b":71}]},{"name":"previous_tx_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":97,"b":114},{"a":412,"b":429}]},{"name":"previous_tx_output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":148,"b":173},{"a":465,"b":490}]},{"name":"new_tx_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":198,"b":210}]},{"name":"new_tx_output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":243,"b":263}]},{"name":"status","required":true,"transform":{"type":"scalar"},"locs":[{"a":279,"b":286}]},{"name":"plutus_datum","required":true,"transform":{"type":"scalar"},"locs":[{"a":308,"b":321}]},{"name":"for_how_long","required":true,"transform":{"type":"scalar"},"locs":[{"a":343,"b":356}]},{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":377,"b":384}]},{"name":"policy_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":512,"b":522}]},{"name":"asset_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":545,"b":556}]},{"name":"amount","required":true,"transform":{"type":"scalar"},"locs":[{"a":575,"b":582}]}],"statement":"UPDATE cde_cardano_projected_nft\nSET\n    owner_address = :owner_address!,\n    previous_tx_hash = :previous_tx_hash!,\n    previous_tx_output_index = :previous_tx_output_index!,\n    current_tx_hash = :new_tx_hash!,\n    current_tx_output_index = :new_tx_output_index!,\n    status = :status!,\n    plutus_datum = :plutus_datum!,\n    for_how_long = :for_how_long!\nWHERE\n    cde_id = :cde_id!\n    AND current_tx_hash = :previous_tx_hash!\n    AND current_tx_output_index = :previous_tx_output_index!\n    AND policy_id = :policy_id!\n    AND asset_name = :asset_name!\n    AND amount = :amount!\nRETURNING previous_tx_hash, previous_tx_output_index"};
+const cdeCardanoProjectedNftUpdateDataIR: any = {"usedParamSet":{"owner_address":true,"previous_tx_hash":true,"previous_tx_output_index":true,"new_tx_hash":true,"new_tx_output_index":true,"status":true,"plutus_datum":true,"for_how_long":true,"cde_name":true,"policy_id":true,"asset_name":true,"amount":true},"params":[{"name":"owner_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":57,"b":71}]},{"name":"previous_tx_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":97,"b":114},{"a":416,"b":433}]},{"name":"previous_tx_output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":148,"b":173},{"a":469,"b":494}]},{"name":"new_tx_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":198,"b":210}]},{"name":"new_tx_output_index","required":true,"transform":{"type":"scalar"},"locs":[{"a":243,"b":263}]},{"name":"status","required":true,"transform":{"type":"scalar"},"locs":[{"a":279,"b":286}]},{"name":"plutus_datum","required":true,"transform":{"type":"scalar"},"locs":[{"a":308,"b":321}]},{"name":"for_how_long","required":true,"transform":{"type":"scalar"},"locs":[{"a":343,"b":356}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":379,"b":388}]},{"name":"policy_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":516,"b":526}]},{"name":"asset_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":549,"b":560}]},{"name":"amount","required":true,"transform":{"type":"scalar"},"locs":[{"a":579,"b":586}]}],"statement":"UPDATE cde_cardano_projected_nft\nSET\n    owner_address = :owner_address!,\n    previous_tx_hash = :previous_tx_hash!,\n    previous_tx_output_index = :previous_tx_output_index!,\n    current_tx_hash = :new_tx_hash!,\n    current_tx_output_index = :new_tx_output_index!,\n    status = :status!,\n    plutus_datum = :plutus_datum!,\n    for_how_long = :for_how_long!\nWHERE\n    cde_name = :cde_name!\n    AND current_tx_hash = :previous_tx_hash!\n    AND current_tx_output_index = :previous_tx_output_index!\n    AND policy_id = :policy_id!\n    AND asset_name = :asset_name!\n    AND amount = :amount!\nRETURNING previous_tx_hash, previous_tx_output_index"};
 
 /**
  * Query generated from SQL:
@@ -143,7 +143,7 @@ const cdeCardanoProjectedNftUpdateDataIR: any = {"usedParamSet":{"owner_address"
  *     plutus_datum = :plutus_datum!,
  *     for_how_long = :for_how_long!
  * WHERE
- *     cde_id = :cde_id!
+ *     cde_name = :cde_name!
  *     AND current_tx_hash = :previous_tx_hash!
  *     AND current_tx_output_index = :previous_tx_output_index!
  *     AND policy_id = :policy_id!

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-projected-nft.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-projected-nft.sql
@@ -4,7 +4,7 @@ WHERE owner_address = :owner_address!;
 
 /* @name cdeCardanoProjectedNftInsertData */
 INSERT INTO cde_cardano_projected_nft(
-    cde_id,
+    cde_name,
     owner_address,
     current_tx_hash,
     current_tx_output_index,
@@ -15,7 +15,7 @@ INSERT INTO cde_cardano_projected_nft(
     plutus_datum,
     for_how_long
 ) VALUES (
-             :cde_id!,
+             :cde_name!,
              :owner_address!,
              :current_tx_hash!,
              :current_tx_output_index!,
@@ -39,7 +39,7 @@ SET
     plutus_datum = :plutus_datum!,
     for_how_long = :for_how_long!
 WHERE
-    cde_id = :cde_id!
+    cde_name = :cde_name!
     AND current_tx_hash = :previous_tx_hash!
     AND current_tx_output_index = :previous_tx_output_index!
     AND policy_id = :policy_id!

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-transfer.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-transfer.queries.ts
@@ -3,7 +3,7 @@ import { PreparedQuery } from '@pgtyped/runtime';
 
 /** 'CdeCardanoTransferInsert' parameters type */
 export interface ICdeCardanoTransferInsertParams {
-  cde_id: number;
+  cde_name: string;
   metadata?: string | null | void;
   raw_tx: string;
   tx_id: string;
@@ -18,18 +18,18 @@ export interface ICdeCardanoTransferInsertQuery {
   result: ICdeCardanoTransferInsertResult;
 }
 
-const cdeCardanoTransferInsertIR: any = {"usedParamSet":{"cde_id":true,"tx_id":true,"raw_tx":true,"metadata":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":88,"b":95}]},{"name":"tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":100,"b":106}]},{"name":"raw_tx","required":true,"transform":{"type":"scalar"},"locs":[{"a":111,"b":118}]},{"name":"metadata","required":false,"transform":{"type":"scalar"},"locs":[{"a":123,"b":131}]}],"statement":"INSERT INTO cde_cardano_transfer (\n  cde_id,\n  tx_id,\n  raw_tx,\n  metadata\n) VALUES (\n  :cde_id!,\n  :tx_id!,\n  :raw_tx!,\n  :metadata\n)"};
+const cdeCardanoTransferInsertIR: any = {"usedParamSet":{"cde_name":true,"tx_id":true,"raw_tx":true,"metadata":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":90,"b":99}]},{"name":"tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":104,"b":110}]},{"name":"raw_tx","required":true,"transform":{"type":"scalar"},"locs":[{"a":115,"b":122}]},{"name":"metadata","required":false,"transform":{"type":"scalar"},"locs":[{"a":127,"b":135}]}],"statement":"INSERT INTO cde_cardano_transfer (\n  cde_name,\n  tx_id,\n  raw_tx,\n  metadata\n) VALUES (\n  :cde_name!,\n  :tx_id!,\n  :raw_tx!,\n  :metadata\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_cardano_transfer (
- *   cde_id,
+ *   cde_name,
  *   tx_id,
  *   raw_tx,
  *   metadata
  * ) VALUES (
- *   :cde_id!,
+ *   :cde_name!,
  *   :tx_id!,
  *   :raw_tx!,
  *   :metadata

--- a/packages/node-sdk/paima-db/src/sql/cde-cardano-transfer.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cardano-transfer.sql
@@ -1,11 +1,11 @@
 /* @name cdeCardanoTransferInsert */
 INSERT INTO cde_cardano_transfer (
-  cde_id,
+  cde_name,
   tx_id,
   raw_tx,
   metadata
 ) VALUES (
-  :cde_id!,
+  :cde_name!,
   :tx_id!,
   :raw_tx!,
   :metadata

--- a/packages/node-sdk/paima-db/src/sql/cde-cursor-tracking-pagination.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-cursor-tracking-pagination.queries.ts
@@ -6,7 +6,7 @@ export type IGetPaginationCursorsParams = void;
 
 /** 'GetPaginationCursors' return type */
 export interface IGetPaginationCursorsResult {
-  cde_id: number;
+  cde_name: string;
   cursor: string;
   finished: boolean;
 }
@@ -30,7 +30,7 @@ export const getPaginationCursors = new PreparedQuery<IGetPaginationCursorsParam
 
 /** 'UpdatePaginationCursor' parameters type */
 export interface IUpdatePaginationCursorParams {
-  cde_id: number;
+  cde_name: string;
   cursor: string;
   finished: boolean;
 }
@@ -44,21 +44,21 @@ export interface IUpdatePaginationCursorQuery {
   result: IUpdatePaginationCursorResult;
 }
 
-const updatePaginationCursorIR: any = {"usedParamSet":{"cde_id":true,"cursor":true,"finished":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":88,"b":95}]},{"name":"cursor","required":true,"transform":{"type":"scalar"},"locs":[{"a":100,"b":107},{"a":169,"b":176}]},{"name":"finished","required":true,"transform":{"type":"scalar"},"locs":[{"a":112,"b":121},{"a":190,"b":199}]}],"statement":"INSERT INTO cde_tracking_cursor_pagination(\n  cde_id,\n  cursor,\n  finished\n) VALUES (\n  :cde_id!,\n  :cursor!,\n  :finished!\n)\nON CONFLICT (cde_id)\nDO UPDATE SET cursor = :cursor!, finished = :finished!"};
+const updatePaginationCursorIR: any = {"usedParamSet":{"cde_name":true,"cursor":true,"finished":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":90,"b":99}]},{"name":"cursor","required":true,"transform":{"type":"scalar"},"locs":[{"a":104,"b":111},{"a":175,"b":182}]},{"name":"finished","required":true,"transform":{"type":"scalar"},"locs":[{"a":116,"b":125},{"a":196,"b":205}]}],"statement":"INSERT INTO cde_tracking_cursor_pagination(\n  cde_name,\n  cursor,\n  finished\n) VALUES (\n  :cde_name!,\n  :cursor!,\n  :finished!\n)\nON CONFLICT (cde_name)\nDO UPDATE SET cursor = :cursor!, finished = :finished!"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_tracking_cursor_pagination(
- *   cde_id,
+ *   cde_name,
  *   cursor,
  *   finished
  * ) VALUES (
- *   :cde_id!,
+ *   :cde_name!,
  *   :cursor!,
  *   :finished!
  * )
- * ON CONFLICT (cde_id)
+ * ON CONFLICT (cde_name)
  * DO UPDATE SET cursor = :cursor!, finished = :finished!
  * ```
  */

--- a/packages/node-sdk/paima-db/src/sql/cde-cursor-tracking-pagination.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-cursor-tracking-pagination.sql
@@ -3,13 +3,13 @@ select * from cde_tracking_cursor_pagination;
 
 /* @name updatePaginationCursor */
 INSERT INTO cde_tracking_cursor_pagination(
-  cde_id,
+  cde_name,
   cursor,
   finished
 ) VALUES (
-  :cde_id!,
+  :cde_name!,
   :cursor!,
   :finished!
 )
-ON CONFLICT (cde_id)
+ON CONFLICT (cde_name)
 DO UPDATE SET cursor = :cursor!, finished = :finished!;

--- a/packages/node-sdk/paima-db/src/sql/cde-erc1155.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc1155.queries.ts
@@ -3,7 +3,7 @@ import { PreparedQuery } from '@pgtyped/runtime';
 
 /** 'CdeErc1155ModifyBalance' parameters type */
 export interface ICdeErc1155ModifyBalanceParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   value: string;
   wallet_address: string;
@@ -18,24 +18,24 @@ export interface ICdeErc1155ModifyBalanceQuery {
   result: ICdeErc1155ModifyBalanceResult;
 }
 
-const cdeErc1155ModifyBalanceIR: any = {"usedParamSet":{"cde_id":true,"token_id":true,"wallet_address":true,"value":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":101}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":106,"b":115}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":120,"b":135}]},{"name":"value","required":true,"transform":{"type":"scalar"},"locs":[{"a":140,"b":146}]}],"statement":"INSERT INTO cde_erc1155_data (\n  cde_id,\n  token_id,\n  wallet_address,\n  balance\n)\nVALUES (\n  :cde_id!,\n  :token_id!,\n  :wallet_address!,\n  :value!\n)\nON CONFLICT (cde_id, token_id, wallet_address)\nDO UPDATE SET balance = CAST(cde_erc1155_data.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC)"};
+const cdeErc1155ModifyBalanceIR: any = {"usedParamSet":{"cde_name":true,"token_id":true,"wallet_address":true,"value":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":96,"b":105}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":110,"b":119}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":124,"b":139}]},{"name":"value","required":true,"transform":{"type":"scalar"},"locs":[{"a":144,"b":150}]}],"statement":"INSERT INTO cde_erc1155_data (\n  cde_name,\n  token_id,\n  wallet_address,\n  balance\n)\nVALUES (\n  :cde_name!,\n  :token_id!,\n  :wallet_address!,\n  :value!\n)\nON CONFLICT (cde_name, token_id, wallet_address)\nDO UPDATE SET balance = CAST(cde_erc1155_data.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc1155_data (
- *   cde_id,
+ *   cde_name,
  *   token_id,
  *   wallet_address,
  *   balance
  * )
  * VALUES (
- *   :cde_id!,
+ *   :cde_name!,
  *   :token_id!,
  *   :wallet_address!,
  *   :value!
  * )
- * ON CONFLICT (cde_id, token_id, wallet_address)
+ * ON CONFLICT (cde_name, token_id, wallet_address)
  * DO UPDATE SET balance = CAST(cde_erc1155_data.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC)
  * ```
  */
@@ -44,7 +44,7 @@ export const cdeErc1155ModifyBalance = new PreparedQuery<ICdeErc1155ModifyBalanc
 
 /** 'CdeErc1155DeleteIfZero' parameters type */
 export interface ICdeErc1155DeleteIfZeroParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   wallet_address: string;
 }
@@ -58,14 +58,14 @@ export interface ICdeErc1155DeleteIfZeroQuery {
   result: ICdeErc1155DeleteIfZeroResult;
 }
 
-const cdeErc1155DeleteIfZeroIR: any = {"usedParamSet":{"cde_id":true,"token_id":true,"wallet_address":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":62,"b":69}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":86,"b":95}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":118,"b":133}]}],"statement":"DELETE FROM cde_erc1155_data\nWHERE balance = '0'\nAND cde_id = :cde_id!\nAND token_id = :token_id!\nAND wallet_address = :wallet_address!"};
+const cdeErc1155DeleteIfZeroIR: any = {"usedParamSet":{"cde_name":true,"token_id":true,"wallet_address":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":64,"b":73}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":90,"b":99}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":122,"b":137}]}],"statement":"DELETE FROM cde_erc1155_data\nWHERE balance = '0'\nAND cde_name = :cde_name!\nAND token_id = :token_id!\nAND wallet_address = :wallet_address!"};
 
 /**
  * Query generated from SQL:
  * ```
  * DELETE FROM cde_erc1155_data
  * WHERE balance = '0'
- * AND cde_id = :cde_id!
+ * AND cde_name = :cde_name!
  * AND token_id = :token_id!
  * AND wallet_address = :wallet_address!
  * ```
@@ -75,7 +75,7 @@ export const cdeErc1155DeleteIfZero = new PreparedQuery<ICdeErc1155DeleteIfZeroP
 
 /** 'CdeErc1155Burn' parameters type */
 export interface ICdeErc1155BurnParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   value: string;
   wallet_address: string;
@@ -90,24 +90,24 @@ export interface ICdeErc1155BurnQuery {
   result: ICdeErc1155BurnResult;
 }
 
-const cdeErc1155BurnIR: any = {"usedParamSet":{"cde_id":true,"token_id":true,"wallet_address":true,"value":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":101}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":106,"b":115}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":120,"b":135}]},{"name":"value","required":true,"transform":{"type":"scalar"},"locs":[{"a":140,"b":146}]}],"statement":"INSERT INTO cde_erc1155_burn (\n  cde_id,\n  token_id,\n  wallet_address,\n  balance\n)\nVALUES (\n  :cde_id!,\n  :token_id!,\n  :wallet_address!,\n  :value!\n)\nON CONFLICT (cde_id, token_id, wallet_address)\nDO UPDATE SET balance = CAST(cde_erc1155_burn.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC)"};
+const cdeErc1155BurnIR: any = {"usedParamSet":{"cde_name":true,"token_id":true,"wallet_address":true,"value":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":96,"b":105}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":110,"b":119}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":124,"b":139}]},{"name":"value","required":true,"transform":{"type":"scalar"},"locs":[{"a":144,"b":150}]}],"statement":"INSERT INTO cde_erc1155_burn (\n  cde_name,\n  token_id,\n  wallet_address,\n  balance\n)\nVALUES (\n  :cde_name!,\n  :token_id!,\n  :wallet_address!,\n  :value!\n)\nON CONFLICT (cde_name, token_id, wallet_address)\nDO UPDATE SET balance = CAST(cde_erc1155_burn.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc1155_burn (
- *   cde_id,
+ *   cde_name,
  *   token_id,
  *   wallet_address,
  *   balance
  * )
  * VALUES (
- *   :cde_id!,
+ *   :cde_name!,
  *   :token_id!,
  *   :wallet_address!,
  *   :value!
  * )
- * ON CONFLICT (cde_id, token_id, wallet_address)
+ * ON CONFLICT (cde_name, token_id, wallet_address)
  * DO UPDATE SET balance = CAST(cde_erc1155_burn.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC)
  * ```
  */
@@ -116,14 +116,14 @@ export const cdeErc1155Burn = new PreparedQuery<ICdeErc1155BurnParams,ICdeErc115
 
 /** 'CdeErc1155GetAllTokens' parameters type */
 export interface ICdeErc1155GetAllTokensParams {
-  cde_id: number;
+  cde_name: string;
   wallet_address: string;
 }
 
 /** 'CdeErc1155GetAllTokens' return type */
 export interface ICdeErc1155GetAllTokensResult {
   balance: string;
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   wallet_address: string;
 }
@@ -134,13 +134,13 @@ export interface ICdeErc1155GetAllTokensQuery {
   result: ICdeErc1155GetAllTokensResult;
 }
 
-const cdeErc1155GetAllTokensIR: any = {"usedParamSet":{"cde_id":true,"wallet_address":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":53}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":76,"b":91}]}],"statement":"SELECT * from cde_erc1155_data\nWHERE cde_id = :cde_id!\nAND wallet_address = :wallet_address!\nAND CAST(balance AS NUMERIC) > 0"};
+const cdeErc1155GetAllTokensIR: any = {"usedParamSet":{"cde_name":true,"wallet_address":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":80,"b":95}]}],"statement":"SELECT * from cde_erc1155_data\nWHERE cde_name = :cde_name!\nAND wallet_address = :wallet_address!\nAND CAST(balance AS NUMERIC) > 0"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * from cde_erc1155_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND wallet_address = :wallet_address!
  * AND CAST(balance AS NUMERIC) > 0
  * ```
@@ -150,14 +150,14 @@ export const cdeErc1155GetAllTokens = new PreparedQuery<ICdeErc1155GetAllTokensP
 
 /** 'CdeErc1155GetByTokenId' parameters type */
 export interface ICdeErc1155GetByTokenIdParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
 }
 
 /** 'CdeErc1155GetByTokenId' return type */
 export interface ICdeErc1155GetByTokenIdResult {
   balance: string;
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   wallet_address: string;
 }
@@ -168,13 +168,13 @@ export interface ICdeErc1155GetByTokenIdQuery {
   result: ICdeErc1155GetByTokenIdResult;
 }
 
-const cdeErc1155GetByTokenIdIR: any = {"usedParamSet":{"cde_id":true,"token_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":53}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":70,"b":79}]}],"statement":"SELECT * from cde_erc1155_data\nWHERE cde_id = :cde_id!\nAND token_id = :token_id!"};
+const cdeErc1155GetByTokenIdIR: any = {"usedParamSet":{"cde_name":true,"token_id":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":74,"b":83}]}],"statement":"SELECT * from cde_erc1155_data\nWHERE cde_name = :cde_name!\nAND token_id = :token_id!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * from cde_erc1155_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND token_id = :token_id!
  * ```
  */
@@ -183,7 +183,7 @@ export const cdeErc1155GetByTokenId = new PreparedQuery<ICdeErc1155GetByTokenIdP
 
 /** 'CdeErc1155GetByTokenIdAndWallet' parameters type */
 export interface ICdeErc1155GetByTokenIdAndWalletParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   wallet_address: string;
 }
@@ -191,7 +191,7 @@ export interface ICdeErc1155GetByTokenIdAndWalletParams {
 /** 'CdeErc1155GetByTokenIdAndWallet' return type */
 export interface ICdeErc1155GetByTokenIdAndWalletResult {
   balance: string;
-  cde_id: number;
+  cde_name: string;
   token_id: string;
   wallet_address: string;
 }
@@ -202,13 +202,13 @@ export interface ICdeErc1155GetByTokenIdAndWalletQuery {
   result: ICdeErc1155GetByTokenIdAndWalletResult;
 }
 
-const cdeErc1155GetByTokenIdAndWalletIR: any = {"usedParamSet":{"cde_id":true,"wallet_address":true,"token_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":53}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":76,"b":91}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":108,"b":117}]}],"statement":"SELECT * from cde_erc1155_data\nWHERE cde_id = :cde_id!\nAND wallet_address = :wallet_address!\nAND token_id = :token_id!"};
+const cdeErc1155GetByTokenIdAndWalletIR: any = {"usedParamSet":{"cde_name":true,"wallet_address":true,"token_id":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":80,"b":95}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":112,"b":121}]}],"statement":"SELECT * from cde_erc1155_data\nWHERE cde_name = :cde_name!\nAND wallet_address = :wallet_address!\nAND token_id = :token_id!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * from cde_erc1155_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND wallet_address = :wallet_address!
  * AND token_id = :token_id!
  * ```

--- a/packages/node-sdk/paima-db/src/sql/cde-erc1155.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc1155.sql
@@ -1,58 +1,58 @@
 /* @name cdeErc1155ModifyBalance */
 INSERT INTO cde_erc1155_data (
-  cde_id,
+  cde_name,
   token_id,
   wallet_address,
   balance
 )
 VALUES (
-  :cde_id!,
+  :cde_name!,
   :token_id!,
   :wallet_address!,
   :value!
 )
-ON CONFLICT (cde_id, token_id, wallet_address)
+ON CONFLICT (cde_name, token_id, wallet_address)
 DO UPDATE SET balance = CAST(cde_erc1155_data.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC);
 
 /* @name cdeErc1155DeleteIfZero */
 DELETE FROM cde_erc1155_data
 WHERE balance = '0'
-AND cde_id = :cde_id!
+AND cde_name = :cde_name!
 AND token_id = :token_id!
 AND wallet_address = :wallet_address!;
 
 /* @name cdeErc1155Burn */
 INSERT INTO cde_erc1155_burn (
-  cde_id,
+  cde_name,
   token_id,
   wallet_address,
   balance
 )
 VALUES (
-  :cde_id!,
+  :cde_name!,
   :token_id!,
   :wallet_address!,
   :value!
 )
-ON CONFLICT (cde_id, token_id, wallet_address)
+ON CONFLICT (cde_name, token_id, wallet_address)
 DO UPDATE SET balance = CAST(cde_erc1155_burn.balance AS NUMERIC) + CAST(EXCLUDED.balance AS NUMERIC);
 
 /* @name cdeErc1155GetAllTokens */
 SELECT * from cde_erc1155_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND wallet_address = :wallet_address!
 AND CAST(balance AS NUMERIC) > 0
 ;
 
 /* @name cdeErc1155GetByTokenId */
 SELECT * from cde_erc1155_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND token_id = :token_id!
 ;
 
 /* @name cdeErc1155GetByTokenIdAndWallet */
 SELECT * from cde_erc1155_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND wallet_address = :wallet_address!
 AND token_id = :token_id!
 ;

--- a/packages/node-sdk/paima-db/src/sql/cde-erc20-deposit.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc20-deposit.queries.ts
@@ -3,13 +3,13 @@ import { PreparedQuery } from '@pgtyped/runtime';
 
 /** 'CdeErc20DepositGetTotalDeposited' parameters type */
 export interface ICdeErc20DepositGetTotalDepositedParams {
-  cde_id: number;
+  cde_name: string;
   wallet_address: string;
 }
 
 /** 'CdeErc20DepositGetTotalDeposited' return type */
 export interface ICdeErc20DepositGetTotalDepositedResult {
-  cde_id: number;
+  cde_name: string;
   total_deposited: string;
   wallet_address: string;
 }
@@ -20,13 +20,13 @@ export interface ICdeErc20DepositGetTotalDepositedQuery {
   result: ICdeErc20DepositGetTotalDepositedResult;
 }
 
-const cdeErc20DepositGetTotalDepositedIR: any = {"usedParamSet":{"cde_id":true,"wallet_address":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":52,"b":59}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":97}]}],"statement":"SELECT * FROM cde_erc20_deposit_data\nWHERE cde_id = :cde_id!\nAND wallet_address = :wallet_address!"};
+const cdeErc20DepositGetTotalDepositedIR: any = {"usedParamSet":{"cde_name":true,"wallet_address":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":54,"b":63}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":86,"b":101}]}],"statement":"SELECT * FROM cde_erc20_deposit_data\nWHERE cde_name = :cde_name!\nAND wallet_address = :wallet_address!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc20_deposit_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND wallet_address = :wallet_address!
  * ```
  */
@@ -35,7 +35,7 @@ export const cdeErc20DepositGetTotalDeposited = new PreparedQuery<ICdeErc20Depos
 
 /** 'CdeErc20DepositInsertTotalDeposited' parameters type */
 export interface ICdeErc20DepositInsertTotalDepositedParams {
-  cde_id: number;
+  cde_name: string;
   total_deposited: string;
   wallet_address: string;
 }
@@ -49,17 +49,17 @@ export interface ICdeErc20DepositInsertTotalDepositedQuery {
   result: ICdeErc20DepositInsertTotalDepositedResult;
 }
 
-const cdeErc20DepositInsertTotalDepositedIR: any = {"usedParamSet":{"cde_id":true,"wallet_address":true,"total_deposited":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":103,"b":110}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":117,"b":132}]},{"name":"total_deposited","required":true,"transform":{"type":"scalar"},"locs":[{"a":139,"b":155}]}],"statement":"INSERT INTO cde_erc20_deposit_data(\n    cde_id,\n    wallet_address,\n    total_deposited\n) VALUES (\n    :cde_id!,\n    :wallet_address!,\n    :total_deposited!\n)"};
+const cdeErc20DepositInsertTotalDepositedIR: any = {"usedParamSet":{"cde_name":true,"wallet_address":true,"total_deposited":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":105,"b":114}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":121,"b":136}]},{"name":"total_deposited","required":true,"transform":{"type":"scalar"},"locs":[{"a":143,"b":159}]}],"statement":"INSERT INTO cde_erc20_deposit_data(\n    cde_name,\n    wallet_address,\n    total_deposited\n) VALUES (\n    :cde_name!,\n    :wallet_address!,\n    :total_deposited!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc20_deposit_data(
- *     cde_id,
+ *     cde_name,
  *     wallet_address,
  *     total_deposited
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :wallet_address!,
  *     :total_deposited!
  * )
@@ -70,7 +70,7 @@ export const cdeErc20DepositInsertTotalDeposited = new PreparedQuery<ICdeErc20De
 
 /** 'CdeErc20DepositUpdateTotalDeposited' parameters type */
 export interface ICdeErc20DepositUpdateTotalDepositedParams {
-  cde_id: number;
+  cde_name: string;
   total_deposited: string;
   wallet_address: string;
 }
@@ -84,7 +84,7 @@ export interface ICdeErc20DepositUpdateTotalDepositedQuery {
   result: ICdeErc20DepositUpdateTotalDepositedResult;
 }
 
-const cdeErc20DepositUpdateTotalDepositedIR: any = {"usedParamSet":{"total_deposited":true,"cde_id":true,"wallet_address":true},"params":[{"name":"total_deposited","required":true,"transform":{"type":"scalar"},"locs":[{"a":56,"b":72}]},{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":89,"b":96}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":119,"b":134}]}],"statement":"UPDATE cde_erc20_deposit_data\nSET\n    total_deposited = :total_deposited!\nWHERE cde_id = :cde_id!\nAND wallet_address = :wallet_address!"};
+const cdeErc20DepositUpdateTotalDepositedIR: any = {"usedParamSet":{"total_deposited":true,"cde_name":true,"wallet_address":true},"params":[{"name":"total_deposited","required":true,"transform":{"type":"scalar"},"locs":[{"a":56,"b":72}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":91,"b":100}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":123,"b":138}]}],"statement":"UPDATE cde_erc20_deposit_data\nSET\n    total_deposited = :total_deposited!\nWHERE cde_name = :cde_name!\nAND wallet_address = :wallet_address!"};
 
 /**
  * Query generated from SQL:
@@ -92,7 +92,7 @@ const cdeErc20DepositUpdateTotalDepositedIR: any = {"usedParamSet":{"total_depos
  * UPDATE cde_erc20_deposit_data
  * SET
  *     total_deposited = :total_deposited!
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND wallet_address = :wallet_address!
  * ```
  */
@@ -101,12 +101,12 @@ export const cdeErc20DepositUpdateTotalDeposited = new PreparedQuery<ICdeErc20De
 
 /** 'CdeErc20DepositSelectAll' parameters type */
 export interface ICdeErc20DepositSelectAllParams {
-  cde_id: number;
+  cde_name: string;
 }
 
 /** 'CdeErc20DepositSelectAll' return type */
 export interface ICdeErc20DepositSelectAllResult {
-  cde_id: number;
+  cde_name: string;
   total_deposited: string;
   wallet_address: string;
 }
@@ -117,13 +117,13 @@ export interface ICdeErc20DepositSelectAllQuery {
   result: ICdeErc20DepositSelectAllResult;
 }
 
-const cdeErc20DepositSelectAllIR: any = {"usedParamSet":{"cde_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":52,"b":59}]}],"statement":"SELECT * FROM cde_erc20_deposit_data\nWHERE cde_id = :cde_id!"};
+const cdeErc20DepositSelectAllIR: any = {"usedParamSet":{"cde_name":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":54,"b":63}]}],"statement":"SELECT * FROM cde_erc20_deposit_data\nWHERE cde_name = :cde_name!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc20_deposit_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * ```
  */
 export const cdeErc20DepositSelectAll = new PreparedQuery<ICdeErc20DepositSelectAllParams,ICdeErc20DepositSelectAllResult>(cdeErc20DepositSelectAllIR);

--- a/packages/node-sdk/paima-db/src/sql/cde-erc20-deposit.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc20-deposit.sql
@@ -1,15 +1,15 @@
 /* @name cdeErc20DepositGetTotalDeposited */
 SELECT * FROM cde_erc20_deposit_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND wallet_address = :wallet_address!;
 
 /* @name cdeErc20DepositInsertTotalDeposited */
 INSERT INTO cde_erc20_deposit_data(
-    cde_id,
+    cde_name,
     wallet_address,
     total_deposited
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :wallet_address!,
     :total_deposited!
 );
@@ -18,9 +18,9 @@ INSERT INTO cde_erc20_deposit_data(
 UPDATE cde_erc20_deposit_data
 SET
     total_deposited = :total_deposited!
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND wallet_address = :wallet_address!;
 
 /* @name cdeErc20DepositSelectAll */
 SELECT * FROM cde_erc20_deposit_data
-WHERE cde_id = :cde_id!;
+WHERE cde_name = :cde_name!;

--- a/packages/node-sdk/paima-db/src/sql/cde-erc20.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc20.queries.ts
@@ -3,14 +3,14 @@ import { PreparedQuery } from '@pgtyped/runtime';
 
 /** 'CdeErc20GetBalance' parameters type */
 export interface ICdeErc20GetBalanceParams {
-  cde_id: number;
+  cde_name: string;
   wallet_address: string;
 }
 
 /** 'CdeErc20GetBalance' return type */
 export interface ICdeErc20GetBalanceResult {
   balance: string;
-  cde_id: number;
+  cde_name: string;
   wallet_address: string;
 }
 
@@ -20,13 +20,13 @@ export interface ICdeErc20GetBalanceQuery {
   result: ICdeErc20GetBalanceResult;
 }
 
-const cdeErc20GetBalanceIR: any = {"usedParamSet":{"cde_id":true,"wallet_address":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":44,"b":51}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":74,"b":89}]}],"statement":"SELECT * FROM cde_erc20_data\nWHERE cde_id = :cde_id!\nAND wallet_address = :wallet_address!"};
+const cdeErc20GetBalanceIR: any = {"usedParamSet":{"cde_name":true,"wallet_address":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":55}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":78,"b":93}]}],"statement":"SELECT * FROM cde_erc20_data\nWHERE cde_name = :cde_name!\nAND wallet_address = :wallet_address!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc20_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND wallet_address = :wallet_address!
  * ```
  */
@@ -36,7 +36,7 @@ export const cdeErc20GetBalance = new PreparedQuery<ICdeErc20GetBalanceParams,IC
 /** 'CdeErc20InsertBalance' parameters type */
 export interface ICdeErc20InsertBalanceParams {
   balance: string;
-  cde_id: number;
+  cde_name: string;
   wallet_address: string;
 }
 
@@ -49,17 +49,17 @@ export interface ICdeErc20InsertBalanceQuery {
   result: ICdeErc20InsertBalanceResult;
 }
 
-const cdeErc20InsertBalanceIR: any = {"usedParamSet":{"cde_id":true,"wallet_address":true,"balance":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":87,"b":94}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":101,"b":116}]},{"name":"balance","required":true,"transform":{"type":"scalar"},"locs":[{"a":123,"b":131}]}],"statement":"INSERT INTO cde_erc20_data(\n    cde_id,\n    wallet_address,\n    balance\n) VALUES (\n    :cde_id!,\n    :wallet_address!,\n    :balance!\n)"};
+const cdeErc20InsertBalanceIR: any = {"usedParamSet":{"cde_name":true,"wallet_address":true,"balance":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":89,"b":98}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":105,"b":120}]},{"name":"balance","required":true,"transform":{"type":"scalar"},"locs":[{"a":127,"b":135}]}],"statement":"INSERT INTO cde_erc20_data(\n    cde_name,\n    wallet_address,\n    balance\n) VALUES (\n    :cde_name!,\n    :wallet_address!,\n    :balance!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc20_data(
- *     cde_id,
+ *     cde_name,
  *     wallet_address,
  *     balance
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :wallet_address!,
  *     :balance!
  * )
@@ -71,7 +71,7 @@ export const cdeErc20InsertBalance = new PreparedQuery<ICdeErc20InsertBalancePar
 /** 'CdeErc20UpdateBalance' parameters type */
 export interface ICdeErc20UpdateBalanceParams {
   balance: string;
-  cde_id: number;
+  cde_name: string;
   wallet_address: string;
 }
 
@@ -84,7 +84,7 @@ export interface ICdeErc20UpdateBalanceQuery {
   result: ICdeErc20UpdateBalanceResult;
 }
 
-const cdeErc20UpdateBalanceIR: any = {"usedParamSet":{"balance":true,"cde_id":true,"wallet_address":true},"params":[{"name":"balance","required":true,"transform":{"type":"scalar"},"locs":[{"a":40,"b":48}]},{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":65,"b":72}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":95,"b":110}]}],"statement":"UPDATE cde_erc20_data\nSET\n    balance = :balance!\nWHERE cde_id = :cde_id!\nAND wallet_address = :wallet_address!"};
+const cdeErc20UpdateBalanceIR: any = {"usedParamSet":{"balance":true,"cde_name":true,"wallet_address":true},"params":[{"name":"balance","required":true,"transform":{"type":"scalar"},"locs":[{"a":40,"b":48}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":67,"b":76}]},{"name":"wallet_address","required":true,"transform":{"type":"scalar"},"locs":[{"a":99,"b":114}]}],"statement":"UPDATE cde_erc20_data\nSET\n    balance = :balance!\nWHERE cde_name = :cde_name!\nAND wallet_address = :wallet_address!"};
 
 /**
  * Query generated from SQL:
@@ -92,7 +92,7 @@ const cdeErc20UpdateBalanceIR: any = {"usedParamSet":{"balance":true,"cde_id":tr
  * UPDATE cde_erc20_data
  * SET
  *     balance = :balance!
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND wallet_address = :wallet_address!
  * ```
  */

--- a/packages/node-sdk/paima-db/src/sql/cde-erc20.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc20.sql
@@ -1,15 +1,15 @@
 /* @name cdeErc20GetBalance */
 SELECT * FROM cde_erc20_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND wallet_address = :wallet_address!;
 
 /* @name cdeErc20InsertBalance */
 INSERT INTO cde_erc20_data(
-    cde_id,
+    cde_name,
     wallet_address,
     balance
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :wallet_address!,
     :balance!
 );
@@ -18,5 +18,5 @@ INSERT INTO cde_erc20_data(
 UPDATE cde_erc20_data
 SET
     balance = :balance!
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND wallet_address = :wallet_address!;

--- a/packages/node-sdk/paima-db/src/sql/cde-erc6551-registry.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc6551-registry.queries.ts
@@ -4,14 +4,14 @@ import { PreparedQuery } from '@pgtyped/runtime';
 /** 'CdeErc6551GetOwner' parameters type */
 export interface ICdeErc6551GetOwnerParams {
   account_created: string;
-  cde_id: number;
+  cde_name: string;
 }
 
 /** 'CdeErc6551GetOwner' return type */
 export interface ICdeErc6551GetOwnerResult {
   account_created: string;
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   chain_id: string;
   implementation: string;
   salt: string;
@@ -25,13 +25,13 @@ export interface ICdeErc6551GetOwnerQuery {
   result: ICdeErc6551GetOwnerResult;
 }
 
-const cdeErc6551GetOwnerIR: any = {"usedParamSet":{"cde_id":true,"account_created":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":55,"b":62}]},{"name":"account_created","required":true,"transform":{"type":"scalar"},"locs":[{"a":86,"b":102}]}],"statement":"SELECT * FROM cde_erc6551_registry_data\nWHERE cde_id = :cde_id!\nAND account_created = :account_created!"};
+const cdeErc6551GetOwnerIR: any = {"usedParamSet":{"cde_name":true,"account_created":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":57,"b":66}]},{"name":"account_created","required":true,"transform":{"type":"scalar"},"locs":[{"a":90,"b":106}]}],"statement":"SELECT * FROM cde_erc6551_registry_data\nWHERE cde_name = :cde_name!\nAND account_created = :account_created!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc6551_registry_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND account_created = :account_created!
  * ```
  */
@@ -40,7 +40,7 @@ export const cdeErc6551GetOwner = new PreparedQuery<ICdeErc6551GetOwnerParams,IC
 
 /** 'CdeErc6551GetOwnedAccounts' parameters type */
 export interface ICdeErc6551GetOwnedAccountsParams {
-  cde_id: number;
+  cde_name: string;
   token_contract: string;
   token_id: string;
 }
@@ -49,7 +49,7 @@ export interface ICdeErc6551GetOwnedAccountsParams {
 export interface ICdeErc6551GetOwnedAccountsResult {
   account_created: string;
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   chain_id: string;
   implementation: string;
   salt: string;
@@ -63,13 +63,13 @@ export interface ICdeErc6551GetOwnedAccountsQuery {
   result: ICdeErc6551GetOwnedAccountsResult;
 }
 
-const cdeErc6551GetOwnedAccountsIR: any = {"usedParamSet":{"cde_id":true,"token_contract":true,"token_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":55,"b":62}]},{"name":"token_contract","required":true,"transform":{"type":"scalar"},"locs":[{"a":85,"b":100}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":117,"b":126}]}],"statement":"SELECT * FROM cde_erc6551_registry_data\nWHERE cde_id = :cde_id!\nAND token_contract = :token_contract!\nAND token_id = :token_id!"};
+const cdeErc6551GetOwnedAccountsIR: any = {"usedParamSet":{"cde_name":true,"token_contract":true,"token_id":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":57,"b":66}]},{"name":"token_contract","required":true,"transform":{"type":"scalar"},"locs":[{"a":89,"b":104}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":121,"b":130}]}],"statement":"SELECT * FROM cde_erc6551_registry_data\nWHERE cde_name = :cde_name!\nAND token_contract = :token_contract!\nAND token_id = :token_id!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc6551_registry_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND token_contract = :token_contract!
  * AND token_id = :token_id!
  * ```
@@ -81,7 +81,7 @@ export const cdeErc6551GetOwnedAccounts = new PreparedQuery<ICdeErc6551GetOwnedA
 export interface ICdeErc6551InsertRegistryParams {
   account_created: string;
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   chain_id: string;
   implementation: string;
   salt: string;
@@ -98,13 +98,13 @@ export interface ICdeErc6551InsertRegistryQuery {
   result: ICdeErc6551InsertRegistryResult;
 }
 
-const cdeErc6551InsertRegistryIR: any = {"usedParamSet":{"cde_id":true,"block_height":true,"account_created":true,"implementation":true,"token_contract":true,"token_id":true,"chain_id":true,"salt":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":182,"b":189}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":196,"b":209}]},{"name":"account_created","required":true,"transform":{"type":"scalar"},"locs":[{"a":216,"b":232}]},{"name":"implementation","required":true,"transform":{"type":"scalar"},"locs":[{"a":239,"b":254}]},{"name":"token_contract","required":true,"transform":{"type":"scalar"},"locs":[{"a":261,"b":276}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":283,"b":292}]},{"name":"chain_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":299,"b":308}]},{"name":"salt","required":true,"transform":{"type":"scalar"},"locs":[{"a":315,"b":320}]}],"statement":"INSERT INTO cde_erc6551_registry_data(\n    cde_id,\n    block_height,\n    account_created,\n    implementation,\n    token_contract,\n    token_id,\n    chain_id,\n    salt\n) VALUES (\n    :cde_id!,\n    :block_height!,\n    :account_created!,\n    :implementation!,\n    :token_contract!,\n    :token_id!,\n    :chain_id!,\n    :salt!\n)"};
+const cdeErc6551InsertRegistryIR: any = {"usedParamSet":{"cde_name":true,"block_height":true,"account_created":true,"implementation":true,"token_contract":true,"token_id":true,"chain_id":true,"salt":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":184,"b":193}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":200,"b":213}]},{"name":"account_created","required":true,"transform":{"type":"scalar"},"locs":[{"a":220,"b":236}]},{"name":"implementation","required":true,"transform":{"type":"scalar"},"locs":[{"a":243,"b":258}]},{"name":"token_contract","required":true,"transform":{"type":"scalar"},"locs":[{"a":265,"b":280}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":287,"b":296}]},{"name":"chain_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":303,"b":312}]},{"name":"salt","required":true,"transform":{"type":"scalar"},"locs":[{"a":319,"b":324}]}],"statement":"INSERT INTO cde_erc6551_registry_data(\n    cde_name,\n    block_height,\n    account_created,\n    implementation,\n    token_contract,\n    token_id,\n    chain_id,\n    salt\n) VALUES (\n    :cde_name!,\n    :block_height!,\n    :account_created!,\n    :implementation!,\n    :token_contract!,\n    :token_id!,\n    :chain_id!,\n    :salt!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc6551_registry_data(
- *     cde_id,
+ *     cde_name,
  *     block_height,
  *     account_created,
  *     implementation,
@@ -113,7 +113,7 @@ const cdeErc6551InsertRegistryIR: any = {"usedParamSet":{"cde_id":true,"block_he
  *     chain_id,
  *     salt
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :block_height!,
  *     :account_created!,
  *     :implementation!,

--- a/packages/node-sdk/paima-db/src/sql/cde-erc6551-registry.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc6551-registry.sql
@@ -1,17 +1,17 @@
 /* @name cdeErc6551GetOwner */
 SELECT * FROM cde_erc6551_registry_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND account_created = :account_created!;
 
 /* @name cdeErc6551GetOwnedAccounts */
 SELECT * FROM cde_erc6551_registry_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND token_contract = :token_contract!
 AND token_id = :token_id!;
 
 /* @name cdeErc6551InsertRegistry */
 INSERT INTO cde_erc6551_registry_data(
-    cde_id,
+    cde_name,
     block_height,
     account_created,
     implementation,
@@ -20,7 +20,7 @@ INSERT INTO cde_erc6551_registry_data(
     chain_id,
     salt
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :block_height!,
     :account_created!,
     :implementation!,

--- a/packages/node-sdk/paima-db/src/sql/cde-erc721.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc721.queries.ts
@@ -3,13 +3,13 @@ import { PreparedQuery } from '@pgtyped/runtime';
 
 /** 'CdeErc721GetOwner' parameters type */
 export interface ICdeErc721GetOwnerParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
 }
 
 /** 'CdeErc721GetOwner' return type */
 export interface ICdeErc721GetOwnerResult {
-  cde_id: number;
+  cde_name: string;
   nft_owner: string;
   token_id: string;
 }
@@ -20,13 +20,13 @@ export interface ICdeErc721GetOwnerQuery {
   result: ICdeErc721GetOwnerResult;
 }
 
-const cdeErc721GetOwnerIR: any = {"usedParamSet":{"cde_id":true,"token_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":45,"b":52}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":69,"b":78}]}],"statement":"SELECT * FROM cde_erc721_data\nWHERE cde_id = :cde_id!\nAND token_id = :token_id!"};
+const cdeErc721GetOwnerIR: any = {"usedParamSet":{"cde_name":true,"token_id":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":47,"b":56}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":73,"b":82}]}],"statement":"SELECT * FROM cde_erc721_data\nWHERE cde_name = :cde_name!\nAND token_id = :token_id!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc721_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND token_id = :token_id!
  * ```
  */
@@ -35,13 +35,13 @@ export const cdeErc721GetOwner = new PreparedQuery<ICdeErc721GetOwnerParams,ICde
 
 /** 'CdeErc721GetOwnedNfts' parameters type */
 export interface ICdeErc721GetOwnedNftsParams {
-  cde_id: number;
+  cde_name: string;
   nft_owner: string;
 }
 
 /** 'CdeErc721GetOwnedNfts' return type */
 export interface ICdeErc721GetOwnedNftsResult {
-  cde_id: number;
+  cde_name: string;
   nft_owner: string;
   token_id: string;
 }
@@ -52,13 +52,13 @@ export interface ICdeErc721GetOwnedNftsQuery {
   result: ICdeErc721GetOwnedNftsResult;
 }
 
-const cdeErc721GetOwnedNftsIR: any = {"usedParamSet":{"cde_id":true,"nft_owner":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":45,"b":52}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":70,"b":80}]}],"statement":"SELECT * FROM cde_erc721_data\nWHERE cde_id = :cde_id!\nAND nft_owner = :nft_owner!"};
+const cdeErc721GetOwnedNftsIR: any = {"usedParamSet":{"cde_name":true,"nft_owner":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":47,"b":56}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":74,"b":84}]}],"statement":"SELECT * FROM cde_erc721_data\nWHERE cde_name = :cde_name!\nAND nft_owner = :nft_owner!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_erc721_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND nft_owner = :nft_owner!
  * ```
  */
@@ -67,7 +67,7 @@ export const cdeErc721GetOwnedNfts = new PreparedQuery<ICdeErc721GetOwnedNftsPar
 
 /** 'CdeErc721InsertOwner' parameters type */
 export interface ICdeErc721InsertOwnerParams {
-  cde_id: number;
+  cde_name: string;
   nft_owner: string;
   token_id: string;
 }
@@ -81,17 +81,17 @@ export interface ICdeErc721InsertOwnerQuery {
   result: ICdeErc721InsertOwnerResult;
 }
 
-const cdeErc721InsertOwnerIR: any = {"usedParamSet":{"cde_id":true,"token_id":true,"nft_owner":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":84,"b":91}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":107}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":114,"b":124}]}],"statement":"INSERT INTO cde_erc721_data(\n    cde_id,\n    token_id,\n    nft_owner\n) VALUES (\n    :cde_id!,\n    :token_id!,\n    :nft_owner!\n)"};
+const cdeErc721InsertOwnerIR: any = {"usedParamSet":{"cde_name":true,"token_id":true,"nft_owner":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":86,"b":95}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":102,"b":111}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":118,"b":128}]}],"statement":"INSERT INTO cde_erc721_data(\n    cde_name,\n    token_id,\n    nft_owner\n) VALUES (\n    :cde_name!,\n    :token_id!,\n    :nft_owner!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc721_data(
- *     cde_id,
+ *     cde_name,
  *     token_id,
  *     nft_owner
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :token_id!,
  *     :nft_owner!
  * )
@@ -102,7 +102,7 @@ export const cdeErc721InsertOwner = new PreparedQuery<ICdeErc721InsertOwnerParam
 
 /** 'CdeErc721UpdateOwner' parameters type */
 export interface ICdeErc721UpdateOwnerParams {
-  cde_id: number;
+  cde_name: string;
   nft_owner: string;
   token_id: string;
 }
@@ -116,7 +116,7 @@ export interface ICdeErc721UpdateOwnerQuery {
   result: ICdeErc721UpdateOwnerResult;
 }
 
-const cdeErc721UpdateOwnerIR: any = {"usedParamSet":{"nft_owner":true,"cde_id":true,"token_id":true},"params":[{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":43,"b":53}]},{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":70,"b":77}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":103}]}],"statement":"UPDATE cde_erc721_data\nSET\n    nft_owner = :nft_owner!\nWHERE cde_id = :cde_id!\nAND token_id = :token_id!"};
+const cdeErc721UpdateOwnerIR: any = {"usedParamSet":{"nft_owner":true,"cde_name":true,"token_id":true},"params":[{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":43,"b":53}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":72,"b":81}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":107}]}],"statement":"UPDATE cde_erc721_data\nSET\n    nft_owner = :nft_owner!\nWHERE cde_name = :cde_name!\nAND token_id = :token_id!"};
 
 /**
  * Query generated from SQL:
@@ -124,7 +124,7 @@ const cdeErc721UpdateOwnerIR: any = {"usedParamSet":{"nft_owner":true,"cde_id":t
  * UPDATE cde_erc721_data
  * SET
  *     nft_owner = :nft_owner!
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND token_id = :token_id!
  * ```
  */
@@ -148,13 +148,13 @@ export interface ICdeErc721GetAllOwnedNftsQuery {
   result: ICdeErc721GetAllOwnedNftsResult;
 }
 
-const cdeErc721GetAllOwnedNftsIR: any = {"usedParamSet":{"nft_owner":true},"params":[{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":150,"b":160}]}],"statement":"SELECT cde_name, token_id  FROM cde_erc721_data\nJOIN chain_data_extensions ON chain_data_extensions.cde_id = cde_erc721_data.cde_id\nWHERE nft_owner = :nft_owner!"};
+const cdeErc721GetAllOwnedNftsIR: any = {"usedParamSet":{"nft_owner":true},"params":[{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":176,"b":186}]}],"statement":"SELECT chain_data_extensions.cde_name, token_id  FROM cde_erc721_data\nJOIN chain_data_extensions ON chain_data_extensions.cde_name = cde_erc721_data.cde_name\nWHERE nft_owner = :nft_owner!"};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT cde_name, token_id  FROM cde_erc721_data
- * JOIN chain_data_extensions ON chain_data_extensions.cde_id = cde_erc721_data.cde_id
+ * SELECT chain_data_extensions.cde_name, token_id  FROM cde_erc721_data
+ * JOIN chain_data_extensions ON chain_data_extensions.cde_name = cde_erc721_data.cde_name
  * WHERE nft_owner = :nft_owner!
  * ```
  */
@@ -163,7 +163,7 @@ export const cdeErc721GetAllOwnedNfts = new PreparedQuery<ICdeErc721GetAllOwnedN
 
 /** 'CdeErc721Delete' parameters type */
 export interface ICdeErc721DeleteParams {
-  cde_id: number;
+  cde_name: string;
   token_id: string;
 }
 
@@ -176,13 +176,13 @@ export interface ICdeErc721DeleteQuery {
   result: ICdeErc721DeleteResult;
 }
 
-const cdeErc721DeleteIR: any = {"usedParamSet":{"cde_id":true,"token_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":43,"b":50}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":67,"b":76}]}],"statement":"DELETE FROM cde_erc721_data\nWHERE cde_id = :cde_id!\nAND token_id = :token_id!"};
+const cdeErc721DeleteIR: any = {"usedParamSet":{"cde_name":true,"token_id":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":45,"b":54}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":71,"b":80}]}],"statement":"DELETE FROM cde_erc721_data\nWHERE cde_name = :cde_name!\nAND token_id = :token_id!"};
 
 /**
  * Query generated from SQL:
  * ```
  * DELETE FROM cde_erc721_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND token_id = :token_id!
  * ```
  */
@@ -191,7 +191,7 @@ export const cdeErc721Delete = new PreparedQuery<ICdeErc721DeleteParams,ICdeErc7
 
 /** 'CdeErc721BurnInsert' parameters type */
 export interface ICdeErc721BurnInsertParams {
-  cde_id: number;
+  cde_name: string;
   nft_owner: string;
   token_id: string;
 }
@@ -205,17 +205,17 @@ export interface ICdeErc721BurnInsertQuery {
   result: ICdeErc721BurnInsertResult;
 }
 
-const cdeErc721BurnInsertIR: any = {"usedParamSet":{"cde_id":true,"token_id":true,"nft_owner":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":84,"b":91}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":107}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":114,"b":124}]}],"statement":"INSERT INTO cde_erc721_burn(\n    cde_id,\n    token_id,\n    nft_owner\n) VALUES (\n    :cde_id!,\n    :token_id!,\n    :nft_owner!\n)"};
+const cdeErc721BurnInsertIR: any = {"usedParamSet":{"cde_name":true,"token_id":true,"nft_owner":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":86,"b":95}]},{"name":"token_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":102,"b":111}]},{"name":"nft_owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":118,"b":128}]}],"statement":"INSERT INTO cde_erc721_burn(\n    cde_name,\n    token_id,\n    nft_owner\n) VALUES (\n    :cde_name!,\n    :token_id!,\n    :nft_owner!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_erc721_burn(
- *     cde_id,
+ *     cde_name,
  *     token_id,
  *     nft_owner
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :token_id!,
  *     :nft_owner!
  * )

--- a/packages/node-sdk/paima-db/src/sql/cde-erc721.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-erc721.sql
@@ -1,20 +1,20 @@
 /* @name cdeErc721GetOwner */
 SELECT * FROM cde_erc721_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND token_id = :token_id!;
 
 /* @name cdeErc721GetOwnedNfts */
 SELECT * FROM cde_erc721_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND nft_owner = :nft_owner!;
 
 /* @name cdeErc721InsertOwner */
 INSERT INTO cde_erc721_data(
-    cde_id,
+    cde_name,
     token_id,
     nft_owner
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :token_id!,
     :nft_owner!
 );
@@ -23,27 +23,27 @@ INSERT INTO cde_erc721_data(
 UPDATE cde_erc721_data
 SET
     nft_owner = :nft_owner!
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND token_id = :token_id!;
 
 /* @name cdeErc721GetAllOwnedNfts */
-SELECT cde_name, token_id  FROM cde_erc721_data
-JOIN chain_data_extensions ON chain_data_extensions.cde_id = cde_erc721_data.cde_id
+SELECT chain_data_extensions.cde_name, token_id  FROM cde_erc721_data
+JOIN chain_data_extensions ON chain_data_extensions.cde_name = cde_erc721_data.cde_name
 WHERE nft_owner = :nft_owner!;
 
 
 /* @name cdeErc721Delete */
 DELETE FROM cde_erc721_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND token_id = :token_id!;
 
 /* @name cdeErc721BurnInsert */
 INSERT INTO cde_erc721_burn(
-    cde_id,
+    cde_name,
     token_id,
     nft_owner
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :token_id!,
     :nft_owner!
 );

--- a/packages/node-sdk/paima-db/src/sql/cde-generic.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/cde-generic.queries.ts
@@ -5,13 +5,13 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
 
 /** 'CdeGenericGetAllData' parameters type */
 export interface ICdeGenericGetAllDataParams {
-  cde_id: number;
+  cde_name: string;
 }
 
 /** 'CdeGenericGetAllData' return type */
 export interface ICdeGenericGetAllDataResult {
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   event_data: Json;
   id: number;
 }
@@ -22,13 +22,13 @@ export interface ICdeGenericGetAllDataQuery {
   result: ICdeGenericGetAllDataResult;
 }
 
-const cdeGenericGetAllDataIR: any = {"usedParamSet":{"cde_id":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":53}]}],"statement":"SELECT * FROM cde_generic_data\nWHERE cde_id = :cde_id!"};
+const cdeGenericGetAllDataIR: any = {"usedParamSet":{"cde_name":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]}],"statement":"SELECT * FROM cde_generic_data\nWHERE cde_name = :cde_name!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_generic_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * ```
  */
 export const cdeGenericGetAllData = new PreparedQuery<ICdeGenericGetAllDataParams,ICdeGenericGetAllDataResult>(cdeGenericGetAllDataIR);
@@ -37,13 +37,13 @@ export const cdeGenericGetAllData = new PreparedQuery<ICdeGenericGetAllDataParam
 /** 'CdeGenericGetBlockheightData' parameters type */
 export interface ICdeGenericGetBlockheightDataParams {
   block_height: number;
-  cde_id: number;
+  cde_name: string;
 }
 
 /** 'CdeGenericGetBlockheightData' return type */
 export interface ICdeGenericGetBlockheightDataResult {
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   event_data: Json;
   id: number;
 }
@@ -54,13 +54,13 @@ export interface ICdeGenericGetBlockheightDataQuery {
   result: ICdeGenericGetBlockheightDataResult;
 }
 
-const cdeGenericGetBlockheightDataIR: any = {"usedParamSet":{"cde_id":true,"block_height":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":53}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":74,"b":87}]}],"statement":"SELECT * FROM cde_generic_data\nWHERE cde_id = :cde_id!\nAND block_height = :block_height!"};
+const cdeGenericGetBlockheightDataIR: any = {"usedParamSet":{"cde_name":true,"block_height":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":78,"b":91}]}],"statement":"SELECT * FROM cde_generic_data\nWHERE cde_name = :cde_name!\nAND block_height = :block_height!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_generic_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND block_height = :block_height!
  * ```
  */
@@ -69,7 +69,7 @@ export const cdeGenericGetBlockheightData = new PreparedQuery<ICdeGenericGetBloc
 
 /** 'CdeGenericGetRangeData' parameters type */
 export interface ICdeGenericGetRangeDataParams {
-  cde_id: number;
+  cde_name: string;
   from_block: number;
   to_block: number;
 }
@@ -77,7 +77,7 @@ export interface ICdeGenericGetRangeDataParams {
 /** 'CdeGenericGetRangeData' return type */
 export interface ICdeGenericGetRangeDataResult {
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   event_data: Json;
   id: number;
 }
@@ -88,13 +88,13 @@ export interface ICdeGenericGetRangeDataQuery {
   result: ICdeGenericGetRangeDataResult;
 }
 
-const cdeGenericGetRangeDataIR: any = {"usedParamSet":{"cde_id":true,"from_block":true,"to_block":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":53}]},{"name":"from_block","required":true,"transform":{"type":"scalar"},"locs":[{"a":75,"b":86}]},{"name":"to_block","required":true,"transform":{"type":"scalar"},"locs":[{"a":108,"b":117}]}],"statement":"SELECT * FROM cde_generic_data\nWHERE cde_id = :cde_id!\nAND block_height >= :from_block!\nAND block_height <= :to_block!"};
+const cdeGenericGetRangeDataIR: any = {"usedParamSet":{"cde_name":true,"from_block":true,"to_block":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":57}]},{"name":"from_block","required":true,"transform":{"type":"scalar"},"locs":[{"a":79,"b":90}]},{"name":"to_block","required":true,"transform":{"type":"scalar"},"locs":[{"a":112,"b":121}]}],"statement":"SELECT * FROM cde_generic_data\nWHERE cde_name = :cde_name!\nAND block_height >= :from_block!\nAND block_height <= :to_block!"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM cde_generic_data
- * WHERE cde_id = :cde_id!
+ * WHERE cde_name = :cde_name!
  * AND block_height >= :from_block!
  * AND block_height <= :to_block!
  * ```
@@ -105,7 +105,7 @@ export const cdeGenericGetRangeData = new PreparedQuery<ICdeGenericGetRangeDataP
 /** 'CdeGenericInsertData' parameters type */
 export interface ICdeGenericInsertDataParams {
   block_height: number;
-  cde_id: number;
+  cde_name: string;
   event_data: Json;
 }
 
@@ -118,17 +118,17 @@ export interface ICdeGenericInsertDataQuery {
   result: ICdeGenericInsertDataResult;
 }
 
-const cdeGenericInsertDataIR: any = {"usedParamSet":{"cde_id":true,"block_height":true,"event_data":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":90,"b":97}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":104,"b":117}]},{"name":"event_data","required":true,"transform":{"type":"scalar"},"locs":[{"a":124,"b":135}]}],"statement":"INSERT INTO cde_generic_data(\n    cde_id,\n    block_height,\n    event_data\n) VALUES (\n    :cde_id!,\n    :block_height!,\n    :event_data!\n)"};
+const cdeGenericInsertDataIR: any = {"usedParamSet":{"cde_name":true,"block_height":true,"event_data":true},"params":[{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":92,"b":101}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":108,"b":121}]},{"name":"event_data","required":true,"transform":{"type":"scalar"},"locs":[{"a":128,"b":139}]}],"statement":"INSERT INTO cde_generic_data(\n    cde_name,\n    block_height,\n    event_data\n) VALUES (\n    :cde_name!,\n    :block_height!,\n    :event_data!\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_generic_data(
- *     cde_id,
+ *     cde_name,
  *     block_height,
  *     event_data
  * ) VALUES (
- *     :cde_id!,
+ *     :cde_name!,
  *     :block_height!,
  *     :event_data!
  * )

--- a/packages/node-sdk/paima-db/src/sql/cde-generic.sql
+++ b/packages/node-sdk/paima-db/src/sql/cde-generic.sql
@@ -1,25 +1,25 @@
 /* @name cdeGenericGetAllData */
 SELECT * FROM cde_generic_data
-WHERE cde_id = :cde_id!;
+WHERE cde_name = :cde_name!;
 
 /* @name cdeGenericGetBlockheightData */
 SELECT * FROM cde_generic_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND block_height = :block_height!;
 
 /* @name cdeGenericGetRangeData */
 SELECT * FROM cde_generic_data
-WHERE cde_id = :cde_id!
+WHERE cde_name = :cde_name!
 AND block_height >= :from_block!
 AND block_height <= :to_block!;
 
 /* @name cdeGenericInsertData */
 INSERT INTO cde_generic_data(
-    cde_id,
+    cde_name,
     block_height,
     event_data
 ) VALUES (
-    :cde_id!,
+    :cde_name!,
     :block_height!,
     :event_data!
 );

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
@@ -29,7 +29,6 @@ export const getDynamicExtensions = new PreparedQuery<IGetDynamicExtensionsParam
 
 /** 'InsertDynamicExtension' parameters type */
 export interface IInsertDynamicExtensionParams {
-  cde_id: number;
   config: string;
 }
 
@@ -42,7 +41,7 @@ export interface IInsertDynamicExtensionQuery {
   result: IInsertDynamicExtensionResult;
 }
 
-const insertDynamicExtensionIR: any = {"usedParamSet":{"cde_id":true,"config":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":80,"b":87}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":101}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_id,\n    config\n) VALUES (\n    :cde_id!,\n    :config!\n)"};
+const insertDynamicExtensionIR: any = {"usedParamSet":{"config":true},"params":[{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":119,"b":126}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_id,\n    config\n) \nSELECT \n    MAX(chain_data_extensions.cde_id),\n    :config!\nFROM\n    chain_data_extensions"};
 
 /**
  * Query generated from SQL:
@@ -50,10 +49,12 @@ const insertDynamicExtensionIR: any = {"usedParamSet":{"cde_id":true,"config":tr
  * INSERT INTO cde_dynamic_primitive_config(
  *     cde_id,
  *     config
- * ) VALUES (
- *     :cde_id!,
+ * ) 
+ * SELECT 
+ *     MAX(chain_data_extensions.cde_id),
  *     :config!
- * )
+ * FROM
+ *     chain_data_extensions
  * ```
  */
 export const insertDynamicExtension = new PreparedQuery<IInsertDynamicExtensionParams,IInsertDynamicExtensionResult>(insertDynamicExtensionIR);

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
@@ -1,0 +1,61 @@
+/** Types generated for queries found in "src/sql/dynamic-primitives.sql" */
+import { PreparedQuery } from '@pgtyped/runtime';
+
+/** 'GetDynamicExtensions' parameters type */
+export type IGetDynamicExtensionsParams = void;
+
+/** 'GetDynamicExtensions' return type */
+export interface IGetDynamicExtensionsResult {
+  cde_id: number;
+  config: string;
+}
+
+/** 'GetDynamicExtensions' query type */
+export interface IGetDynamicExtensionsQuery {
+  params: IGetDynamicExtensionsParams;
+  result: IGetDynamicExtensionsResult;
+}
+
+const getDynamicExtensionsIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT * FROM cde_dynamic_primitive_config"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * FROM cde_dynamic_primitive_config
+ * ```
+ */
+export const getDynamicExtensions = new PreparedQuery<IGetDynamicExtensionsParams,IGetDynamicExtensionsResult>(getDynamicExtensionsIR);
+
+
+/** 'InsertDynamicExtension' parameters type */
+export interface IInsertDynamicExtensionParams {
+  cde_id: number;
+  config: string;
+}
+
+/** 'InsertDynamicExtension' return type */
+export type IInsertDynamicExtensionResult = void;
+
+/** 'InsertDynamicExtension' query type */
+export interface IInsertDynamicExtensionQuery {
+  params: IInsertDynamicExtensionParams;
+  result: IInsertDynamicExtensionResult;
+}
+
+const insertDynamicExtensionIR: any = {"usedParamSet":{"cde_id":true,"config":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":80,"b":87}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":101}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_id,\n    config\n) VALUES (\n    :cde_id!,\n    :config!\n)"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO cde_dynamic_primitive_config(
+ *     cde_id,
+ *     config
+ * ) VALUES (
+ *     :cde_id!,
+ *     :config!
+ * )
+ * ```
+ */
+export const insertDynamicExtension = new PreparedQuery<IInsertDynamicExtensionParams,IInsertDynamicExtensionResult>(insertDynamicExtensionIR);
+
+

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
@@ -8,6 +8,7 @@ export type IGetDynamicExtensionsParams = void;
 export interface IGetDynamicExtensionsResult {
   cde_name: string;
   config: string;
+  parent: string;
 }
 
 /** 'GetDynamicExtensions' query type */
@@ -27,10 +28,41 @@ const getDynamicExtensionsIR: any = {"usedParamSet":{},"params":[],"statement":"
 export const getDynamicExtensions = new PreparedQuery<IGetDynamicExtensionsParams,IGetDynamicExtensionsResult>(getDynamicExtensionsIR);
 
 
+/** 'GetDynamicExtensionsByParent' parameters type */
+export interface IGetDynamicExtensionsByParentParams {
+  parent: string;
+}
+
+/** 'GetDynamicExtensionsByParent' return type */
+export interface IGetDynamicExtensionsByParentResult {
+  cde_name: string;
+  config: string;
+  parent: string;
+}
+
+/** 'GetDynamicExtensionsByParent' query type */
+export interface IGetDynamicExtensionsByParentQuery {
+  params: IGetDynamicExtensionsByParentParams;
+  result: IGetDynamicExtensionsByParentResult;
+}
+
+const getDynamicExtensionsByParentIR: any = {"usedParamSet":{"parent":true},"params":[{"name":"parent","required":true,"transform":{"type":"scalar"},"locs":[{"a":58,"b":65}]}],"statement":"SELECT * FROM cde_dynamic_primitive_config\nWHERE parent = :parent!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * FROM cde_dynamic_primitive_config
+ * WHERE parent = :parent!
+ * ```
+ */
+export const getDynamicExtensionsByParent = new PreparedQuery<IGetDynamicExtensionsByParentParams,IGetDynamicExtensionsByParentResult>(getDynamicExtensionsByParentIR);
+
+
 /** 'InsertDynamicExtension' parameters type */
 export interface IInsertDynamicExtensionParams {
   base_name: string;
   config: string;
+  parent_name: string;
 }
 
 /** 'InsertDynamicExtension' return type */
@@ -42,17 +74,19 @@ export interface IInsertDynamicExtensionQuery {
   result: IInsertDynamicExtensionResult;
 }
 
-const insertDynamicExtensionIR: any = {"usedParamSet":{"base_name":true,"config":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":92},{"a":186,"b":196}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":111,"b":118}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_name,\n    config\n) \nSELECT \n    :base_name! || COUNT(*),\n    :config!\nFROM\n    cde_dynamic_primitive_config\nWHERE starts_with(cde_name, :base_name!)"};
+const insertDynamicExtensionIR: any = {"usedParamSet":{"base_name":true,"parent_name":true,"config":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":94,"b":104},{"a":217,"b":227}]},{"name":"parent_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":123,"b":135}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":142,"b":149}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_name,\n    parent,\n    config\n) \nSELECT \n    :base_name! || COUNT(*),\n    :parent_name!,\n    :config!\nFROM\n    cde_dynamic_primitive_config\nWHERE starts_with(cde_name, :base_name!)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_dynamic_primitive_config(
  *     cde_name,
+ *     parent,
  *     config
  * ) 
  * SELECT 
  *     :base_name! || COUNT(*),
+ *     :parent_name!,
  *     :config!
  * FROM
  *     cde_dynamic_primitive_config

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
@@ -42,7 +42,7 @@ export interface IInsertDynamicExtensionQuery {
   result: IInsertDynamicExtensionResult;
 }
 
-const insertDynamicExtensionIR: any = {"usedParamSet":{"base_name":true,"config":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":92},{"a":193,"b":203}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":118,"b":125}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_name,\n    config\n) \nSELECT \n    :base_name! || '-' || COUNT(*),\n    :config!\nFROM\n    cde_dynamic_primitive_config\nWHERE starts_with(cde_name, :base_name! || '-')"};
+const insertDynamicExtensionIR: any = {"usedParamSet":{"base_name":true,"config":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":92},{"a":186,"b":196}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":111,"b":118}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_name,\n    config\n) \nSELECT \n    :base_name! || COUNT(*),\n    :config!\nFROM\n    cde_dynamic_primitive_config\nWHERE starts_with(cde_name, :base_name!)"};
 
 /**
  * Query generated from SQL:
@@ -52,11 +52,11 @@ const insertDynamicExtensionIR: any = {"usedParamSet":{"base_name":true,"config"
  *     config
  * ) 
  * SELECT 
- *     :base_name! || '-' || COUNT(*),
+ *     :base_name! || COUNT(*),
  *     :config!
  * FROM
  *     cde_dynamic_primitive_config
- * WHERE starts_with(cde_name, :base_name! || '-')
+ * WHERE starts_with(cde_name, :base_name!)
  * ```
  */
 export const insertDynamicExtension = new PreparedQuery<IInsertDynamicExtensionParams,IInsertDynamicExtensionResult>(insertDynamicExtensionIR);

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.queries.ts
@@ -6,7 +6,7 @@ export type IGetDynamicExtensionsParams = void;
 
 /** 'GetDynamicExtensions' return type */
 export interface IGetDynamicExtensionsResult {
-  cde_id: number;
+  cde_name: string;
   config: string;
 }
 
@@ -29,6 +29,7 @@ export const getDynamicExtensions = new PreparedQuery<IGetDynamicExtensionsParam
 
 /** 'InsertDynamicExtension' parameters type */
 export interface IInsertDynamicExtensionParams {
+  base_name: string;
   config: string;
 }
 
@@ -41,20 +42,21 @@ export interface IInsertDynamicExtensionQuery {
   result: IInsertDynamicExtensionResult;
 }
 
-const insertDynamicExtensionIR: any = {"usedParamSet":{"config":true},"params":[{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":119,"b":126}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_id,\n    config\n) \nSELECT \n    MAX(chain_data_extensions.cde_id),\n    :config!\nFROM\n    chain_data_extensions"};
+const insertDynamicExtensionIR: any = {"usedParamSet":{"base_name":true,"config":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":92},{"a":193,"b":203}]},{"name":"config","required":true,"transform":{"type":"scalar"},"locs":[{"a":118,"b":125}]}],"statement":"INSERT INTO cde_dynamic_primitive_config(\n    cde_name,\n    config\n) \nSELECT \n    :base_name! || '-' || COUNT(*),\n    :config!\nFROM\n    cde_dynamic_primitive_config\nWHERE starts_with(cde_name, :base_name! || '-')"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO cde_dynamic_primitive_config(
- *     cde_id,
+ *     cde_name,
  *     config
  * ) 
  * SELECT 
- *     MAX(chain_data_extensions.cde_id),
+ *     :base_name! || '-' || COUNT(*),
  *     :config!
  * FROM
- *     chain_data_extensions
+ *     cde_dynamic_primitive_config
+ * WHERE starts_with(cde_name, :base_name! || '-')
  * ```
  */
 export const insertDynamicExtension = new PreparedQuery<IInsertDynamicExtensionParams,IInsertDynamicExtensionResult>(insertDynamicExtensionIR);

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
@@ -7,8 +7,8 @@ INSERT INTO cde_dynamic_primitive_config(
     config
 ) 
 SELECT 
-    :base_name! || '-' || COUNT(*),
+    :base_name! || COUNT(*),
     :config!
 FROM
     cde_dynamic_primitive_config
-WHERE starts_with(cde_name, :base_name! || '-');
+WHERE starts_with(cde_name, :base_name!);

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
@@ -5,7 +5,9 @@ SELECT * FROM cde_dynamic_primitive_config;
 INSERT INTO cde_dynamic_primitive_config(
     cde_id,
     config
-) VALUES (
-    :cde_id!,
+) 
+SELECT 
+    MAX(chain_data_extensions.cde_id),
     :config!
-);
+FROM
+    chain_data_extensions;

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
@@ -1,0 +1,11 @@
+/* @name getDynamicExtensions */
+SELECT * FROM cde_dynamic_primitive_config;
+
+/* @name  insertDynamicExtension */
+INSERT INTO cde_dynamic_primitive_config(
+    cde_id,
+    config
+) VALUES (
+    :cde_id!,
+    :config!
+);

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
@@ -1,13 +1,19 @@
 /* @name getDynamicExtensions */
 SELECT * FROM cde_dynamic_primitive_config;
 
+/* @name getDynamicExtensionsByParent */
+SELECT * FROM cde_dynamic_primitive_config
+WHERE parent = :parent!;
+
 /* @name  insertDynamicExtension */
 INSERT INTO cde_dynamic_primitive_config(
     cde_name,
+    parent,
     config
 ) 
 SELECT 
     :base_name! || COUNT(*),
+    :parent_name!,
     :config!
 FROM
     cde_dynamic_primitive_config

--- a/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
+++ b/packages/node-sdk/paima-db/src/sql/dynamic-primitives.sql
@@ -3,11 +3,12 @@ SELECT * FROM cde_dynamic_primitive_config;
 
 /* @name  insertDynamicExtension */
 INSERT INTO cde_dynamic_primitive_config(
-    cde_id,
+    cde_name,
     config
 ) 
 SELECT 
-    MAX(chain_data_extensions.cde_id),
+    :base_name! || '-' || COUNT(*),
     :config!
 FROM
-    chain_data_extensions;
+    cde_dynamic_primitive_config
+WHERE starts_with(cde_name, :base_name! || '-');

--- a/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
@@ -7,7 +7,6 @@ export type IGetChainDataExtensionsParams = void;
 /** 'GetChainDataExtensions' return type */
 export interface IGetChainDataExtensionsResult {
   cde_hash: number | null;
-  cde_id: number;
   cde_name: string;
   cde_type: number;
   scheduled_prefix: string | null;
@@ -33,13 +32,12 @@ export const getChainDataExtensions = new PreparedQuery<IGetChainDataExtensionsP
 
 /** 'GetSpecificChainDataExtension' parameters type */
 export interface IGetSpecificChainDataExtensionParams {
-  cde_id?: number | null | void;
+  cde_name?: string | null | void;
 }
 
 /** 'GetSpecificChainDataExtension' return type */
 export interface IGetSpecificChainDataExtensionResult {
   cde_hash: number | null;
-  cde_id: number;
   cde_name: string;
   cde_type: number;
   scheduled_prefix: string | null;
@@ -52,13 +50,13 @@ export interface IGetSpecificChainDataExtensionQuery {
   result: IGetSpecificChainDataExtensionResult;
 }
 
-const getSpecificChainDataExtensionIR: any = {"usedParamSet":{"cde_id":true},"params":[{"name":"cde_id","required":false,"transform":{"type":"scalar"},"locs":[{"a":51,"b":57}]}],"statement":"SELECT * FROM chain_data_extensions\nWHERE cde_id = :cde_id"};
+const getSpecificChainDataExtensionIR: any = {"usedParamSet":{"cde_name":true},"params":[{"name":"cde_name","required":false,"transform":{"type":"scalar"},"locs":[{"a":53,"b":61}]}],"statement":"SELECT * FROM chain_data_extensions\nWHERE cde_name = :cde_name"};
 
 /**
  * Query generated from SQL:
  * ```
  * SELECT * FROM chain_data_extensions
- * WHERE cde_id = :cde_id
+ * WHERE cde_name = :cde_name
  * ```
  */
 export const getSpecificChainDataExtension = new PreparedQuery<IGetSpecificChainDataExtensionParams,IGetSpecificChainDataExtensionResult>(getSpecificChainDataExtensionIR);
@@ -72,7 +70,6 @@ export interface ISelectChainDataExtensionsByNameParams {
 /** 'SelectChainDataExtensionsByName' return type */
 export interface ISelectChainDataExtensionsByNameResult {
   cde_hash: number | null;
-  cde_id: number;
   cde_name: string;
   cde_type: number;
   scheduled_prefix: string | null;
@@ -100,7 +97,6 @@ export const selectChainDataExtensionsByName = new PreparedQuery<ISelectChainDat
 /** 'RegisterChainDataExtension' parameters type */
 export interface IRegisterChainDataExtensionParams {
   cde_hash: number;
-  cde_id?: number | null | void;
   cde_name: string;
   cde_type: number;
   scheduled_prefix?: string | null | void;
@@ -116,31 +112,70 @@ export interface IRegisterChainDataExtensionQuery {
   result: IRegisterChainDataExtensionResult;
 }
 
-const registerChainDataExtensionIR: any = {"usedParamSet":{"cde_id":true,"cde_type":true,"cde_name":true,"cde_hash":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"cde_id","required":false,"transform":{"type":"scalar"},"locs":[{"a":188,"b":194}]},{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":241,"b":250}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":257,"b":266}]},{"name":"cde_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":273,"b":282}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":289,"b":307}]},{"name":"scheduled_prefix","required":false,"transform":{"type":"scalar"},"locs":[{"a":314,"b":330}]}],"statement":"INSERT INTO\n    chain_data_extensions (\n        CDE_ID,\n        CDE_TYPE,\n        CDE_NAME,\n        CDE_HASH,\n        START_BLOCKHEIGHT,\n        SCHEDULED_PREFIX\n    )\nSELECT\n    COALESCE(:cde_id, MAX(chain_data_extensions.cde_id) + 1),\n    :cde_type!,\n    :cde_name!,\n    :cde_hash!,\n    :start_blockheight!,\n    :scheduled_prefix\nFROM\n    chain_data_extensions"};
+const registerChainDataExtensionIR: any = {"usedParamSet":{"cde_type":true,"cde_name":true,"cde_hash":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":165,"b":174}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":181,"b":190}]},{"name":"cde_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":197,"b":206}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":213,"b":231}]},{"name":"scheduled_prefix","required":false,"transform":{"type":"scalar"},"locs":[{"a":238,"b":254}]}],"statement":"INSERT INTO\n    chain_data_extensions (\n        CDE_TYPE,\n        CDE_NAME,\n        CDE_HASH,\n        START_BLOCKHEIGHT,\n        SCHEDULED_PREFIX\n    )\nVALUES (\n    :cde_type!,\n    :cde_name!,\n    :cde_hash!,\n    :start_blockheight!,\n    :scheduled_prefix\n)"};
 
 /**
  * Query generated from SQL:
  * ```
  * INSERT INTO
  *     chain_data_extensions (
- *         CDE_ID,
  *         CDE_TYPE,
  *         CDE_NAME,
  *         CDE_HASH,
  *         START_BLOCKHEIGHT,
  *         SCHEDULED_PREFIX
  *     )
- * SELECT
- *     COALESCE(:cde_id, MAX(chain_data_extensions.cde_id) + 1),
+ * VALUES (
  *     :cde_type!,
  *     :cde_name!,
  *     :cde_hash!,
  *     :start_blockheight!,
  *     :scheduled_prefix
- * FROM
- *     chain_data_extensions
+ * )
  * ```
  */
 export const registerChainDataExtension = new PreparedQuery<IRegisterChainDataExtensionParams,IRegisterChainDataExtensionResult>(registerChainDataExtensionIR);
+
+
+/** 'RegisterDynamicChainDataExtension' parameters type */
+export interface IRegisterDynamicChainDataExtensionParams {
+  base_name: string;
+  cde_type: number;
+  scheduled_prefix: string;
+  start_blockheight: number;
+}
+
+/** 'RegisterDynamicChainDataExtension' return type */
+export type IRegisterDynamicChainDataExtensionResult = void;
+
+/** 'RegisterDynamicChainDataExtension' query type */
+export interface IRegisterDynamicChainDataExtensionQuery {
+  params: IRegisterDynamicChainDataExtensionParams;
+  result: IRegisterDynamicChainDataExtensionResult;
+}
+
+const registerDynamicChainDataExtensionIR: any = {"usedParamSet":{"base_name":true,"cde_type":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":156},{"a":301,"b":311}]},{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":182,"b":191}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":198,"b":216}]},{"name":"scheduled_prefix","required":true,"transform":{"type":"scalar"},"locs":[{"a":223,"b":240}]}],"statement":"INSERT INTO\n    chain_data_extensions (\n        CDE_NAME,\n        CDE_TYPE,\n        START_BLOCKHEIGHT,\n        SCHEDULED_PREFIX\n    )\nSELECT \n    :base_name! || '-' || COUNT(*),\n    :cde_type!,\n    :start_blockheight!,\n    :scheduled_prefix!\nFROM\n    chain_data_extensions\nWHERE starts_with(cde_name, :base_name! || '-')"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO
+ *     chain_data_extensions (
+ *         CDE_NAME,
+ *         CDE_TYPE,
+ *         START_BLOCKHEIGHT,
+ *         SCHEDULED_PREFIX
+ *     )
+ * SELECT 
+ *     :base_name! || '-' || COUNT(*),
+ *     :cde_type!,
+ *     :start_blockheight!,
+ *     :scheduled_prefix!
+ * FROM
+ *     chain_data_extensions
+ * WHERE starts_with(cde_name, :base_name! || '-')
+ * ```
+ */
+export const registerDynamicChainDataExtension = new PreparedQuery<IRegisterDynamicChainDataExtensionParams,IRegisterDynamicChainDataExtensionResult>(registerDynamicChainDataExtensionIR);
 
 

--- a/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
@@ -6,7 +6,7 @@ export type IGetChainDataExtensionsParams = void;
 
 /** 'GetChainDataExtensions' return type */
 export interface IGetChainDataExtensionsResult {
-  cde_hash: number;
+  cde_hash: number | null;
   cde_id: number;
   cde_name: string;
   cde_type: number;
@@ -38,7 +38,7 @@ export interface IGetSpecificChainDataExtensionParams {
 
 /** 'GetSpecificChainDataExtension' return type */
 export interface IGetSpecificChainDataExtensionResult {
-  cde_hash: number;
+  cde_hash: number | null;
   cde_id: number;
   cde_name: string;
   cde_type: number;
@@ -71,7 +71,7 @@ export interface ISelectChainDataExtensionsByNameParams {
 
 /** 'SelectChainDataExtensionsByName' return type */
 export interface ISelectChainDataExtensionsByNameResult {
-  cde_hash: number;
+  cde_hash: number | null;
   cde_id: number;
   cde_name: string;
   cde_type: number;

--- a/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
@@ -100,7 +100,7 @@ export const selectChainDataExtensionsByName = new PreparedQuery<ISelectChainDat
 /** 'RegisterChainDataExtension' parameters type */
 export interface IRegisterChainDataExtensionParams {
   cde_hash: number;
-  cde_id: number;
+  cde_id?: number | null | void;
   cde_name: string;
   cde_type: number;
   scheduled_prefix?: string | null | void;
@@ -116,26 +116,29 @@ export interface IRegisterChainDataExtensionQuery {
   result: IRegisterChainDataExtensionResult;
 }
 
-const registerChainDataExtensionIR: any = {"usedParamSet":{"cde_id":true,"cde_type":true,"cde_name":true,"cde_hash":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"cde_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":148,"b":155}]},{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":162,"b":171}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":178,"b":187}]},{"name":"cde_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":194,"b":203}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":210,"b":228}]},{"name":"scheduled_prefix","required":false,"transform":{"type":"scalar"},"locs":[{"a":235,"b":251}]}],"statement":"INSERT INTO chain_data_extensions(\n    cde_id,\n    cde_type,\n    cde_name,\n    cde_hash,\n    start_blockheight,\n    scheduled_prefix\n) VALUES (\n    :cde_id!,\n    :cde_type!,\n    :cde_name!,\n    :cde_hash!,\n    :start_blockheight!,\n    :scheduled_prefix\n)"};
+const registerChainDataExtensionIR: any = {"usedParamSet":{"cde_id":true,"cde_type":true,"cde_name":true,"cde_hash":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"cde_id","required":false,"transform":{"type":"scalar"},"locs":[{"a":188,"b":194}]},{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":241,"b":250}]},{"name":"cde_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":257,"b":266}]},{"name":"cde_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":273,"b":282}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":289,"b":307}]},{"name":"scheduled_prefix","required":false,"transform":{"type":"scalar"},"locs":[{"a":314,"b":330}]}],"statement":"INSERT INTO\n    chain_data_extensions (\n        CDE_ID,\n        CDE_TYPE,\n        CDE_NAME,\n        CDE_HASH,\n        START_BLOCKHEIGHT,\n        SCHEDULED_PREFIX\n    )\nSELECT\n    COALESCE(:cde_id, MAX(chain_data_extensions.cde_id) + 1),\n    :cde_type!,\n    :cde_name!,\n    :cde_hash!,\n    :start_blockheight!,\n    :scheduled_prefix\nFROM\n    chain_data_extensions"};
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO chain_data_extensions(
- *     cde_id,
- *     cde_type,
- *     cde_name,
- *     cde_hash,
- *     start_blockheight,
- *     scheduled_prefix
- * ) VALUES (
- *     :cde_id!,
+ * INSERT INTO
+ *     chain_data_extensions (
+ *         CDE_ID,
+ *         CDE_TYPE,
+ *         CDE_NAME,
+ *         CDE_HASH,
+ *         START_BLOCKHEIGHT,
+ *         SCHEDULED_PREFIX
+ *     )
+ * SELECT
+ *     COALESCE(:cde_id, MAX(chain_data_extensions.cde_id) + 1),
  *     :cde_type!,
  *     :cde_name!,
  *     :cde_hash!,
  *     :start_blockheight!,
  *     :scheduled_prefix
- * )
+ * FROM
+ *     chain_data_extensions
  * ```
  */
 export const registerChainDataExtension = new PreparedQuery<IRegisterChainDataExtensionParams,IRegisterChainDataExtensionResult>(registerChainDataExtensionIR);

--- a/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/extensions.queries.ts
@@ -154,7 +154,7 @@ export interface IRegisterDynamicChainDataExtensionQuery {
   result: IRegisterDynamicChainDataExtensionResult;
 }
 
-const registerDynamicChainDataExtensionIR: any = {"usedParamSet":{"base_name":true,"cde_type":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":156},{"a":301,"b":311}]},{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":182,"b":191}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":198,"b":216}]},{"name":"scheduled_prefix","required":true,"transform":{"type":"scalar"},"locs":[{"a":223,"b":240}]}],"statement":"INSERT INTO\n    chain_data_extensions (\n        CDE_NAME,\n        CDE_TYPE,\n        START_BLOCKHEIGHT,\n        SCHEDULED_PREFIX\n    )\nSELECT \n    :base_name! || '-' || COUNT(*),\n    :cde_type!,\n    :start_blockheight!,\n    :scheduled_prefix!\nFROM\n    chain_data_extensions\nWHERE starts_with(cde_name, :base_name! || '-')"};
+const registerDynamicChainDataExtensionIR: any = {"usedParamSet":{"base_name":true,"cde_type":true,"start_blockheight":true,"scheduled_prefix":true},"params":[{"name":"base_name","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":156},{"a":294,"b":304}]},{"name":"cde_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":175,"b":184}]},{"name":"start_blockheight","required":true,"transform":{"type":"scalar"},"locs":[{"a":191,"b":209}]},{"name":"scheduled_prefix","required":true,"transform":{"type":"scalar"},"locs":[{"a":216,"b":233}]}],"statement":"INSERT INTO\n    chain_data_extensions (\n        CDE_NAME,\n        CDE_TYPE,\n        START_BLOCKHEIGHT,\n        SCHEDULED_PREFIX\n    )\nSELECT \n    :base_name! || COUNT(*),\n    :cde_type!,\n    :start_blockheight!,\n    :scheduled_prefix!\nFROM\n    chain_data_extensions\nWHERE starts_with(cde_name, :base_name!)"};
 
 /**
  * Query generated from SQL:
@@ -167,13 +167,13 @@ const registerDynamicChainDataExtensionIR: any = {"usedParamSet":{"base_name":tr
  *         SCHEDULED_PREFIX
  *     )
  * SELECT 
- *     :base_name! || '-' || COUNT(*),
+ *     :base_name! || COUNT(*),
  *     :cde_type!,
  *     :start_blockheight!,
  *     :scheduled_prefix!
  * FROM
  *     chain_data_extensions
- * WHERE starts_with(cde_name, :base_name! || '-')
+ * WHERE starts_with(cde_name, :base_name!)
  * ```
  */
 export const registerDynamicChainDataExtension = new PreparedQuery<IRegisterDynamicChainDataExtensionParams,IRegisterDynamicChainDataExtensionResult>(registerDynamicChainDataExtensionIR);

--- a/packages/node-sdk/paima-db/src/sql/extensions.sql
+++ b/packages/node-sdk/paima-db/src/sql/extensions.sql
@@ -36,10 +36,10 @@ INSERT INTO
         SCHEDULED_PREFIX
     )
 SELECT 
-    :base_name! || '-' || COUNT(*),
+    :base_name! || COUNT(*),
     :cde_type!,
     :start_blockheight!,
     :scheduled_prefix!
 FROM
     chain_data_extensions
-WHERE starts_with(cde_name, :base_name! || '-');
+WHERE starts_with(cde_name, :base_name!);

--- a/packages/node-sdk/paima-db/src/sql/extensions.sql
+++ b/packages/node-sdk/paima-db/src/sql/extensions.sql
@@ -10,18 +10,21 @@ SELECT * FROM chain_data_extensions
 WHERE cde_name = :cde_name!;
 
 /* @name registerChainDataExtension */
-INSERT INTO chain_data_extensions(
-    cde_id,
-    cde_type,
-    cde_name,
-    cde_hash,
-    start_blockheight,
-    scheduled_prefix
-) VALUES (
-    :cde_id!,
+INSERT INTO
+    chain_data_extensions (
+        CDE_ID,
+        CDE_TYPE,
+        CDE_NAME,
+        CDE_HASH,
+        START_BLOCKHEIGHT,
+        SCHEDULED_PREFIX
+    )
+SELECT
+    COALESCE(:cde_id, MAX(chain_data_extensions.cde_id) + 1),
     :cde_type!,
     :cde_name!,
     :cde_hash!,
     :start_blockheight!,
     :scheduled_prefix
-);
+FROM
+    chain_data_extensions;

--- a/packages/node-sdk/paima-db/src/sql/extensions.sql
+++ b/packages/node-sdk/paima-db/src/sql/extensions.sql
@@ -3,7 +3,7 @@ SELECT * FROM chain_data_extensions;
 
 /* @name getSpecificChainDataExtension */
 SELECT * FROM chain_data_extensions
-WHERE cde_id = :cde_id;
+WHERE cde_name = :cde_name;
 
 /* @name selectChainDataExtensionsByName */
 SELECT * FROM chain_data_extensions
@@ -12,19 +12,34 @@ WHERE cde_name = :cde_name!;
 /* @name registerChainDataExtension */
 INSERT INTO
     chain_data_extensions (
-        CDE_ID,
         CDE_TYPE,
         CDE_NAME,
         CDE_HASH,
         START_BLOCKHEIGHT,
         SCHEDULED_PREFIX
     )
-SELECT
-    COALESCE(:cde_id, MAX(chain_data_extensions.cde_id) + 1),
+VALUES (
     :cde_type!,
     :cde_name!,
     :cde_hash!,
     :start_blockheight!,
     :scheduled_prefix
+);
+
+
+/* @name registerDynamicChainDataExtension */
+INSERT INTO
+    chain_data_extensions (
+        CDE_NAME,
+        CDE_TYPE,
+        START_BLOCKHEIGHT,
+        SCHEDULED_PREFIX
+    )
+SELECT 
+    :base_name! || '-' || COUNT(*),
+    :cde_type!,
+    :start_blockheight!,
+    :scheduled_prefix!
 FROM
-    chain_data_extensions;
+    chain_data_extensions
+WHERE starts_with(cde_name, :base_name! || '-');

--- a/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
@@ -34,19 +34,6 @@ import type {
   ICdeErc1155GetByTokenIdResult,
 } from '@paima/db';
 
-/* Functions to retrieve CDE ID: */
-
-export async function getcdeNameByName(
-  readonlyDBConn: Pool,
-  cdeName: string
-): Promise<string | null> {
-  const results = await selectChainDataExtensionsByName.run({ cde_name: cdeName }, readonlyDBConn);
-  if (results.length === 0) {
-    return null;
-  }
-  return results[0].cde_name;
-}
-
 /* Functions to retrieve CDE data using the CDE ID: */
 
 export async function internalGetNftOwner(

--- a/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access-internals.ts
@@ -36,26 +36,26 @@ import type {
 
 /* Functions to retrieve CDE ID: */
 
-export async function getCdeIdByName(
+export async function getcdeNameByName(
   readonlyDBConn: Pool,
   cdeName: string
-): Promise<number | null> {
+): Promise<string | null> {
   const results = await selectChainDataExtensionsByName.run({ cde_name: cdeName }, readonlyDBConn);
   if (results.length === 0) {
     return null;
   }
-  return results[0].cde_id;
+  return results[0].cde_name;
 }
 
 /* Functions to retrieve CDE data using the CDE ID: */
 
 export async function internalGetNftOwner(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   nftId: bigint
 ): Promise<string | null> {
   const results = await cdeErc721GetOwner.run(
-    { cde_id: cdeId, token_id: nftId.toString(10) },
+    { cde_name: cdeName, token_id: nftId.toString(10) },
     readonlyDBConn
   );
   if (results.length === 0) {
@@ -80,12 +80,12 @@ export async function internalGetAllOwnedNfts(
 
 export async function internalGetOwnedNfts(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   ownerAddress: string
 ): Promise<bigint[]> {
   ownerAddress = ownerAddress.toLowerCase();
   const results = await cdeErc721GetOwnedNfts.run(
-    { cde_id: cdeId, nft_owner: ownerAddress },
+    { cde_name: cdeName, nft_owner: ownerAddress },
     readonlyDBConn
   );
   return results.map(row => BigInt(row.token_id));
@@ -93,12 +93,12 @@ export async function internalGetOwnedNfts(
 
 export async function internalGetFungibleTokenBalance(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   walletAddress: string
 ): Promise<bigint | null> {
   walletAddress = walletAddress.toLowerCase();
   const results = await cdeErc20GetBalance.run(
-    { cde_id: cdeId, wallet_address: walletAddress },
+    { cde_name: cdeName, wallet_address: walletAddress },
     readonlyDBConn
   );
   if (results.length === 0) {
@@ -110,12 +110,12 @@ export async function internalGetFungibleTokenBalance(
 
 export async function internalGetTotalDeposited(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   walletAddress: string
 ): Promise<bigint | null> {
   walletAddress = walletAddress.toLowerCase();
   const results = await cdeErc20DepositGetTotalDeposited.run(
-    { cde_id: cdeId, wallet_address: walletAddress },
+    { cde_name: cdeName, wallet_address: walletAddress },
     readonlyDBConn
   );
   if (results.length === 0) {
@@ -127,21 +127,21 @@ export async function internalGetTotalDeposited(
 
 export async function internalGetDonorsAboveThreshold(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   threshold: bigint
 ): Promise<string[]> {
-  const results = await cdeErc20DepositSelectAll.run({ cde_id: cdeId }, readonlyDBConn);
+  const results = await cdeErc20DepositSelectAll.run({ cde_name: cdeName }, readonlyDBConn);
   const aboveThreshold = results.filter(res => BigInt(res.total_deposited) >= threshold);
   return aboveThreshold.map(res => res.wallet_address);
 }
 
 export async function internalGetGenericDataBlockheight(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   blockHeight: number
 ): Promise<GenericCdeDataUnit[]> {
   const results = await cdeGenericGetBlockheightData.run(
-    { cde_id: cdeId, block_height: blockHeight },
+    { cde_name: cdeName, block_height: blockHeight },
     readonlyDBConn
   );
   return results.map(res => ({
@@ -152,12 +152,12 @@ export async function internalGetGenericDataBlockheight(
 
 export async function internalGetGenericDataBlockheightRange(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   fromBlock: number,
   toBlock: number
 ): Promise<GenericCdeDataUnit[]> {
   const results = await cdeGenericGetRangeData.run(
-    { cde_id: cdeId, from_block: fromBlock, to_block: toBlock },
+    { cde_name: cdeName, from_block: fromBlock, to_block: toBlock },
     readonlyDBConn
   );
   return results.map(res => ({
@@ -168,31 +168,31 @@ export async function internalGetGenericDataBlockheightRange(
 
 export async function internalGetErc1155AllTokens(
   readonlyDBConn: Pool,
-  cde_id: number,
+  cde_name: string,
   wallet_address: string
 ): Promise<ICdeErc1155GetAllTokensResult[]> {
-  return await cdeErc1155GetAllTokens.run({ cde_id, wallet_address }, readonlyDBConn);
+  return await cdeErc1155GetAllTokens.run({ cde_name, wallet_address }, readonlyDBConn);
 }
 
 export async function internalGetErc1155ByTokenId(
   readonlyDBConn: Pool,
-  cde_id: number,
+  cde_name: string,
   token_id: bigint
 ): Promise<ICdeErc1155GetByTokenIdResult | null> {
   return (
-    await cdeErc1155GetByTokenId.run({ cde_id, token_id: String(token_id) }, readonlyDBConn)
+    await cdeErc1155GetByTokenId.run({ cde_name, token_id: String(token_id) }, readonlyDBConn)
   )[0];
 }
 
 export async function internalGetErc1155ByTokenIdAndWallet(
   readonlyDBConn: Pool,
-  cde_id: number,
+  cde_name: string,
   wallet_address: string,
   token_id: bigint
 ): Promise<ICdeErc1155GetByTokenIdAndWalletResult | null> {
   return (
     await cdeErc1155GetByTokenIdAndWallet.run(
-      { cde_id, wallet_address, token_id: String(token_id) },
+      { cde_name, wallet_address, token_id: String(token_id) },
       readonlyDBConn
     )
   )[0];
@@ -200,11 +200,11 @@ export async function internalGetErc1155ByTokenIdAndWallet(
 
 export async function internalGetErc6551AccountOwner(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   accountCreated: string
 ): Promise<TokenIdPair | null> {
   const results = await cdeErc6551GetOwner.run(
-    { cde_id: cdeId, account_created: accountCreated },
+    { cde_name: cdeName, account_created: accountCreated },
     readonlyDBConn
   );
   if (results.length === 0) {
@@ -219,11 +219,11 @@ export async function internalGetErc6551AccountOwner(
 
 export async function internalGetAllOwnedErc6551Accounts(
   readonlyDBConn: Pool,
-  cdeId: number,
+  cdeName: string,
   nft: TokenIdPair
 ): Promise<string[]> {
   const results = await cdeErc6551GetOwnedAccounts.run(
-    { cde_id: cdeId, token_contract: nft.tokenContract, token_id: nft.tokenId },
+    { cde_name: cdeName, token_contract: nft.tokenContract, token_id: nft.tokenId },
     readonlyDBConn
   );
   return results.map(row => row.account_created);

--- a/packages/node-sdk/paima-utils-backend/src/cde-access.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access.ts
@@ -32,6 +32,7 @@ import type {
   TokenIdPair,
   CardanoAssetUtxo,
 } from './types.js';
+import { DYNAMIC_PRIMITIVE_NAME_SEPARATOR } from '@paima/utils';
 
 /**
  * Fetch the owner of the NFT from the database
@@ -235,6 +236,10 @@ export async function getCardanoAssetUtxosByPolicyId(
   policyId: string
 ): Promise<CardanoAssetUtxo[]> {
   return await internalGetCardanoAssetUtxos(readonlyDBConn, address, 'policy_id', policyId);
+}
+
+export function generateDynamicPrimitiveName(parentName: string, id: number): string {
+  return `${parentName}${DYNAMIC_PRIMITIVE_NAME_SEPARATOR}${id}`;
 }
 
 export async function getDynamicExtensions(

--- a/packages/node-sdk/paima-utils-backend/src/cde-access.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access.ts
@@ -18,11 +18,12 @@ import {
   internalGetErc1155ByTokenId,
   internalGetErc1155ByTokenIdAndWallet,
 } from './cde-access-internals.js';
-import type {
-  ICdeCardanoGetProjectedNftResult,
-  ICdeErc1155GetAllTokensResult,
-  ICdeErc1155GetByTokenIdAndWalletResult,
-  ICdeErc1155GetByTokenIdResult,
+import {
+  getDynamicExtensionsByParent,
+  type ICdeCardanoGetProjectedNftResult,
+  type ICdeErc1155GetAllTokensResult,
+  type ICdeErc1155GetByTokenIdAndWalletResult,
+  type ICdeErc1155GetByTokenIdResult,
 } from '@paima/db';
 export type { ICdeErc1155GetAllTokensResult };
 import type {
@@ -234,4 +235,13 @@ export async function getCardanoAssetUtxosByPolicyId(
   policyId: string
 ): Promise<CardanoAssetUtxo[]> {
   return await internalGetCardanoAssetUtxos(readonlyDBConn, address, 'policy_id', policyId);
+}
+
+export async function getDynamicExtensions(
+  readonlyDBConn: Pool,
+  parent: string
+): Promise<{ name: string; config: string }[]> {
+  const dbResult = await getDynamicExtensionsByParent.run({ parent: parent }, readonlyDBConn);
+
+  return dbResult.map(ext => ({ name: ext.cde_name, config: ext.config }));
 }

--- a/packages/node-sdk/paima-utils-backend/src/cde-access.ts
+++ b/packages/node-sdk/paima-utils-backend/src/cde-access.ts
@@ -1,7 +1,6 @@
 import type { Pool } from 'pg';
 
 import {
-  getCdeIdByName,
   internalGetNftOwner,
   internalGetOwnedNfts,
   internalGetFungibleTokenBalance,
@@ -41,9 +40,7 @@ export async function getNftOwner(
   cdeName: string,
   nftId: bigint
 ): Promise<string | null> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return null;
-  return await internalGetNftOwner(readonlyDBConn, cdeId, nftId);
+  return await internalGetNftOwner(readonlyDBConn, cdeName, nftId);
 }
 
 /**
@@ -78,9 +75,7 @@ export async function getOwnedNfts(
   cdeName: string,
   ownerAddress: string
 ): Promise<bigint[]> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return [];
-  return await internalGetOwnedNfts(readonlyDBConn, cdeId, ownerAddress);
+  return await internalGetOwnedNfts(readonlyDBConn, cdeName, ownerAddress);
 }
 
 /**
@@ -91,9 +86,7 @@ export async function getFungibleTokenBalance(
   cdeName: string,
   walletAddress: string
 ): Promise<bigint | null> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return null;
-  return await internalGetFungibleTokenBalance(readonlyDBConn, cdeId, walletAddress);
+  return await internalGetFungibleTokenBalance(readonlyDBConn, cdeName, walletAddress);
 }
 
 /**
@@ -104,9 +97,7 @@ export async function totalAmountDeposited(
   cdeName: string,
   walletAddress: string
 ): Promise<bigint | null> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return null;
-  return await internalGetTotalDeposited(readonlyDBConn, cdeId, walletAddress);
+  return await internalGetTotalDeposited(readonlyDBConn, cdeName, walletAddress);
 }
 
 /**
@@ -117,9 +108,7 @@ export async function findUsersWithDepositsGreaterThan(
   cdeName: string,
   thresholdAmount: bigint
 ): Promise<string[]> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return [];
-  return await internalGetDonorsAboveThreshold(readonlyDBConn, cdeId, thresholdAmount);
+  return await internalGetDonorsAboveThreshold(readonlyDBConn, cdeName, thresholdAmount);
 }
 
 /**
@@ -130,9 +119,7 @@ export async function getGenericDataBlockheight(
   cdeName: string,
   blockHeight: number
 ): Promise<GenericCdeDataUnit[]> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return [];
-  return await internalGetGenericDataBlockheight(readonlyDBConn, cdeId, blockHeight);
+  return await internalGetGenericDataBlockheight(readonlyDBConn, cdeName, blockHeight);
 }
 
 /**
@@ -144,9 +131,7 @@ export async function getGenericDataBlockheightRange(
   fromBlock: number,
   toBlock: number
 ): Promise<GenericCdeDataUnit[]> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return [];
-  return await internalGetGenericDataBlockheightRange(readonlyDBConn, cdeId, fromBlock, toBlock);
+  return await internalGetGenericDataBlockheightRange(readonlyDBConn, cdeName, fromBlock, toBlock);
 }
 
 /**
@@ -157,9 +142,7 @@ export async function getErc1155AllTokens(
   cdeName: string,
   wallet: string
 ): Promise<ICdeErc1155GetAllTokensResult[]> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return [];
-  return await internalGetErc1155AllTokens(readonlyDBConn, cdeId, wallet);
+  return await internalGetErc1155AllTokens(readonlyDBConn, cdeName, wallet);
 }
 
 /**
@@ -170,9 +153,7 @@ export async function getErc1155ByTokenId(
   cdeName: string,
   tokenId: bigint
 ): Promise<ICdeErc1155GetByTokenIdResult | null> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return null;
-  return await internalGetErc1155ByTokenId(readonlyDBConn, cdeId, tokenId);
+  return await internalGetErc1155ByTokenId(readonlyDBConn, cdeName, tokenId);
 }
 
 /**
@@ -184,9 +165,7 @@ export async function getErc1155ByTokenIdAndWallet(
   wallet: string,
   tokenId: bigint
 ): Promise<ICdeErc1155GetByTokenIdAndWalletResult | null> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return null;
-  return await internalGetErc1155ByTokenIdAndWallet(readonlyDBConn, cdeId, wallet, tokenId);
+  return await internalGetErc1155ByTokenIdAndWallet(readonlyDBConn, cdeName, wallet, tokenId);
 }
 
 /**
@@ -197,9 +176,7 @@ export async function getErc6551AccountOwner(
   cdeName: string,
   accountCreated: string
 ): Promise<TokenIdPair | null> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return null;
-  return await internalGetErc6551AccountOwner(readonlyDBConn, cdeId, accountCreated);
+  return await internalGetErc6551AccountOwner(readonlyDBConn, cdeName, accountCreated);
 }
 
 /**
@@ -210,9 +187,7 @@ export async function getAllOwnedErc6551Accounts(
   cdeName: string,
   nft: TokenIdPair
 ): Promise<string[]> {
-  const cdeId = await getCdeIdByName(readonlyDBConn, cdeName);
-  if (cdeId === null) return [];
-  return await internalGetAllOwnedErc6551Accounts(readonlyDBConn, cdeId, nft);
+  return await internalGetAllOwnedErc6551Accounts(readonlyDBConn, cdeName, nft);
 }
 
 /**

--- a/packages/paima-sdk/paima-utils/src/constants.ts
+++ b/packages/paima-sdk/paima-utils/src/constants.ts
@@ -27,6 +27,7 @@ export const enum ChainDataExtensionType {
   ERC1155 = 12,
   MinaEventGeneric = 13,
   MinaActionGeneric = 14,
+  DynamicPrimitive = 15,
 }
 
 export const enum ChainDataExtensionDatumType {
@@ -44,6 +45,7 @@ export const enum ChainDataExtensionDatumType {
   Erc1155Transfer,
   MinaEventGeneric,
   MinaActionGeneric,
+  DynamicPrimitive,
 }
 
 export const FUNNEL_PRESYNC_FINISHED = 'finished';

--- a/packages/paima-sdk/paima-utils/src/constants.ts
+++ b/packages/paima-sdk/paima-utils/src/constants.ts
@@ -55,3 +55,5 @@ export const enum InternalEventType {
   EvmLastBlock,
   MinaLastTimestamp,
 }
+
+export const DYNAMIC_PRIMITIVE_NAME_SEPARATOR = '##';

--- a/packages/paima-sdk/paima-utils/src/constants.ts
+++ b/packages/paima-sdk/paima-utils/src/constants.ts
@@ -27,7 +27,7 @@ export const enum ChainDataExtensionType {
   ERC1155 = 12,
   MinaEventGeneric = 13,
   MinaActionGeneric = 14,
-  DynamicPrimitive = 15,
+  DynamicEvmPrimitive = 15,
 }
 
 export const enum ChainDataExtensionDatumType {
@@ -45,7 +45,7 @@ export const enum ChainDataExtensionDatumType {
   Erc1155Transfer,
   MinaEventGeneric,
   MinaActionGeneric,
-  DynamicPrimitive,
+  DynamicEvmPrimitive,
 }
 
 export const FUNNEL_PRESYNC_FINISHED = 'finished';


### PR DESCRIPTION
# About

This adds a new primitive, which is used to instantiate new erc721 primitives at runtime. I tried to keep the code open for extension to other target primitives, but keeping it to erc721 for now to simplify test cases. Currently it should work for both the block funnel and the parallel evm funnel.

## Configuration

### Example
```yaml
# extensions.yaml
extensions:
  - name: "Dynamic erc721"
    type: "dynamic-primitive"
    startBlockHeight: 0
    network: "Hardhat"
    contractAddress: "0x5FbDB2315678afecb367f032d93F642f64180aa3"
    scheduledPrefix: "derc721"
    eventSignature: "MyEvent(address)"
    abiPath: "../dynamic-contract/out/EventEmitter.sol/EventEmitter.json"
    targetType: "erc721"
    fields:
      contractAddress: value
```

The primitive is based on the generic one, so it also uses a generic `eventSignature`, and it requires an abi to be provided in `abiPath`. This is because there is no standard interface for this otherwise, so I tried to keep it somewhat flexible.

- `scheduledPrefix` is the prefix _of the generated primitives_ . There is no scheduled data for the `dynamic-primitive`. This is the same for each one of the generated primitives, since I think otherwise it's not possible to write the parsing rules (if it depended on something dynamic).
- `targetType` can only be `erc721` for now.
- `fields` is used to map the event field name from the contract. So in this example the event has the following signature.

```solidity
event MyEvent(address indexed value);
```

This is used to populate the `contractAddress` field in the resulting erc721 configuration.