### PR TITLE
Helper log. Made argument optional. Fix for hardhat getFee()

### DIFF
--- a/packages/engine/paima-runtime/src/cde-config/validation.ts
+++ b/packages/engine/paima-runtime/src/cde-config/validation.ts
@@ -38,6 +38,14 @@ export async function validatePersistentCdeConfig(
       return false;
     }
     if (persistent.cde_hash && persistent.cde_hash !== cde.hash) {
+      doLog(
+        'Unexpected hash for',
+        persistent.cde_name,
+        'found',
+        persistent.cde_hash,
+        'expected',
+        cde.hash
+      );
       return false;
     }
   }

--- a/packages/node-sdk/paima-db/src/scheduled-constructors.ts
+++ b/packages/node-sdk/paima-db/src/scheduled-constructors.ts
@@ -23,7 +23,7 @@ import type {
 export function createScheduledData(
   inputData: string,
   blockHeight: number,
-  cdeName: string,
+  cdeName?: string,
   txHash?: string
 ): SQLUpdate {
   const nsdParams: INewScheduledDataParams = {

--- a/packages/paima-sdk/paima-utils/src/contracts.ts
+++ b/packages/paima-sdk/paima-utils/src/contracts.ts
@@ -165,7 +165,8 @@ export function validatePaimaL2ContractAddress(address: string): void {
 
 export async function retrieveFee(address: string, web3: Web3): Promise<string> {
   const contract = getPaimaL2Contract(address, web3);
-  return await contract.methods.fee().call();
+  // getFee returns a String or BigInt
+  return String(await contract.methods.fee().call());
 }
 
 export async function getPaimaL2ContractOwner(address: string, web3: Web3): Promise<string> {


### PR DESCRIPTION
* Added log when CDE does not match. Useful for developers, when swapping contrast, doing development, and experimenting without having to resync the node or recalculate the hash manually.

* createScheduledData cdeName should be optional, as the game node uses this interface but does not insert cde scheduled data

* Hardhat getFee was returning a bigInt instead of a string, breaking the middleware for some specific wallet actions. 