### PR TITLE
Add flipped parser for the unsafe JSON typebox helper

### DIFF
--- a/packages/node-sdk/sync/src/sync-protocols/evm/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/evm/fetcher.ts
@@ -74,7 +74,7 @@ export class EvmFetcher
         [
           all(
             keysOf(groupedByPage).map(function* (pageJson) {
-              const page = Value.Decode(PageSchema, pageJson);
+              const page = Value.Encode(PageSchema, pageJson);
               return {
                 raw: yield* call(() => pageFetcher(page)),
                 primitives: groupedByPage[pageJson],
@@ -105,7 +105,7 @@ export class EvmFetcher
           { length: data.to - data.from + 1 },
           (_, i) => i + data.from,
         ).map(function* (page: Page) {
-          const key = Value.Encode(PageSchema, page);
+          const key = Value.Decode(PageSchema, page);
           return {
             raw: yield* call(() => pageFetcher(page)),
             primitives: groupedByPage[key] ?? [],
@@ -133,7 +133,7 @@ export class EvmFetcher
     primitives: PrimitiveType[],
   ): Record<EvmRpcPageJson, PrimitiveType[]> {
     return primitives.reduce((acc, primitive) => {
-      const key = Value.Encode(
+      const key = Value.Decode(
         PageSchema,
         Number(primitive.output.syncProtocol.payload.ownChain.blockNumber),
       );

--- a/packages/node-sdk/sync/src/sync-protocols/evm/types.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/evm/types.ts
@@ -14,10 +14,10 @@ export type Page = BlockNumber;
 const PageJsonSchema = Type.Unsafe<
   EvmRpcPageJson
 >(Type.String());
-export const PageSchema = TypeboxHelpers.JsonUnsafeCast<
+export const PageSchema = TypeboxHelpers.SerializeObjAsJson<
   Page,
   typeof PageJsonSchema
->(PageJsonSchema);
+>();
 
 export type PrimitiveType = FlattenSyncProtocolIOFor<
   ConfigSyncProtocolType.EVM_RPC_MAIN | ConfigSyncProtocolType.EVM_RPC_PARALLEL,

--- a/packages/paima-sdk/config/src/schema/primitive/output/evm/rpc.ts
+++ b/packages/paima-sdk/config/src/schema/primitive/output/evm/rpc.ts
@@ -106,7 +106,7 @@ export const PrimitiveEvmRpcErc1155TransferSyncProtocolResponse = Type.Object({
 // Generic
 // =======
 
-// TODO: should this be a string and/or JsonUnsafeCast?
+// TODO: should this be a string and/or SerializeObjAsJson?
 export const PrimitiveEvmRpcGenericPayload = Type.Any();
 
 export const PrimitiveEvmRpcGenericSyncProtocolResponse = Type.Object({

--- a/packages/paima-sdk/config/src/schema/primitive/output/midnight/graphql.ts
+++ b/packages/paima-sdk/config/src/schema/primitive/output/midnight/graphql.ts
@@ -19,9 +19,10 @@ const MidnightEncodedStateJsonSchema = Type.Unsafe<
   MidnightEncodedStateJson
 >(Type.String());
 export const PrimitiveMidnightContractStatePayload = TypeboxHelpers
-  .JsonUnsafeCast<EncodedStateValue, typeof MidnightEncodedStateJsonSchema>(
-    MidnightEncodedStateJsonSchema,
-  );
+  .SerializeObjAsJson<
+    EncodedStateValue,
+    typeof MidnightEncodedStateJsonSchema
+  >();
 export const PrimitiveMidnightContractStateSyncProtocolResponse = Type.Object({
   primitive: Type.Literal(ConfigPrimitiveType.MidnightContractState),
   payloadType: Type.Literal(ConfigPrimitivePayloadType.Event),

--- a/packages/paima-sdk/config/src/schema/primitive/output/mod.ts
+++ b/packages/paima-sdk/config/src/schema/primitive/output/mod.ts
@@ -3,5 +3,5 @@ export * from "./types.ts";
 export * from "./cardano/carp.ts";
 export * from "./common.ts";
 export * from "./evm/rpc.ts";
-export * from "./midnight.ts";
-export * from "./mina.ts";
+export * from "./midnight/graphql.ts";
+export * from "./mina/graphql.ts";

--- a/packages/paima-sdk/config/src/schema/sync-protocols/cardano/carp.ts
+++ b/packages/paima-sdk/config/src/schema/sync-protocols/cardano/carp.ts
@@ -22,10 +22,10 @@ import {
 // =====
 
 const CarpCursorJsonSchema = Type.Unsafe<CarpCursorJson>(Type.String());
-export const CarpCursor = TypeboxHelpers.JsonUnsafeCast<{
+export const CarpCursor = TypeboxHelpers.SerializeObjAsJson<{
   block: CardanoBlockHash;
   tx: CardanoTxHash;
-}, typeof CarpCursorJsonSchema>(CarpCursorJsonSchema);
+}, typeof CarpCursorJsonSchema>();
 
 // ===========
 // Base schema

--- a/packages/paima-sdk/utils/src/types/typebox-helpers.ts
+++ b/packages/paima-sdk/utils/src/types/typebox-helpers.ts
@@ -12,6 +12,7 @@ import type {
   TString,
   TTransform,
   TUnion,
+  TUnsafe,
 } from "@sinclair/typebox";
 import { Value, ValueErrorType } from "@sinclair/typebox/value";
 import type { AbiEvent } from "abitype";
@@ -234,7 +235,14 @@ export const TypeboxHelpers = {
     schema: T,
     options?: SchemaOptions,
   ): TUnion<[T, TNull]> => Type.Union([schema, Type.Null()], options),
-  JsonUnsafeCast: <
+  SerializeObjAsJson: <
+    T,
+    StringSchema extends TSchema & { [Kind]: string } = TString,
+  >(): TTransform<TUnsafe<T>, Static<StringSchema>> =>
+    Type.Transform(Type.Unsafe<T>(Type.Any()))
+      .Decode((x) => JSON.stringify(x) as Static<StringSchema>)
+      .Encode((x) => JSON.parse(x as string) as T),
+  SerializeJsonAsObj: <
     T,
     StringSchema extends TSchema & { [Kind]: string } = TString,
   >(


### PR DESCRIPTION
There are cases where it's not realistic to rewrite types from an external library into Typebox. In these cases, we had an unsafe cast where types would be represented as a JSON string at rest, and written to files as an object 

This PR adds the inverse case where it's represented as a Javascript object at rest, and written to files as a JSON string