### PR TITLE
Show logs immediately instead of on a 300ms timer

### DIFF
--- a/packages/build-tools/tui/src/logs-server.ts
+++ b/packages/build-tools/tui/src/logs-server.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { fastify, type FastifyRequest } from "fastify";
 import { type Static, Type } from "@sinclair/typebox";
 import { ENV } from "@paima/utils/node-env";
@@ -26,7 +27,7 @@ const LogDisplayControlSchema = Type.Object({
 });
 type LogDisplayControl = Static<typeof LogDisplayControlSchema>;
 
-export class LogServer {
+export class LogServer extends EventEmitter<{ "addLogs": [OTelLog[]] }> {
   private dataStore = new RingBuffer<OTelLog>(MAX_DATA_ITEMS);
   private processLogStates: Record<string, boolean> = {}; // Track per-process log display state
 
@@ -63,9 +64,11 @@ export class LogServer {
     for (const log of logs) {
       this.dataStore.push(log);
     }
+    this.emit("addLogs", logs);
   }
 
-  public async init() {
+  /** Start the OTel HTTP server, returning once it's listening. */
+  public async start() {
     this.server.post("/v1/data", {
       schema: {
         body: Type.Array(OTelLogSchema),

--- a/packages/build-tools/tui/src/logs-standalone.ts
+++ b/packages/build-tools/tui/src/logs-standalone.ts
@@ -7,7 +7,6 @@ import { ENV } from "@paima/utils/node-env";
 // This is a standalone script that can be used to view logs from the collector.
 // Its purpose is to be used in a tmux session, and not as a part of the TUI.
 class LogsViewer {
-  private readonly pollInterval = 300; // ms
   public isRunning = false;
   private logDisplayStates: Record<string, boolean> = {};
   private logServer: LogServer;
@@ -70,20 +69,15 @@ class LogsViewer {
   }
 
   async start(): Promise<void> {
-    // Do not await, so it runs in the background.
-    this.logServer.init();
+    console.log("🔍 Starting log server...");
 
-    console.log("🔍 Starting log viewer...");
-    console.log(`📡 Polling every ${this.pollInterval}ms`);
-    console.log("Press Ctrl+C to stop\n");
-
-    this.isRunning = true;
     try {
       Deno.lstatSync("./logs");
     } catch (error) {
       Deno.mkdirSync("./logs", { recursive: true });
     }
 
+    // Set up displayLogs's destination
     attachTransport((logObj: ILogObj) => {
       const message = logObj[0] as string;
       const cleanMessage = message.replace(this.ansiRegex(), "");
@@ -96,16 +90,12 @@ class LogsViewer {
       );
     });
 
-    const poll = async () => {
-      if (!this.isRunning) return;
-      const logs = this.logServer.getData();
-      this.displayLogs(logs);
-      await new Promise((resolve) => setTimeout(resolve, this.pollInterval));
-      poll();
-    };
+    // Attach log server to displayLogs then start the log server
+    this.logServer.on("addLogs", (logs) => this.displayLogs(logs));
+    await this.logServer.start();
 
-    // Start polling
-    poll();
+    this.isRunning = true;
+    console.log("🔍 Log viewer started. Press Ctrl+C to stop.");
   }
 }
 
@@ -129,10 +119,10 @@ Deno.addSignalListener("SIGINT", () => {
   Deno.exit(0);
 });
 
-viewer.start().then(() => {
-  console.log("🔍 Log viewer started");
-}).catch((error) => {
+try {
+  await viewer.start();
+} catch (error) {
   console.error(error);
   killTmux();
   Deno.exit(1);
-});
+}


### PR DESCRIPTION
The ring buffer is still available to HTTP clients at `/v1/data`, but the command-line view now prints each log event it receives immediately, fixing the stuttery appearance.