### PR TITLE
Fix batcher hash

### DIFF
--- a/packages/engine/paima-funnel/src/paima-l2-processing.ts
+++ b/packages/engine/paima-funnel/src/paima-l2-processing.ts
@@ -8,9 +8,10 @@ import {
   createMessageForBatcher,
   extractBatches,
 } from '@paima/concise';
-import { toBN, hexToUtf8, sha3 } from 'web3-utils';
+import { toBN, hexToUtf8 } from 'web3-utils';
 import type { PoolClient } from 'pg';
 import { getMainAddress } from '@paima/db';
+import { keccak_256 } from 'js-sha3';
 
 interface ValidatedSubmittedData extends STFSubmittedData {
   validated: boolean;
@@ -222,14 +223,12 @@ export function createBatchNonce(
   userAddress: string,
   inputData: string
 ): string {
-  return hashFxn(millisecondTimestamp + userAddress + inputData);
+  return '0x' + keccak_256(millisecondTimestamp + userAddress + inputData);
 }
 export function createUnbatchedNonce(
   blockHeight: number,
   userAddress: string,
   inputData: string
 ): string {
-  return hashFxn(blockHeight.toString(10) + userAddress + inputData);
+  return '0x' + keccak_256(blockHeight.toString(10) + userAddress + inputData);
 }
-
-const hashFxn = (s: string): string => sha3(s) || '0x0';

--- a/packages/paima-sdk/paima-concise/src/batcher.ts
+++ b/packages/paima-sdk/paima-concise/src/batcher.ts
@@ -1,5 +1,5 @@
 import type { AddressType, WalletAddress, UserSignature, InputDataString } from '@paima/utils';
-import { sha3 } from 'web3-utils';
+import { keccak_256 } from 'js-sha3';
 
 export const OUTER_BATCH_DIVIDER: string = '\x02';
 export const INNER_BATCH_DIVIDER: string = '\x03';
@@ -30,10 +30,8 @@ export function createMessageForBatcher(
  *       So it contains the address indirectly
  */
 export function hashBatchSubunit(input: BatchedSubunit): string {
-  return hashFxn(input.userAddress + input.gameInput + input.millisecondTimestamp);
+  return '0x' + keccak_256(input.userAddress + input.gameInput + input.millisecondTimestamp);
 }
-
-const hashFxn = (s: string): string => sha3(s) || '0x0';
 
 export function packInput(input: BatchedSubunit): string {
   return [

--- a/packages/paima-sdk/paima-utils/src/types.ts
+++ b/packages/paima-sdk/paima-utils/src/types.ts
@@ -41,21 +41,26 @@ export type TransactionTemplate = {
 export type NonceString = string;
 
 export interface SubmittedData {
-  /** Address of the wallet that submitted the data. */
+  /** Address of the wallet that submitted the data (0x0 in the case of a primitive). */
   realAddress: WalletAddress;
+  /** STF input */
   inputData: InputDataString;
   inputNonce: NonceString;
+  /** any native token sent to the L2 contract. 0 if this is not a direct user transaction  */
   suppliedValue: string;
+  /** whether or not this came from an primitive/timer or a direct user transaction */
   scheduled: boolean;
   dryRun?: boolean;
+  /** multichain identifier: https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md */
   caip2: string;
+  /** See docs for how this is calculated */
   txHash: string;
 }
 
 export interface STFSubmittedData extends SubmittedData {
   /** Mapped address to main wallet. */
   userAddress: WalletAddress;
-  /** Fixed User ID */
+  /** Fixed User ID (starting with 1 for real users, and 0 in the case of a primitive) */
   userId: number;
   /** Transaction hash of Primitive that triggered this scheduled data, if known. */
   scheduledTxHash?: string;


### PR DESCRIPTION
The function to calculate the batch subunit hash was calculated like this

```js
import { sha3 } from 'web3-utils';
sha3 (input.userAddress + input.gameInput + input.millisecondTimestamp);
```

The problem is that `web3-utils` will treat strings starting with `0x` as hexadecimal-encoded binary if the string is a hex string

This is problematic in theory, because if `input.gameInput` is an empty string, it could give something like `0x1234 + "" + 1000` which is a valid hexadecimal string

To avoid this, I'm switching to the `js-sha` function keccak256 (which is the same hash algorithm as `web3-utils`) as it doesn't do this kind of dangerous implicit conversion

I don't think this actually affected any game in theory (since gameInput usually always contains at least one `|`), but let's fix it anyway