### PR TITLE
fix evm block funnel: presync is processing dyn primitives twice

### DIFF
--- a/packages/engine/paima-funnel/src/funnels/block/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/block/funnel.ts
@@ -220,7 +220,12 @@ export class BlockFunnel extends BaseFunnel implements ChainFunnel {
       const ungroupedCdeData = (
         await getUngroupedCdeData(
           this.web3,
-          this.sharedData.extensions.filter(extension => extension.network === this.chainName),
+          this.sharedData.extensions.filter(
+            extension =>
+              extension.network === this.chainName &&
+              // these are fetched above
+              extension.cdeType !== ChainDataExtensionType.DynamicEvmPrimitive
+          ),
           fromBlock,
           toBlock,
           this.chainName


### PR DESCRIPTION
Dynamic primitive events are triggered twice in the presync phase (but not in the sync), which causes the dynamic extensions to be duplicated.

Potentially we could also add a unique constraint to the config in the db just in case? But I'm not sure.