### PR TITLE
Isolate STF failures to the single input that caused them

### DIFF
--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -388,6 +388,7 @@ async function processScheduledData(
       doLog(`[paima-sm] Error on scheduled data STF call. Skipping`, err);
       continue;
     }
+    if (sqlQueries.length === 0) continue;
 
     await tryOrRollback(DBConn, async () => {
       for (const [query, params] of sqlQueries) {
@@ -461,6 +462,7 @@ async function processUserInputs(
       doLog(`[paima-sm] Error on user input STF call. Skipping`, err);
       continue;
     }
+    if (sqlQueries.length === 0) continue;
 
     await tryOrRollback(DBConn, async () => {
       for (const [query, params] of sqlQueries) {


### PR DESCRIPTION
This should fix the issue I mentioned in Slack and #364 where a single STF error can cause the entire block transaction to get skipped.

I haven't tested this PR, but hopefully it works