### PR TITLE
Simplify quickstart instructions and add links to check.sh

### DIFF
--- a/docs/site/docs/home/0-intro/0-intro.md
+++ b/docs/site/docs/home/0-intro/0-intro.md
@@ -18,23 +18,19 @@ Paima Engine is a Web3 Engine optimized for dApps, games, gamification and auton
 
 ## App Quick Start
 
-> Linux and Macos are supported. Windows WSL is experimental.
+> Linux and macOS are supported. Windows WSL is experimental.
 
 > This is a preview of the Paima Engine V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
 
-First clone the repository and copy the `/templates/evm-midnight/` folder, this will give us a working template.
+First, clone the repository and use the `templates/evm-midnight/` folder as a working template:
 
 ```sh
 # Clone and move to evm-midnight template
-git clone git@github.com:PaimaStudios/paima-engine.git
-cd paima-engine
-git checkout v-next
-cd templates/evm-midnight
-```
+git clone git@github.com:PaimaStudios/paima-engine.git --branch v-next
+cd paima-engine/templates/evm-midnight
 
-```sh
 # Check for external dependencies
-./../check.sh
+../check.sh
 
 # Install packages
 deno install --allow-scripts && ./patch.sh
@@ -48,7 +44,7 @@ deno task dev
 ```
 
 Now you should see the dApp running in your browser!
-Continue the [Quick Start Guide](../10-quickstart/10-quickstart.md)
+Continue at the [Quick Start Guide](../10-quickstart/10-quickstart.md).
 
 ## What is Paima Engine
 

--- a/docs/site/docs/home/0-intro/0-intro.md
+++ b/docs/site/docs/home/0-intro/0-intro.md
@@ -8,10 +8,11 @@ slug: /
 ## What is Paima Engine
 
 Paima Engine is a Web3 Engine optimized for dApps, games, gamification and autonomous worlds that allows quickly building web3 apps.
-  * Connect multiple chains, leveraging their tech as tokens, and existing markets.
-  * Build on-chain dApps without blockchain specific knowledge.
-  * Secure: all interactions go into the chains and not your Paima Node.
-  * Iterate quickly as tools are developer centered.
+
+- Connect multiple chains, leveraging their tech as tokens, and existing markets.
+- Build on-chain dApps without blockchain specific knowledge.
+- Secure: all interactions go into the chains and not your Paima Node.
+- Iterate quickly as tools are developer centered.
 
 [Learn more about Paima Engine](./1-what-is-paima-engine.md)
 
@@ -20,7 +21,6 @@ Paima Engine is a Web3 Engine optimized for dApps, games, gamification and auton
 > Linux and Macos are supported. Windows WSL is experimental.
 
 > This is a preview of the Paima Engine V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
-
 
 First clone the repository and copy the `/templates/evm-midnight/` folder, this will give us a working template.
 
@@ -47,9 +47,8 @@ deno task build:midnight
 deno task dev
 ```
 
-
-Now you should see the dApp running in your browser!  
-Continue the [Quick Start Guide](../10-quickstart/10-quickstart.md) 
+Now you should see the dApp running in your browser!
+Continue the [Quick Start Guide](../10-quickstart/10-quickstart.md)
 
 ## What is Paima Engine
 
@@ -57,18 +56,15 @@ Continue the [Quick Start Guide](../10-quickstart/10-quickstart.md)
 
 [Learn more about Paima Engine](./1-what-is-paima-engine.md)
 
-
 ## Main Components
 
-* [Chain Sync](../100-components/101-sync-service.md)
-* [State Machine](../100-components/102-state-machine.md)
-* [API](../100-components/103-api.md)
+- [Chain Sync](../100-components/101-sync-service.md)
+- [State Machine](../100-components/102-state-machine.md)
+- [API](../100-components/103-api.md)
 
 [See All Components](../100-components//100-components.md)
 
-
 ## Guide for Paima Engine Contributor
 
-* [Paima Engine Architecture](../1000-paima-engine/1000-paima-engine.md)
-* [Contribution Guide](../1000-paima-engine/1100-contributions.md)
-
+- [Paima Engine Architecture](../1000-paima-engine/1000-paima-engine.md)
+- [Contribution Guide](../1000-paima-engine/1100-contributions.md)

--- a/docs/site/docs/home/10-quickstart/10-quickstart.md
+++ b/docs/site/docs/home/10-quickstart/10-quickstart.md
@@ -36,42 +36,47 @@ deno task dev
 Now you should see the dApp running in your browser!
 
 ### Terminal
+
 <iframe src="https://drive.google.com/file/d/1vLHmm9HrPrKiIHJlnnX3aopeX0J-A9Oz/preview" width="640" height="480" allow="autoplay"></iframe>
 
 ### Browser
+
 <iframe src="https://drive.google.com/file/d/1hDh5PkKQdDx8UXnBsS1clypvXF14Msvm/preview" width="640" height="480" allow="autoplay"></iframe>
 
 Once you have the template up and running, there are different parts you can modify or extend.
-* **State Machine**: Logic and rules for events.
-* **Front End**: User side App.
-* **Chain Config**: Connect different chains.
-* **Process Orchestrator**: Decide what processes to start and run for development.
-* **Contracts & Paima-L2**: Deploy and connect different contracts.
-* **Grammar**: Define Paima-L2 Contract valid Inputs
 
-More [Components](../100-components/100-components.md) 
+- **State Machine**: Logic and rules for events.
+- **Front End**: User side App.
+- **Chain Config**: Connect different chains.
+- **Process Orchestrator**: Decide what processes to start and run for development.
+- **Contracts & Paima-L2**: Deploy and connect different contracts.
+- **Grammar**: Define Paima-L2 Contract valid Inputs
+
+More [Components](../100-components/100-components.md)
 
 ## Packages & Folder Structure
 
 > We will be using `/templates/evm-midnight/` as example for the following definitions.
 
 Default folder structure:
+
 ```
 |-- deno.json                     # workspace definition
 |-- packages
-     |-- client                   # paima engine node  
+     |-- client                   # paima engine node
      |     |-- database           # database queries and tables
      |     |-- node               # node startup, api, and state machine
      |
      |-- frontend                 # web app
-     | 
+     |
      |-- shared                   # shared components between client and frontend
      |     |-- contracts/evm      # hardhat & evm contracts
      |     |-- contracts/midnight # midnight contracts
-     |     |-- data-types         # grammar and node sync/contract definitions 
+     |     |-- data-types         # grammar and node sync/contract definitions
 ```
 
 Workspace packages:
+
 ```
 
 client/database              @example-evm-midnight/database
@@ -81,6 +86,7 @@ shared/contracts/evm         @example-evm-midnight/evm-contracts
 shared/contracts/midnight    @example-evm-midnight/midnight-contracts
 shared/contracts/data-types  @example-evm-midnight/data-types
 ```
+
 ## Startup Overview
 
 The Paima Engine Startup sequence:
@@ -101,7 +107,7 @@ graph TD
     subgraph "Phase 1: Orchestration"
         B(Process Orchestrator)
         subgraph "Launches & Monitors Dependencies"
-            
+
             C[fa:fa-server Infrastructure:<br/>Database, Collector, ...]
             D[fa:fa-database Dev Tools:<br/>TUI, Explorer, ...]
             E[fa:fa-network-wired Chain Services:<br/>Nodes, Indexers, Proof Server, Deploy Contracts, ...]
@@ -130,9 +136,9 @@ graph TD
     D --> G;
     E --> G;
     F --> G;
-    
+
     G -- All services ready --> H;
-    
+
     H --> L;
     H --> I;
     H --> J;
@@ -163,7 +169,6 @@ main(function* () {
 
 Learn more about the [Node Startup](../100-components/117-node-startup.md)
 
-
 ## State Machine
 
 A State Machine (SM) is the core of your Paima Engine application, defining its logic and rules. Let's break down the concept:
@@ -184,19 +189,18 @@ Events         STF-2 (e.g., handle transfer)   (database)
 Let's start with a practical example where calls to a `Paima L2` contract are converted into actions.
 
 For example, this STF:
+
 ```ts
-stm.addStateTransition(
-  "create",
-  function* (data) {
-    const { game_id } = data.parsedInput.payload;
-    yield* World.resolve(create_game, {
-      game_id: game_id,
-      block_height: data.blockHeight,
-    });
-    return;
-  },
-);
+stm.addStateTransition("create", function* (data) {
+  const { game_id } = data.parsedInput.payload;
+  yield* World.resolve(create_game, {
+    game_id: game_id,
+    block_height: data.blockHeight,
+  });
+  return;
+});
 ```
+
 If the contract [PaimaL2 Event](../100-components/104-paima-l2-contract.md) function `submitGameInput` is called with payload `["create", "0x1234"]`, this creates a row in your `games` table, with id = `0x1234`
 
 Now your application can read the database and use the created "game" from the table.
@@ -205,23 +209,24 @@ More about the [State Machine](../100-components/102-state-machine.md)
 
 ## Frontend (dApp)
 
-The frontend is your user-facing application, such as a web game or a dashboard. 
+The frontend is your user-facing application, such as a web game or a dashboard.
 The `/templates/evm-midnight/` comes with a folder called `/packages/frontend/` with an example Web App. It interacts with Paima Engine in two primary ways:
 
-
 ### Writes (Sending Actions)
+
 > Paima Engine web application, games or other frontend require to write to the Blockchain to interact with Paima Engine.
 
-* **Direct Contract Interaction**. E.g., Call `transfer` on a `ERC20` contract. Wallets can be integrated to make these calls.
-* **Direct Paima L2 Contract Interaction**: `Submit Input` method. This allows to pass a custom message to the engine. Wallets can be integrated to make these calls.  
-* **Batcher Interaction**: Interact with your contracts, but through a HTTP calls. This custom built service can convert and validate the calls and writes to the Contract.
+- **Direct Contract Interaction**. E.g., Call `transfer` on a `ERC20` contract. Wallets can be integrated to make these calls.
+- **Direct Paima L2 Contract Interaction**: `Submit Input` method. This allows to pass a custom message to the engine. Wallets can be integrated to make these calls.
+- **Batcher Interaction**: Interact with your contracts, but through a HTTP calls. This custom built service can convert and validate the calls and writes to the Contract.
 
 ### Reads
-* **Reads from Blockchain** Some blockchains expose APIs you can read to get the state or other information. We do not recommend doing this unless strictly necessary.
-* **Reads from Paima Engine API** Paima Engine Provides son Endpoints you can consume.
-* **Reads from Custom API** You can create your own custom endpoints.
 
-More about the [Frontend](../100-components/115-frontend.md)  
+- **Reads from Blockchain** Some blockchains expose APIs you can read to get the state or other information. We do not recommend doing this unless strictly necessary.
+- **Reads from Paima Engine API** Paima Engine Provides son Endpoints you can consume.
+- **Reads from Custom API** You can create your own custom endpoints.
+
+More about the [Frontend](../100-components/115-frontend.md)
 More about the [API](../100-components/103-api.md)
 
 ## Chain Config & Sync Service
@@ -293,39 +298,36 @@ While any contract works, Paima provides the specialized **`PaimaL2Contract`**, 
 
 You connect a contract event to your State Machine by defining a **Primitive** in your chain configuration, which links the event to a `scheduledPrefix` that triggers your game logic.
 
-Learn more about [Contracts](../100-components/105-contracts.md)  
+Learn more about [Contracts](../100-components/105-contracts.md)
 More about [Paima L2](../100-components/104-paima-l2-contract.md)
 
 ## Process Orchestrator
 
 Developing a multi-chain dApp requires running many services at once. The **Process Orchestrator** is a powerful tool that automates your entire local development setup.
 
-When you run `deno task dev`, the orchestrator defined in the `start.ts` file at the `/template/evm-midnight/` example, and launches your complete environment in the correct order. 
+When you run `deno task dev`, the orchestrator defined in the `start.ts` file at the `/template/evm-midnight/` example, and launches your complete environment in the correct order.
 
 This includes:
 
-*   Starting local blockchains (EVM, Midnight, etc.).
-*   Deploying your smart contracts.
-*   Running essential services like a development database and the Paima Batcher.
+- Starting local blockchains (EVM, Midnight, etc.).
+- Deploying your smart contracts.
+- Running essential services like a development database and the Paima Batcher.
 
 By handling all this infrastructure automatically, the orchestrator makes local development a simple, one-command process. Once the environment is ready, it starts the main **Paima Sync Service**, which begins syncing data and running your state machine.
 
 ```ts
 const config = Value.Parse(OrchestratorConfig, {
-    processes: {
-        // Launch Dev DB & Collector
-        [ComponentNames.PAIMA_PGLITE]: true,
-        [ComponentNames.COLLECTOR]: true,
-    },
+  processes: {
+    // Launch Dev DB & Collector
+    [ComponentNames.PAIMA_PGLITE]: true,
+    [ComponentNames.COLLECTOR]: true,
+  },
 
-    processesToLaunch: [
-        startEvm,
-        startMidnight,
-    ],
+  processesToLaunch: [startEvm, startMidnight],
 });
 await start(config);
-
 ```
+
 More about [Processes Orchestrator](../100-components/106-processes.md)
 
 ## Grammar
@@ -335,13 +337,14 @@ The Grammar is the language of your dApp, connecting on-chain inputs to your Sta
 The first element (`"attack"`) is the **prefix**. It acts as a command that the engine uses to route the input to the correct State Transition Function (STF). You define these rules in a `grammar.ts` file, specifying the name and data type for each argument. This provides automatic validation and type-safety for all user actions.
 
 Example grammar definition:
+
 ```ts
 export const grammar = {
   attack: [
     ["playerId", Type.Integer()],
     ["moveId", Type.Integer()],
   ],
-  
+
   // Auto-generate other primitives
   ...Object.fromEntries(
     Object.entries(mapPrimitivesToGrammar(localhostConfig.primitives))
@@ -350,7 +353,6 @@ export const grammar = {
 ```
 
 More about [Grammar](../100-components/111-grammar.md)
-
 
 ## Next Steps: Dive Deeper into Paima Engine
 
@@ -362,55 +364,55 @@ Now you're ready to explore the full power and flexibility of the engine. Use th
 
 You've touched on the basics, now master the details of the components you've already used:
 
-*   [State Machine](../100-components/102-state-machine.md): Learn advanced techniques for managing your dApp's logic.
-*   [Sync Service & Chain Config](../100-components/101-sync-service.md): Uncover the full potential of multi-chain data aggregation.
-*   [Contracts & The Paima L2 Contract](../100-components/105-contracts.md): Explore the specifics of the `PaimaL2Contract` and other provided contracts.
-*   [Grammar](../100-components/111-grammar.md): Master the language of your dApp for complex interactions.
-*   [Frontend (dApp)](../100-components/115-frontend.md): Discover best practices for building user interfaces.
+- [State Machine](../100-components/102-state-machine.md): Learn advanced techniques for managing your dApp's logic.
+- [Sync Service & Chain Config](../100-components/101-sync-service.md): Uncover the full potential of multi-chain data aggregation.
+- [Contracts & The Paima L2 Contract](../100-components/105-contracts.md): Explore the specifics of the `PaimaL2Contract` and other provided contracts.
+- [Grammar](../100-components/111-grammar.md): Master the language of your dApp for complex interactions.
+- [Frontend (dApp)](../100-components/115-frontend.md): Discover best practices for building user interfaces.
 
 ### Advanced Features & Services
 
 Level up your application with Paima's powerful, built-in services:
 
-*   [**Batcher**](../100-components/108-batcher.md): Offer a gasless, cross-chain experience to your users.
-*   [**Accounts**](../100-components/116-accounts.md): Implement a flexible L2 account system that goes beyond simple wallets.
-*   [**Randomness**](../100-components/113-randomness.md): Learn how to use Paima's deterministic randomness for fair and replayable game mechanics.
-*   [**Database**](../100-components/109-database.md): Take full control of your application's data with custom tables and queries.
-*   [**Achievements**](../100-components/114-achievements.md): Integrate a standardized achievement system into your dApp.
+- [**Batcher**](../100-components/108-batcher.md): Offer a gasless, cross-chain experience to your users.
+- [**Accounts**](../100-components/116-accounts.md): Implement a flexible L2 account system that goes beyond simple wallets.
+- [**Randomness**](../100-components/113-randomness.md): Learn how to use Paima's deterministic randomness for fair and replayable game mechanics.
+- [**Database**](../100-components/109-database.md): Take full control of your application's data with custom tables and queries.
+- [**Achievements**](../100-components/114-achievements.md): Integrate a standardized achievement system into your dApp.
 
 ### Multi-Chain Development
 
 Paima is a multi-chain engine at its core. Learn how to connect to and leverage the unique capabilities of different blockchains:
 
-*   [EVM Chains (Ethereum, Arbitrum, etc.)](../200-chains/201-evm.md)
-*   [Midnight (Zero-Knowledge)](../200-chains/202-midnight.md)
-*   [Cardano](../200-chains/203-cardano.md)
-*   [Avail (Data Availability)](../200-chains/204-avail.md)
+- [EVM Chains (Ethereum, Arbitrum, etc.)](../200-chains/201-evm.md)
+- [Midnight (Zero-Knowledge)](../200-chains/202-midnight.md)
+- [Cardano](../200-chains/203-cardano.md)
+- [Avail (Data Availability)](../200-chains/204-avail.md)
 
 ### Deployment and Lifecycle
 
 Ready to go live? These guides cover the final steps in your development journey:
 
-*   [Deploying Your Game to Production](../300-deployment/301-deploy-game.md)
-*   [Versioning and Upgrading Your dApp](../300-deployment/302-versioning.md)
+- [Deploying Your Game to Production](../300-deployment/301-deploy-game.md)
+- [Versioning and Upgrading Your dApp](../300-deployment/302-versioning.md)
 
 ### Standards and Interoperability (PRCs)
 
 Paima Request for Comments (PRCs) are open standards that enable interoperability between dApps in the Paima ecosystem. Implementing these standards can enhance composability and user engagement.
 
-*   **PRC-1**: A standard for in-game achievements.
-*   **PRC-2**: The "Hololocker" for projecting L1 NFTs into your dApp without bridging.
-*   **PRC-3 & PRC-5**: "Inverse Projection" standards for representing in-game assets as tradable NFTs and tokens on major L1s.
+- **PRC-1**: A standard for in-game achievements.
+- **PRC-2**: The "Hololocker" for projecting L1 NFTs into your dApp without bridging.
+- **PRC-3 & PRC-5**: "Inverse Projection" standards for representing in-game assets as tradable NFTs and tokens on major L1s.
 
 ### See it all in Action: The Tarochi Example
 
 To see how all these components come together to build a complete, complex, and successful on-chain game, dive into our comprehensive tutorial based on a real-world example.
 
-*   [**Building Tarochi with Paima Engine**](../1100-example-tarochi/1100-example-tarochi.md)
+- [**Building Tarochi with Paima Engine**](../1100-example-tarochi/1100-example-tarochi.md)
 
 ### Contributing to Paima Engine
 
 For advanced developers interested in the engine's internals or looking to contribute:
 
-*   [Paima Engine Packages (NPM & JSR)](../1000-paima-engine/1000-paima-engine.md)
-*   [How to Contribute](../1000-paima-engine/1100-contributions.md)
+- [Paima Engine Packages (NPM & JSR)](../1000-paima-engine/1000-paima-engine.md)
+- [How to Contribute](../1000-paima-engine/1100-contributions.md)

--- a/docs/site/docs/home/10-quickstart/10-quickstart.md
+++ b/docs/site/docs/home/10-quickstart/10-quickstart.md
@@ -5,22 +5,18 @@ slug: /quick-start
 
 # Quick Start
 
-> Linux and Macos are supported. Windows WSL is experimental.
+> Linux and macOS are supported. Windows WSL is experimental.
 
 > This is a preview of the Paima Engine V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
 
-First clone the repository and copy the `/templates/evm-midnight/` folder, this will give us a working template.
+First, clone the repository and use the `templates/evm-midnight/` folder as a working template:
 
 ```sh
-git clone git@github.com:PaimaStudios/paima-engine.git
-cd paima-engine
-git checkout v-next
-cd templates/evm-midnight
-```
+git clone git@github.com:PaimaStudios/paima-engine.git --branch v-next
+cd paima-engine/templates/evm-midnight
 
-```sh
 # Check for external dependencies
-./../check.sh
+../check.sh
 
 # Install packages
 deno install --allow-scripts && ./patch.sh

--- a/templates/check.sh
+++ b/templates/check.sh
@@ -74,9 +74,11 @@ if command -v deno &> /dev/null; then
         print_success "deno is installed (version: $DENO_VERSION) - meets requirement >= $REQUIRED_DENO_VERSION"
     else
         print_error "deno version $DENO_VERSION is installed but version >= $REQUIRED_DENO_VERSION is required. Please upgrade deno."
+        echo "🌐 https://docs.deno.com/runtime/getting_started/installation/"
     fi
 else
     print_error "deno is not installed. Please install deno >= $REQUIRED_DENO_VERSION."
+    echo "🌐 https://docs.deno.com/runtime/getting_started/installation/"
 fi
 echo
 
@@ -90,9 +92,11 @@ if command -v node &> /dev/null; then
         print_success "node is installed (version: $NODE_VERSION) - meets requirement >= 22"
     else
         print_error "node version $NODE_VERSION is installed but version >= 22 is required. Please upgrade node."
+        echo "🌐 https://nodejs.org/en/download"
     fi
 else
     print_error "node is not installed. Please install node >= 22."
+    echo "🌐 https://nodejs.org/en/download"
 fi
 echo
 
@@ -129,6 +133,7 @@ if FORGE_OUTPUT=$(forge --version 2>/dev/null); then
     print_success "forge is installed (version: $FORGE_VERSION)"
 else
     print_error "forge is not installed. Please install Foundry (forge)."
+    echo "🌐 https://getfoundry.sh/introduction/installation"
 fi
 echo
 
@@ -150,6 +155,7 @@ if COMPACT_OUTPUT=$(compact --version 2>/dev/null); then
     echo
 else
     print_error "compact is not installed. Please install compact."
+    echo "🌐 https://github.com/midnightntwrk/compact/releases"
 fi
 echo
 

--- a/templates/check.sh
+++ b/templates/check.sh
@@ -1,16 +1,8 @@
-
 #!/bin/bash
-
 # Dependency checker script
-# This script checks for all required dependencies and shows error messages for missing ones
+# This script checks for all required dependencies and shows error messages for missing ones.
 
 set -e  # Exit on any error
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
 
 # Track if any checks failed
 FAILED=0
@@ -18,20 +10,24 @@ FAILED=0
 echo "🔍 Checking dependencies..."
 echo
 
-# Function to print success message
+# Colors for output
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+NC=$'\033[0m' # No Color
+
 print_success() {
-    printf "${GREEN}✅ $1${NC}\n"
+    echo "${GREEN}✅ $1${NC}"
 }
 
-# Function to print error message
 print_error() {
-    printf "${RED}❌ $1${NC}\n"
+    echo "${RED}❌ $1${NC}"
     FAILED=1
 }
 
-# Function to print warning message
 print_warning() {
-    printf "${YELLOW}⚠️  $1${NC}\n"
+    # Two spaces because terminals seem not to know this is double-width.
+    echo "${YELLOW}⚠️  $1${NC}"
 }
 
 # Function to compare semantic versions
@@ -88,8 +84,8 @@ echo
 echo "Checking node..."
 if command -v node &> /dev/null; then
     NODE_VERSION=$(node --version | sed 's/v//')
-    NODE_MAJOR=$(echo $NODE_VERSION | cut -d'.' -f1)
-    
+    NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d'.' -f1)
+
     if [ "$NODE_MAJOR" -ge 22 ]; then
         print_success "node is installed (version: $NODE_VERSION) - meets requirement >= 22"
     else
@@ -141,27 +137,28 @@ echo "Checking compact..."
 if COMPACT_OUTPUT=$(compact --version 2>/dev/null); then
     COMPACT_VERSION=$(echo "$COMPACT_OUTPUT" | head -n1 | cut -d' ' -f2)
     print_success "compact is installed (version: $COMPACT_VERSION)"
+
+    # Check if compact compile is working
+    echo "Checking compact compile..."
+    if COMPACT_COMPILE_OUTPUT=$(compact compile --version 2>/dev/null); then
+        COMPACT_COMPILE_VERSION=$(echo "$COMPACT_COMPILE_OUTPUT" | head -n1)
+        print_success "compact compile is working (version: $COMPACT_COMPILE_VERSION)"
+    else
+        print_error "compact compile is not working. Please check your compact installation."
+        echo "   Consider running \`compact update\`."
+    fi
+    echo
 else
     print_error "compact is not installed. Please install compact."
-fi
-echo
-
-# Check if compact compile is working
-echo "Checking compact compile..."
-if COMPACT_COMPILE_OUTPUT=$(compact compile --version 2>/dev/null); then
-    COMPACT_COMPILE_VERSION=$(echo "$COMPACT_COMPILE_OUTPUT" | head -n1)
-    print_success "compact compile is working (version: $COMPACT_COMPILE_VERSION)"
-else
-    print_error "compact compile is not working. Please check your compact installation."
 fi
 echo
 
 # Final result
 echo "================================================"
 if [ $FAILED -eq 0 ]; then
-    printf "${GREEN}🎉 All dependency checks passed!${NC}\n"
+    echo "${GREEN}🎉 All dependency checks passed!${NC}"
     exit 0
 else
-    printf "${RED}💥 Some dependency checks failed. Please install the missing dependencies.${NC}\n"
+    echo "${RED}💥 Some dependency checks failed. Please install the missing dependencies.${NC}"
     exit 1
 fi


### PR DESCRIPTION
Quickstart docs:
- Autoformat Markdown (using Prettier)
- Simplify `git clone` command

check.sh:
- Fix shellcheck warnings
- Add links to the installation instructions for Deno, Node, Forge, and Compact

---

Autoformatting can be undone if it seems noisy.