### PR TITLE
fix for emulated fetch range calculation

### DIFF
--- a/packages/engine/paima-funnel/src/funnels/emulated/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/emulated/funnel.ts
@@ -118,7 +118,7 @@ export class EmulatedBlocksFunnel extends BaseFunnel {
           if (synced) break;
           if (fetchedData.length === 0) break;
           const queueTimeRange =
-            fetchedData[fetchedData.length - 1].timestamp - fetchedData[0].timestamp;
+            fetchedData[fetchedData.length - 1].timestamp - this.processingQueue[0].timestamp;
           if (queueTimeRange >= ENV.BLOCK_TIME) {
             break;
           }


### PR DESCRIPTION
`fetchedData[fetchedData.length - 1].timestamp - fetchedData[0].timestamp` is the total time for the last fetch cycle, but it should be the time window for all pending data to be processed. 