### PR TITLE
Make some APIs more flexible and fix corner-case encoding bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@aiken-lang/aiken/node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "extraneous": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@aiken-lang/aiken/node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -26069,15 +26084,6 @@
         "dom-walk": "^0.1.0"
       }
     },
-    "node_modules/mina-signer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mina-signer/-/mina-signer-2.1.2.tgz",
-      "integrity": "sha512-fvi1L8vjEFHyZp66eUsCXp80A5WXEHKvGunwLikDWMilVC7bS36AvVZOc1s+8F48xNsKXuxcwkMrPWPzNgechA==",
-      "dependencies": {
-        "blakejs": "^1.2.1",
-        "js-sha256": "^0.9.0"
-      }
-    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
@@ -39156,12 +39162,21 @@
         "algosdk": "^2.3.0",
         "bech32": "^2.0.0",
         "bs58check": "^4.0.0",
-        "mina-signer": "^2.1.1",
+        "mina-signer": "^3.0.7",
         "tweetnacl": "^1.0.3",
         "web3": "1.10.0",
         "web3-utils": "1.10.0"
-      },
-      "devDependencies": {}
+      }
+    },
+    "packages/paima-sdk/paima-crypto/node_modules/mina-signer": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/mina-signer/-/mina-signer-3.0.7.tgz",
+      "integrity": "sha512-7eYp/6WWj2VzJjvfC8dNeGMud/brdBrzkUsCdysFFXnfV2/FVpVhAGCMfaS6hs0HJtS4+eplmiD2hXfshQS8CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "blakejs": "^1.2.1",
+        "js-sha256": "^0.9.0"
+      }
     },
     "packages/paima-sdk/paima-crypto/node_modules/tweetnacl": {
       "version": "1.0.3",

--- a/packages/node-sdk/paima-db/src/delegate-wallet.ts
+++ b/packages/node-sdk/paima-db/src/delegate-wallet.ts
@@ -9,7 +9,7 @@ import {
   getDelegationsToWithAddress,
   getMainAddressFromAddress,
 } from './sql/wallet-delegation.queries.js';
-import type { PoolClient, Notification, Client } from 'pg';
+import type { Notification, Client } from 'pg';
 import type { IDatabaseConnection } from '@pgtyped/runtime/lib/tag';
 
 export type WalletDelegate = { address: string; id: number };
@@ -55,7 +55,7 @@ export async function getMainAddress(
 
 export async function getRelatedWallets(
   _address: string,
-  DBConn: PoolClient
+  DBConn: IDatabaseConnection
 ): Promise<{
   from: IGetDelegationsFromWithAddressResult[];
   to: IGetDelegationsToWithAddressResult[];

--- a/packages/node-sdk/paima-db/src/delegate-wallet.ts
+++ b/packages/node-sdk/paima-db/src/delegate-wallet.ts
@@ -29,7 +29,7 @@ export async function getMainAddress(
   _address: string,
   DBConn: IDatabaseConnection
 ): Promise<WalletDelegate> {
-  const address = _address.toLocaleLowerCase();
+  const address = _address.toLowerCase();
   let addressMapping: WalletDelegate | undefined = addressCache.get(address);
   if (useAddressCache && addressMapping) return addressMapping;
 
@@ -61,7 +61,7 @@ export async function getRelatedWallets(
   to: IGetDelegationsToWithAddressResult[];
   id: number;
 }> {
-  const address = _address.toLocaleLowerCase();
+  const address = _address.toLowerCase();
   const [addressResult] = await getAddressFromAddress.run({ address }, DBConn);
   if (!addressResult) {
     return { from: [], to: [], id: NO_USER_ID };

--- a/packages/node-sdk/paima-db/src/sql/achievements.queries.ts
+++ b/packages/node-sdk/paima-db/src/sql/achievements.queries.ts
@@ -55,7 +55,7 @@ export interface ISetAchievementProgressQuery {
   result: ISetAchievementProgressResult;
 }
 
-const setAchievementProgressIR: any = {"usedParamSet":{"wallet":true,"name":true,"completed_date":true,"progress":true,"total":true},"params":[{"name":"wallet","required":true,"transform":{"type":"scalar"},"locs":[{"a":89,"b":96}]},{"name":"name","required":true,"transform":{"type":"scalar"},"locs":[{"a":99,"b":104}]},{"name":"completed_date","required":false,"transform":{"type":"scalar"},"locs":[{"a":107,"b":121}]},{"name":"progress","required":false,"transform":{"type":"scalar"},"locs":[{"a":124,"b":132}]},{"name":"total","required":false,"transform":{"type":"scalar"},"locs":[{"a":135,"b":140}]}],"statement":"INSERT INTO achievement_progress (wallet, name, completed_date, progress, total)\nVALUES (:wallet!, :name!, :completed_date, :progress, :total)\nON CONFLICT (wallet, name)\nDO UPDATE SET\n  completed_date = EXCLUDED.completed_date,\n  progress = EXCLUDED.progress,\n  total = EXCLUDED.total"};
+const setAchievementProgressIR: any = {"usedParamSet":{"wallet":true,"name":true,"completed_date":true,"progress":true,"total":true},"params":[{"name":"wallet","required":true,"transform":{"type":"scalar"},"locs":[{"a":89,"b":96}]},{"name":"name","required":true,"transform":{"type":"scalar"},"locs":[{"a":99,"b":104}]},{"name":"completed_date","required":false,"transform":{"type":"scalar"},"locs":[{"a":107,"b":121}]},{"name":"progress","required":false,"transform":{"type":"scalar"},"locs":[{"a":124,"b":132}]},{"name":"total","required":false,"transform":{"type":"scalar"},"locs":[{"a":135,"b":140}]}],"statement":"INSERT INTO achievement_progress (wallet, name, completed_date, progress, total)\nVALUES (:wallet!, :name!, :completed_date, :progress, :total)\nON CONFLICT (wallet, name)\nDO UPDATE SET\n  completed_date = LEAST(achievement_progress.completed_date, EXCLUDED.completed_date::TIMESTAMP),\n  progress = EXCLUDED.progress,\n  total = EXCLUDED.total"};
 
 /**
  * Query generated from SQL:
@@ -64,7 +64,7 @@ const setAchievementProgressIR: any = {"usedParamSet":{"wallet":true,"name":true
  * VALUES (:wallet!, :name!, :completed_date, :progress, :total)
  * ON CONFLICT (wallet, name)
  * DO UPDATE SET
- *   completed_date = EXCLUDED.completed_date,
+ *   completed_date = LEAST(achievement_progress.completed_date, EXCLUDED.completed_date::TIMESTAMP),
  *   progress = EXCLUDED.progress,
  *   total = EXCLUDED.total
  * ```

--- a/packages/node-sdk/paima-db/src/sql/achievements.sql
+++ b/packages/node-sdk/paima-db/src/sql/achievements.sql
@@ -12,6 +12,6 @@ INSERT INTO achievement_progress (wallet, name, completed_date, progress, total)
 VALUES (:wallet!, :name!, :completed_date, :progress, :total)
 ON CONFLICT (wallet, name)
 DO UPDATE SET
-  completed_date = EXCLUDED.completed_date,
+  completed_date = LEAST(achievement_progress.completed_date, EXCLUDED.completed_date::TIMESTAMP),
   progress = EXCLUDED.progress,
   total = EXCLUDED.total;

--- a/packages/node-sdk/paima-funnel/src/funnels/emulated/funnel.ts
+++ b/packages/node-sdk/paima-funnel/src/funnels/emulated/funnel.ts
@@ -286,7 +286,7 @@ export class EmulatedBlocksFunnel extends BaseFunnel {
         processingQueue[processingQueue.length - 1]?.blockNumber ?? 0
       ),
       latestFetchedTimestamp: Math.max(
-        parseInt(res.second_timestamp, 10),
+        Number(res.second_timestamp),
         processingQueue[processingQueue.length - 1]?.timestamp ?? 0
       ),
     };

--- a/packages/node-sdk/paima-runtime/src/runtime-loops.ts
+++ b/packages/node-sdk/paima-runtime/src/runtime-loops.ts
@@ -169,7 +169,7 @@ async function getPresyncStartBlockheight(
     const caip2 = caip2PrefixFor(config[network]);
     result[caip2] = freshPresyncStart;
 
-    const latestPresyncBlockheight = await gameStateMachine.getPresyncBlockHeight(network);
+    const latestPresyncBlockheight = await gameStateMachine.getPresyncBlockHeight(caip2);
 
     if (latestPresyncBlockheight > 0) {
       result[caip2] = latestPresyncBlockheight + 1;

--- a/packages/node-sdk/paima-runtime/src/snapshots.ts
+++ b/packages/node-sdk/paima-runtime/src/snapshots.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 
-import { exec } from 'child_process';
-import type { ExecException } from 'child_process';
+import { execFile } from 'child_process';
+import type { ExecFileException } from 'child_process';
 import { doLog, logError } from '@paima/utils';
 
 const SNAPSHOT_INTERVAL = 21600;
@@ -42,18 +42,19 @@ async function getNewestFilename(dir: string): Promise<string> {
 }
 
 async function saveSnapshot(blockHeight: number): Promise<void> {
-  const username = process.env.DB_USER;
-  const password = process.env.DB_PW;
-  const database = process.env.DB_NAME;
-  const host = process.env.DB_HOST;
-  const port = process.env.DB_PORT || '5432';
   const fileName = `paima-snapshot-${blockHeight}.sql`;
   doLog(`[paima-runtime::snapshots] Saving Snapshot: ${fileName}`);
-  exec(
-    `pg_dump --dbname=postgresql://${username}:${password}@${host}:${port}/${database} -f ${snapshotPath(
-      fileName
-    )}`,
-    (error: ExecException | null, stdout: string, stderr: string) => {
+  const url = Object.assign(new URL('postgresql://'), {
+    hostname: process.env.DB_HOST,
+    port: process.env.DB_PORT || '5432',
+    username: process.env.DB_USER,
+    password: process.env.DB_PW,
+    pathname: process.env.DB_NAME,
+  } satisfies Partial<URL>).toString();
+  execFile(
+    'pg_dump',
+    [`--dbname=${url}`, '-f', snapshotPath(fileName)],
+    (error: ExecFileException | null, stdout: string, stderr: string) => {
       if (error) {
         doLog(`[paima-runtime::snapshots] Error saving snapshot: ${stderr}`);
       }

--- a/packages/node-sdk/paima-sm/src/cde-erc721-transfer.ts
+++ b/packages/node-sdk/paima-sm/src/cde-erc721-transfer.ts
@@ -21,7 +21,7 @@ export default async function processErc721Datum(
   const { to, tokenId, from } = cdeDatum.payload;
   const toAddr = to.toLowerCase();
 
-  const isBurn = Boolean(toAddr.toLocaleLowerCase().match(/^0x0+(dead)?$/g));
+  const isBurn = Boolean(toAddr.toLowerCase().match(/^0x0+(dead)?$/g));
 
   const updateList: SQLUpdate[] = [];
   try {

--- a/packages/node-sdk/paima-sm/src/delegate-wallet.ts
+++ b/packages/node-sdk/paima-sm/src/delegate-wallet.ts
@@ -76,7 +76,7 @@ export class DelegateWallet {
 
   /* Generate Plaintext Message */
   private generateMessage(internalMessage: string = ''): string {
-    return `${DelegateWallet.DELEGATE_WALLET_PREFIX}${DelegateWallet.SEP}${internalMessage.toLocaleLowerCase()}`;
+    return `${DelegateWallet.DELEGATE_WALLET_PREFIX}${DelegateWallet.SEP}${internalMessage.toLowerCase()}`;
   }
 
   private validateSender(to: string, from: string, realAddress: string): void {
@@ -305,7 +305,7 @@ export class DelegateWallet {
             this.verifySignature(from, this.generateMessage(to), from_signature),
             this.verifySignature(to, this.generateMessage(from), to_signature),
           ]);
-          await this.cmdDelegate(from.toLocaleLowerCase(), to.toLocaleLowerCase());
+          await this.cmdDelegate(from.toLowerCase(), to.toLowerCase());
           doLog(`Delegate Wallet ${from.substring(0, 8)}... -> ${to.substring(0, 8)}...`);
           return true;
         }
@@ -319,14 +319,14 @@ export class DelegateWallet {
             this.verifySignature(from, this.generateMessage(to), from_signature),
             this.verifySignature(to, this.generateMessage(from), to_signature),
           ]);
-          await this.cmdMigrate(from.toLocaleLowerCase(), to.toLocaleLowerCase());
+          await this.cmdMigrate(from.toLowerCase(), to.toLowerCase());
 
           doLog(`Migrate Wallet ${from.substring(0, 8)}... -> ${to.substring(0, 8)}...`);
           return true;
         }
         case 'cancelDelegations': {
           const { to } = parsed.args;
-          await this.cmdCancelDelegations(userAddress.toLocaleLowerCase(), to.toLocaleLowerCase());
+          await this.cmdCancelDelegations(userAddress.toLowerCase(), to.toLowerCase());
           doLog(
             `Cancel Delegate ${userAddress.substring(0, 8)}... -> ${to ? to.substring(0, 8) + '...' : '*'}`
           );

--- a/packages/node-sdk/paima-sm/src/types.ts
+++ b/packages/node-sdk/paima-sm/src/types.ts
@@ -192,7 +192,7 @@ interface CdeDatumDynamicEvmPrimitivePayload {
   targetConfig:
     | {
         type: CdeEntryTypeName.ERC721;
-        scheduledPrefix: string;
+        scheduledPrefix?: string | undefined;
         burnScheduledPrefix?: string | undefined;
       }
     | {
@@ -246,7 +246,7 @@ export interface CdeErc721MintDatum extends CdeEvmDatumBase {
   cdeDatumType: ChainDataExtensionDatumType.ERC721Mint;
   payload: CdeDatumErc721MintPayload;
   contractAddress: string;
-  scheduledPrefix: string;
+  scheduledPrefix: string | undefined;
 }
 
 export interface CdeErc20DepositDatum extends CdeEvmDatumBase {
@@ -405,7 +405,7 @@ export const ChainDataExtensionErc721Config = Type.Intersect([
   Type.Object({
     type: Type.Literal(CdeEntryTypeName.ERC721),
     contractAddress: EvmAddress,
-    scheduledPrefix: Type.String(),
+    scheduledPrefix: Type.Optional(Type.String()),
     burnScheduledPrefix: Type.Optional(Type.String()),
   }),
 ]);

--- a/packages/paima-sdk/paima-crypto/package.json
+++ b/packages/paima-sdk/paima-crypto/package.json
@@ -23,18 +23,17 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest run"
   },
-  "devDependencies": {},
   "dependencies": {
-    "web3": "1.10.0",
-    "web3-utils": "1.10.0",
     "@cardano-foundation/cardano-verify-datasignature": "^1.0.11",
-    "algosdk": "^2.3.0",
-    "tweetnacl": "^1.0.3",
+    "@paima/utils": "5.0.0",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
+    "algosdk": "^2.3.0",
     "bech32": "^2.0.0",
-    "@paima/utils": "5.0.0",
-    "mina-signer": "^2.1.1",
-    "bs58check": "^4.0.0"
+    "bs58check": "^4.0.0",
+    "mina-signer": "^3.0.7",
+    "tweetnacl": "^1.0.3",
+    "web3": "1.10.0",
+    "web3-utils": "1.10.0"
   }
 }

--- a/packages/paima-sdk/paima-crypto/src/mina.ts
+++ b/packages/paima-sdk/paima-crypto/src/mina.ts
@@ -24,7 +24,7 @@ export class MinaCrypto implements IVerify {
         return false;
       }
 
-      const Client = (await import('mina-signer')).default;
+      const { default: Client } = await import('mina-signer');
 
       const signerClient = new Client({ network: network as NetworkId });
 

--- a/packages/paima-sdk/paima-mw-core/src/delegate-wallet/index.ts
+++ b/packages/paima-sdk/paima-mw-core/src/delegate-wallet/index.ts
@@ -106,7 +106,7 @@ export class WalletConnectHelper {
   private static readonly SEP = ':';
 
   public buildMessageToSign(subMessage: string): string {
-    return `${WalletConnectHelper.DELEGATE_WALLET_PREFIX}${WalletConnectHelper.SEP}${subMessage.toLocaleLowerCase()}`;
+    return `${WalletConnectHelper.DELEGATE_WALLET_PREFIX}${WalletConnectHelper.SEP}${subMessage.toLowerCase()}`;
   }
 
   private getProvider(walletType: AddressType): IProvider<unknown> {

--- a/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
+++ b/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
@@ -212,7 +212,9 @@ export async function postConciselyEncodedData(
   }
 }
 
-async function getAdjustedHeight(deploymentChainBlockHeight: number): Promise<number> {
+async function getAdjustedHeight(deploymentChainBlockHeight: number): Promise<Result<number>> {
+  const errorFxn = buildEndpointErrorFxn('getAdjustedHeight');
+
   const emulatedActive =
     getEmulatedBlocksActive() ??
     (await emulatedBlocksActiveOnBackend().then(
@@ -221,17 +223,22 @@ async function getAdjustedHeight(deploymentChainBlockHeight: number): Promise<nu
 
   if (emulatedActive) {
     const BLOCK_DELAY = 1000;
+    // -1 here means the block isn't part of the chain yet so we can't know the mapping
+    const BLOCK_NOT_PART_OF_CHAIN_YET = -1;
 
-    while (true) {
+    for (let i = 0; i < BATCHER_RETRIES; ++i) {
       const remote = await deploymentChainBlockHeightToEmulated(deploymentChainBlockHeight);
-      // TODO: magic number. -1 here means the block isn't part of the chain yet so we can't know the mapping
-      if (!(remote.success === false || remote.result === -1)) {
-        return remote.result;
+      if (remote.success === true && remote.result !== BLOCK_NOT_PART_OF_CHAIN_YET) {
+        return remote;
       }
       await wait(BLOCK_DELAY);
     }
+    return errorFxn(
+      PaimaMiddlewareErrorCode.ERROR_POSTING_TO_BATCHER,
+      "emulated block didn't succeed in time"
+    );
   } else {
-    return deploymentChainBlockHeight;
+    return { success: true, result: deploymentChainBlockHeight };
   }
 }
 
@@ -250,10 +257,7 @@ async function postString(
       TX_VERIFICATION_RETRY_DELAY,
       TX_VERIFICATION_RETRY_COUNT
     );
-    return {
-      success: true,
-      result: await getAdjustedHeight(deploymentChainBlockHeight),
-    };
+    return await getAdjustedHeight(deploymentChainBlockHeight);
   } catch (err) {
     return errorFxn(PaimaMiddlewareErrorCode.ERROR_POSTING_TO_CHAIN, err);
   }
@@ -342,10 +346,7 @@ async function verifyBatcherSubmission(inputHash: string): Promise<Result<number
           FE_ERR_BATCHER_REJECTED_INPUT
         );
       } else if (status.status === 'posted') {
-        return {
-          success: true,
-          result: await getAdjustedHeight(status.block_height),
-        };
+        return await getAdjustedHeight(status.block_height);
       }
     } catch (err) {
       errorFxn(PaimaMiddlewareErrorCode.INVALID_RESPONSE_FROM_BATCHER, err);

--- a/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
+++ b/packages/paima-sdk/paima-mw-core/src/helpers/posting.ts
@@ -222,15 +222,14 @@ async function getAdjustedHeight(deploymentChainBlockHeight: number): Promise<nu
   if (emulatedActive) {
     const BLOCK_DELAY = 1000;
 
-    // TODO: magic number. -1 here means the block isn't part of the chain yet so we can't know the mapping
-    let block = -1;
-    while (block === -1) {
+    while (true) {
       const remote = await deploymentChainBlockHeightToEmulated(deploymentChainBlockHeight);
-      if (remote.success === false || remote.result === -1) {
-        await wait(BLOCK_DELAY);
+      // TODO: magic number. -1 here means the block isn't part of the chain yet so we can't know the mapping
+      if (!(remote.success === false || remote.result === -1)) {
+        return remote.result;
       }
+      await wait(BLOCK_DELAY);
     }
-    return block;
   } else {
     return deploymentChainBlockHeight;
   }

--- a/packages/paima-sdk/paima-mw-core/src/helpers/query-constructors.ts
+++ b/packages/paima-sdk/paima-mw-core/src/helpers/query-constructors.ts
@@ -21,15 +21,13 @@ export function buildBackendQuery(endpoint: string, options: QueryOptions): stri
 }
 
 export function buildQuery(endpoint: string, options: QueryOptions): string {
-  const optStrings: string[] = [];
-  for (let opt in options) {
-    const valString = queryValueToString(options[opt]);
-    optStrings.push(`${opt}=${valString}`);
-  }
-  if (optStrings.length === 0) {
+  const queryString = new URLSearchParams(
+    Object.entries(options).map(([k, v]) => [k, queryValueToString(v)])
+  ).toString();
+  if (queryString.length === 0) {
     return endpoint;
   } else {
-    return `${endpoint}?${optStrings.join('&')}`;
+    return `${endpoint}?${queryString}`;
   }
 }
 


### PR DESCRIPTION
- Fix possible crash in presync on second run due to passing network name where caip2 is expected.
- Allow `getRelatedWallets` to accept any `IDatabaseConnection`, not just `PoolClient`.
- Make ERC721 primitive `scheduledPrefix` optional in case a game doesn't need to react to mint events.
- Fix middleware `buildQuery` helper not escaping values; e.g. `{"a": "b&c=d"}` now properly round-trips.
- Fix snapshots not saving if DB password contains special characters.
- Fix `getAdjustedHeight` for emulated block mode always infinite looping.
- Use `toLowerCase` instead of `toLocaleLowerCase` on wallet addresses to avoid theoretical problems if a server is ever run in [Turkish locale](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase#description).
- Attempt to fix inconsistent CJS/ESM incompatibility issues with `mina-signer` by upgrading to a version that has native ESM support.
- Tweak setAchievementProgress to keep existing completed_date if set.