### PR TITLE
add transactionHash field to dynamic primitive datum

### DIFF
--- a/packages/engine/paima-funnel/src/cde/dynamic.ts
+++ b/packages/engine/paima-funnel/src/cde/dynamic.ts
@@ -31,5 +31,6 @@ export default async function getCdeDynamicEvmPrimitive(
     network,
     scheduledPrefix: extension.targetConfig.scheduledPrefix,
     burnScheduledPrefix: extension.targetConfig.burnScheduledPrefix,
+    transactionHash: event.transactionHash,
   }));
 }


### PR DESCRIPTION
I didn't rebase #362 before merging, so now master doesn't compile because of this missing field (for which there was no conflict of course). Not really sure if we should do anything with the field itself.