### PR TITLE
Add PaimaParser.Json() helper

### DIFF
--- a/packages/paima-sdk/paima-concise/src/PaimaParser.ts
+++ b/packages/paima-sdk/paima-concise/src/PaimaParser.ts
@@ -201,7 +201,7 @@ export class PaimaParser {
     // Add standard - common expressions to parse * and |
     grammar += `
 asterisk  ::= "*"
-pipe ::= "|" 
+pipe ::= "|"
 at ::= "@"
 `;
 
@@ -318,6 +318,11 @@ at ::= "@"
       }
       return transform ? transform(input) : input;
     };
+  }
+
+  // For use with extension Primitives that supply JSON objects.
+  public static Json(): ParserCommandExec {
+    return (keyName: string, input: string) => JSON.parse(input);
   }
 
   private log(message: string): void {


### PR DESCRIPTION
The [Mina Primitive docs][1] currently advise just copy-pasting this wherever you need it. It's also used for generic EVM primitives. Seems like something useful to put in the shared toolbox.

[1]: https://docs.paimastudios.com/home/react-to-events/primitive-catalogue/mina/generic/#concise-format