### PR TITLE
Proposed changed to event export interface

### DIFF
--- a/packages/engine/paima-sm/src/index.ts
+++ b/packages/engine/paima-sm/src/index.ts
@@ -60,7 +60,7 @@ import type {
 import { ConfigNetworkType } from '@paima/utils';
 import assertNever from 'assert-never';
 import { keccak_256 } from 'js-sha3';
-import type { AppEvents, EventPathAndDef, generateAppEvents, ResolvedPath } from '@paima/events';
+import type { AppEvents, EventPathAndDef, ResolvedPath } from '@paima/events';
 import { PaimaEventManager } from '@paima/events';
 import { PaimaEventBroker } from '@paima/broker';
 
@@ -360,7 +360,6 @@ const SM: GameStateMachineInitializer = {
           );
 
         // Commit finishing of processing to DB
-
         const blockHeader = genV1BlockHeader(
           {
             blockHash: strip0x(latestChainData.blockHash),
@@ -379,7 +378,7 @@ const SM: GameStateMachineInitializer = {
         );
         return processedCount;
       },
-      getAppEvents(): ReturnType<typeof generateAppEvents> {
+      getAppEvents(): AppEvents {
         return events;
       },
     };
@@ -494,7 +493,7 @@ async function processScheduledData<Events extends AppEvents>(
   randomnessGenerator: Prando,
   precompiles: Precompiles['precompiles'],
   indexForEvent: (txHash: string) => number,
-  eventDefinitions: ReturnType<typeof generateAppEvents>,
+  eventDefinitions: AppEvents,
   prevBlockHash: null | Buffer
 ): Promise<TxHashes> {
   const scheduledData = await getScheduledDataByBlockHeight.run(
@@ -646,7 +645,7 @@ async function processUserInputs<Events extends AppEvents>(
   randomnessGenerator: Prando,
   indexForEvent: (txHash: string) => number,
   txIndexInBlock: number,
-  eventDefinitions: ReturnType<typeof generateAppEvents>,
+  eventDefinitions: AppEvents,
   prevBlockHash: null | Buffer
 ): Promise<TxHashes> {
   const resultingHashes: TxHashes = {
@@ -825,7 +824,7 @@ async function processInternalEvents(
 }
 
 type EventsToEmit<Event extends EventPathAndDef> = [
-  ValueOf<ReturnType<typeof generateAppEvents>>[0],
+  ValueOf<AppEvents>[0],
   ResolvedPath<Event['path']> & Event['type'],
 ][];
 
@@ -837,7 +836,7 @@ function handleEvents<Event extends EventPathAndDef>(
   sqlQueries: SQLUpdate[],
   txIndexInBlock: number,
   latestChainData: ChainData,
-  eventDefinitions: ReturnType<typeof generateAppEvents>,
+  eventDefinitions: AppEvents,
   eventsToEmit: EventsToEmit<Event>
 ): void {
   for (let log_index = 0; log_index < events.length; log_index++) {

--- a/packages/engine/paima-sm/src/types.ts
+++ b/packages/engine/paima-sm/src/types.ts
@@ -18,7 +18,7 @@ import type { SubmittedData, STFSubmittedData, PreExecutionBlockHeader } from '@
 import { Type } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
 import type { ProjectedNftStatus } from '@dcspark/carp-client';
-import type { AppEvents, generateAppEvents, ResolvedPath } from '@paima/events';
+import type { AppEvents, ResolvedPath } from '@paima/events';
 
 export interface ChainData {
   /** in seconds */
@@ -672,7 +672,7 @@ export interface GameStateMachineInitializer {
     gameStateTransitionRouter: GameStateTransitionFunctionRouter<any>,
     startBlockHeight: number,
     precompiles: Precompiles,
-    events: ReturnType<typeof generateAppEvents>
+    events: AppEvents
   ) => GameStateMachine;
 }
 
@@ -691,5 +691,5 @@ export interface GameStateMachine {
   presyncProcess: (dbTx: PoolClient, latestCdeData: PresyncChainData) => Promise<void>;
   markPresyncMilestone: (blockHeight: number, network: string) => Promise<void>;
   dryRun: (gameInput: string, userAddress: string) => Promise<boolean>;
-  getAppEvents: () => ReturnType<typeof generateAppEvents>;
+  getAppEvents: () => AppEvents;
 }

--- a/packages/engine/paima-standalone/src/sm.ts
+++ b/packages/engine/paima-standalone/src/sm.ts
@@ -1,14 +1,12 @@
 import type { GameStateMachine } from '@paima/sm';
 import PaimaSM from '@paima/sm';
-import type { AppEventsImport, PreCompilesImport } from './utils/import.js';
+import type { PreCompilesImport } from './utils/import.js';
 import { importGameStateTransitionRouter } from './utils/import.js';
 import { poolConfig } from './utils/index.js';
 import { ENV } from '@paima/utils';
+import type { AppEvents } from '@paima/events';
 
-export const gameSM = (
-  precompiles: PreCompilesImport,
-  gameEvents: AppEventsImport
-): GameStateMachine => {
+export const gameSM = (precompiles: PreCompilesImport, gameEvents: AppEvents): GameStateMachine => {
   const gameStateTransitionRouter = importGameStateTransitionRouter();
 
   return PaimaSM.initialize(
@@ -17,6 +15,6 @@ export const gameSM = (
     gameStateTransitionRouter,
     ENV.START_BLOCKHEIGHT,
     precompiles,
-    gameEvents.events
+    gameEvents
   );
 };

--- a/packages/engine/paima-standalone/src/utils/import.ts
+++ b/packages/engine/paima-standalone/src/utils/import.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import type { GameStateTransitionFunctionRouter } from '@paima/sm';
 import type { TsoaFunction } from '@paima/runtime';
 import type { AchievementMetadata } from '@paima/utils-backend';
-import type { generateAppEvents } from '@paima/events';
+import type { groupEvents, registerEvents } from '@paima/events';
 
 /**
  * Checks that the user packed their game code and it is available for Paima Engine to use to run
@@ -74,7 +74,7 @@ export function importPrecompiles(): PreCompilesImport {
 }
 
 const EVENTS_FILENAME = 'packaged/events.cjs';
-export type AppEventsImport = { events: ReturnType<typeof generateAppEvents> };
+export type AppEventsImport = { events: ReturnType<typeof registerEvents> };
 
 /**
  * Reads repackaged user's code placed next to the executable in `events.cjs` file

--- a/packages/engine/paima-standalone/src/utils/input.ts
+++ b/packages/engine/paima-standalone/src/utils/input.ts
@@ -34,6 +34,7 @@ import {
 import type { Template } from './types.js';
 import RegisterRoutes, { EngineService } from '@paima/rest';
 import { poolConfig } from './index.js';
+import { groupEvents } from '@paima/events';
 
 // Prompt user for input in the CLI
 export const userPrompt = (query: string): Promise<string> => {
@@ -144,7 +145,8 @@ export const runPaimaEngine = async (): Promise<void> => {
     // Import & initialize state machine
     const precompilesImport = importPrecompiles();
     const eventsImport = importEvents();
-    const stateMachine = gameSM(precompilesImport, eventsImport);
+    const groupedEvents = groupEvents(eventsImport.events);
+    const stateMachine = gameSM(precompilesImport, groupedEvents);
     console.log(`Connecting to database at ${poolConfig.host}:${poolConfig.port}`);
     const dbConn = await stateMachine.getReadonlyDbConn().connect();
     const funnelFactory = await FunnelFactory.initialize(dbConn);
@@ -173,7 +175,7 @@ export const runPaimaEngine = async (): Promise<void> => {
     registerDocsOpenAPI(importOpenApiJson());
     registerDocsPrecompiles(precompilesImport.precompiles);
     registerValidationErrorHandler();
-    registerDocsAppEvents(eventsImport.events);
+    registerDocsAppEvents(groupedEvents);
 
     void engine.run(ENV.STOP_BLOCKHEIGHT, ENV.SERVER_ONLY_MODE);
   } else {

--- a/packages/paima-sdk/paima-events/src/app-events.ts
+++ b/packages/paima-sdk/paima-events/src/app-events.ts
@@ -11,14 +11,13 @@ type Data<T extends LogEvent<LogEventFields<TSchema>[]>> = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AllEventsUnion<T extends ReadonlyArray<any>> = {
+type AllEventsUnion<T extends Record<string, LogEvent<LogEventFields<TSchema>[]>>> = {
   [K in keyof T]: Data<T[K]>;
-}[number];
+};
 
-type ValueArray<T> = T extends { [K in keyof T]: infer U } ? U[] : never;
 export type EventQueue<T extends Record<string, LogEvent<LogEventFields<TSchema>[]>>> = {
   address: `0x${string}`;
-  data: AllEventsUnion<ValueArray<T>>;
+  data: AllEventsUnion<T>[keyof T];
 }[];
 
 export const toSignature = <T extends LogEvent<LogEventFields<TSchema>[]>>(event: T): string => {

--- a/packages/paima-sdk/paima-events/src/app-events.ts
+++ b/packages/paima-sdk/paima-events/src/app-events.ts
@@ -96,17 +96,27 @@ export const groupEvents = <
 
 // Create payload for the stf from an object.  Using this allows statically
 // checking `data` with the type from `T`.
-export const encodeEventForStf = <T extends ReturnType<typeof genEvent>>(args: {
+export const encodeEventForStf = <
+  T extends Omit<RegisteredEvent<LogEvent<LogEventFields<TSchema>[]>>, 'path'>,
+>(args: {
   from: `0x${string}`;
   topic: T;
-  data: KeypairToObj<T['fields']>;
+  data: KeypairToObj<T['definition']['fields']>;
 }): {
   address: `0x${string}`;
-  data: { name: T['name']; fields: KeypairToObj<T['fields']>; topic: string };
+  data: {
+    name: T['definition']['name'];
+    fields: KeypairToObj<T['definition']['fields']>;
+    topic: string;
+  };
 } => {
   return {
     address: args.from,
-    data: { name: args.topic.name, fields: args.data, topic: toSignatureHash(args.topic) },
+    data: {
+      name: args.topic.definition.name,
+      fields: args.data,
+      topic: toSignatureHash(args.topic.definition),
+    },
   };
 };
 


### PR DESCRIPTION
The new code for the `events` package is as follows

```ts
import type { EventQueue } from '@paima/events';
import { registerEvents } from '@paima/events';
import { genEvent } from '@paima/events';
import { Type } from '@sinclair/typebox';

export const ClickEvent = genEvent({
  name: 'MyClickEvent',
  fields: [
    {
      indexed: true,
      name: 'user',
      type: Type.String(),
    },
    {
      name: 'time',
      type: Type.Number(),
    },
  ],
});

export const eventDefinitions = {
  ClickEvent,
} as const;

export const events = registerEvents(eventDefinitions);
export type Events = EventQueue<typeof eventDefinitions>;
```

You can then use it inside a subscribe call like this

```ts
import { events } from '@game/events';

await PaimaEventManager.Instance.subscribe(
  {
    topic: events.ClickEvent,
    filter: { user: undefined }, // all users
  },
  event => {
    console.log(`EVENT: ${event.time}`);
    callback(`Click time: ${event.time}`);
  }
);
```