### PR TITLE
fix usage of emulatedBlocksActiveOnBackend

### DIFF
--- a/packages/paima-sdk/paima-mw-core/src/endpoints/accounts.ts
+++ b/packages/paima-sdk/paima-mw-core/src/endpoints/accounts.ts
@@ -57,7 +57,9 @@ async function userWalletLogin(
 
   if (getEmulatedBlocksActive() == null) {
     try {
-      if (await emulatedBlocksActiveOnBackend()) {
+      const activeOnBackend = await emulatedBlocksActiveOnBackend();
+
+      if (activeOnBackend.success && activeOnBackend.result) {
         setEmulatedBlocksActive();
       } else {
         setEmulatedBlocksInactive();

--- a/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
+++ b/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
@@ -213,9 +213,11 @@ export async function postConciselyEncodedData(
 }
 
 async function getAdjustedHeight(deploymentChainBlockHeight: number): Promise<number> {
-  const activeOnBackend = await emulatedBlocksActiveOnBackend();
   const emulatedActive =
-    getEmulatedBlocksActive() ?? (activeOnBackend.success && activeOnBackend.result);
+    getEmulatedBlocksActive() ??
+    (await emulatedBlocksActiveOnBackend().then(
+      activeOnBackend => activeOnBackend.success && activeOnBackend.result
+    ));
 
   if (emulatedActive) {
     const BLOCK_DELAY = 1000;

--- a/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
+++ b/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
@@ -213,7 +213,10 @@ export async function postConciselyEncodedData(
 }
 
 async function getAdjustedHeight(deploymentChainBlockHeight: number): Promise<number> {
-  const emulatedActive = getEmulatedBlocksActive() ?? (await emulatedBlocksActiveOnBackend());
+  const activeOnBackend = await emulatedBlocksActiveOnBackend();
+  const emulatedActive =
+    getEmulatedBlocksActive() ?? (activeOnBackend.success && activeOnBackend.result);
+
   if (emulatedActive) {
     const BLOCK_DELAY = 1000;
 


### PR DESCRIPTION
I'm not entirely sure this is the right fix, but at the very least this seems to fix a bug where the frontend thinks the emulated blocks setting is always on (which breaks the confirmations code).

I'm not really sure what should happen if succes is false though.