### PR TITLE
fix error when the presync is empty in parallel evm funnel

### DIFF
--- a/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
+++ b/packages/engine/paima-funnel/src/funnels/parallelEvm/funnel.ts
@@ -96,7 +96,7 @@ export class ParallelEvmFunnel extends BaseFunnel implements ChainFunnel {
       // condition for the presync. So there is no point in starting from
       // earlier than that, since we know there are no events there.
       cachedState.lastBlock = Math.max(
-        queryResults[0].block_height,
+        queryResults[0]?.block_height || cachedState.startBlockHeight - 1,
         cachedState.startBlockHeight - 1
       );
     }


### PR DESCRIPTION
When refactoring the code for the parallel evm and avail funnel I removed a branch that was not supposed to be used anymore (it was there from the time the parallel evm funnel didn't do checkpointing for every block). In the process I forgot to guard this access (because before it was inside an if), which causes the sync to error if the presync finishes empty. Generally this is not the case, but it's likely to happen while testing.