### PR TITLE
Fix improper CommonJS import from web3-utils

### DIFF
--- a/packages/paima-sdk/paima-concise/src/batcher.ts
+++ b/packages/paima-sdk/paima-concise/src/batcher.ts
@@ -1,5 +1,5 @@
 import type { AddressType, WalletAddress, UserSignature, InputDataString } from '@paima/utils';
-import { sha3 } from 'web3-utils';
+import web3utils from 'web3-utils';
 
 export const OUTER_BATCH_DIVIDER: string = '\x02';
 export const INNER_BATCH_DIVIDER: string = '\x03';
@@ -33,7 +33,7 @@ export function hashBatchSubunit(input: BatchedSubunit): string {
   return hashFxn(input.userAddress + input.gameInput + input.millisecondTimestamp);
 }
 
-const hashFxn = (s: string): string => sha3(s) || '0x0';
+const hashFxn = (s: string): string => web3utils.sha3(s) || '0x0';
 
 export function packInput(input: BatchedSubunit): string {
   return [


### PR DESCRIPTION
When running a `jest` test that ultimately imports this, I get an error like:

> SyntaxError: The requested module 'web3-utils' does not provide an export named 'sha3'

This seems to be because Node 20 / `cjs-module-lexer` 1.3.1 chokes on the `module.exports = {...}` object of `web3-utils` and ends up not including `sha3` as a distinct import. The solution is to import the default export and access its `.sha3` field normally. Long-term it might be better to upgrade web3-utils.

Discovered while working on https://github.com/PaimaStudios/paima-game-templates/pull/72.