### PR TITLE
Orchestrator: dependsOn

### DIFF
--- a/e2e/client/node/scripts/e2e.start.ts
+++ b/e2e/client/node/scripts/e2e.start.ts
@@ -26,16 +26,6 @@ const avail_enabled = Deno
   ? (Deno.env.get("DISABLE_AVAIL") === "true" ? false : true)
   : true;
 
-const evmProcessesExtended = launchEvm("@e2e/evm-contracts");
-// Add batcher after the evm processes because it needs the contracts to be deployed
-evmProcessesExtended.stopProcessAtPort.push(3334);
-evmProcessesExtended.processes.push({
-  name: "batcher",
-  args: ["task", "-f", "@e2e/batcher", "start"],
-  waitToExit: false,
-  type: "system-dependency",
-});
-
 /**
  * Launch the Sync through the orchestrator,
  * and wait for the sync process to start and be ready.
@@ -47,7 +37,6 @@ export async function startup(): Promise<Client> {
     logs,
     processes: {
       [ComponentNames.PAIMA_PGLITE]: !external_db_enabled,
-      [ComponentNames.DOCS]: false,
       [ComponentNames.TUI]: false,
       [ComponentNames.TMUX]: false,
     },
@@ -56,24 +45,29 @@ export async function startup(): Promise<Client> {
 
     // Launch my processes
     processesToLaunch: [
-      evmProcessesExtended,
-      yaci_enabled ? launchCardano("@e2e/cardano-contracts") : {},
-      midnight_enabled ? launchMidnight("@e2e/midnight-contracts") : {},
-      avail_enabled ? launchAvail("@e2e/avail-contracts") : {},
+      ...launchEvm("@e2e/evm-contracts"),
+      ...(yaci_enabled ? launchCardano("@e2e/cardano-contracts") : []),
+      ...(midnight_enabled ? launchMidnight("@e2e/midnight-contracts") : []),
+      ...(avail_enabled ? launchAvail("@e2e/avail-contracts") : []),
       {
-        processes: [
-          {
-            name: "frontend-build",
-            args: ["task", "-f", "@paima/explorer", "build"],
-            waitToExit: true,
-          },
-          {
-            name: "e2e-wallet",
-            args: ["task", "-f", "@e2e/wallets-ui", "build"],
-            waitToExit: true,
-          },
-        ],
+        name: "build explorer",
+        args: ["task", "-f", "@paima/explorer", "build"],
+        waitToExit: true,
       },
+      {
+        name: "build e2e-wallet-ui",
+        args: ["task", "-f", "@e2e/wallets-ui", "build"],
+        waitToExit: true,
+      },
+
+      {
+        stopProcessAtPort: [3334],
+        name: "batcher",
+        args: ["task", "-f", "@e2e/batcher", "start"],
+        waitToExit: false,
+        type: "system-dependency",
+        dependsOn: [ComponentNames.DEPLOY_EVM_CONTRACTS],
+      }
     ],
   });
   start(config);

--- a/e2e/client/node/scripts/start.ts
+++ b/e2e/client/node/scripts/start.ts
@@ -24,24 +24,11 @@ const avail_enabled = Deno
   ? (Deno.env.get("DISABLE_AVAIL") === "true" ? false : true)
   : true;
 
-const evmProcessesExtended = launchEvm("@e2e/evm-contracts");
-// Add batcher after the evm processes because it needs the contracts to be deployed
-evmProcessesExtended.stopProcessAtPort.push(3334);
-evmProcessesExtended.processes.push(
-  { // Launch the Batcher with our PaimaL2 Contract
-    name: "batcher",
-    args: ["task", "-f", "@e2e/batcher", "start"],
-    waitToExit: false,
-    type: "system-dependency",
-  },
-);
-
 const config = Value.Parse(OrchestratorConfig, {
   logs,
   processes: {
     [ComponentNames.TMUX]: logs === "development",
     [ComponentNames.TUI]: logs === "development",
-    [ComponentNames.DOCS]: false,
     // Launch Dev DB & Collector
     [ComponentNames.PAIMA_PGLITE]: !external_db_enabled,
     [ComponentNames.COLLECTOR]: logs === "development",
@@ -51,27 +38,34 @@ const config = Value.Parse(OrchestratorConfig, {
 
   // Launch my processes
   processesToLaunch: [
-    evmProcessesExtended,
-    yaci_enabled ? launchCardano("@e2e/cardano-contracts") : {},
-    avail_enabled ? launchAvail("@e2e/avail-contracts") : {},
-    midnight_enabled ? launchMidnight("@e2e/midnight-contracts") : {},
-    {
+    ...launchEvm("@e2e/evm-contracts"),
+    ...(yaci_enabled ? launchCardano("@e2e/cardano-contracts") : []),
+    ...(avail_enabled ? launchAvail("@e2e/avail-contracts") : []),
+    ...(midnight_enabled ? launchMidnight("@e2e/midnight-contracts") : []),
+    { 
+      name: "build explorer",
       stopProcessAtPort: [10590],
-      processes: [
-        {
-          name: "frontend-build",
-          args: ["task", "-f", "paima/explorer", "build"],
-          waitToExit: true,
-        },
-        {
-          name: "frontend-server",
-          args: ["task", "-f", "@paima/explorer", "server:start"],
-          waitToExit: false,
-          type: "system-dependency",
-          link: "http://localhost:10590",
-        },
-      ],
+      args: ["task", "-f", "paima/explorer", "build"],
+      waitToExit: true,
+      dependsOn: [],
     },
+    {
+      name: "serve explorer",
+      args: ["task", "-f", "@paima/explorer", "server:start"],
+      waitToExit: false,
+      type: "system-dependency",
+      link: "http://localhost:10590",
+      dependsOn: [],
+    },
+    { 
+      // Launch the Batcher with our PaimaL2 Contract
+      stopProcessAtPort: [3334],
+      name: "batcher",
+      args: ["task", "-f", "@e2e/batcher", "start"],
+      waitToExit: false,
+      type: "system-dependency",
+      dependsOn: [ComponentNames.DEPLOY_EVM_CONTRACTS],
+    }
   ],
 });
 

--- a/packages/build-tools/orchestrator/scripts/launch-avail.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-avail.ts
@@ -17,10 +17,17 @@ import { ComponentNames } from "@paima/log";
 //
 // packageName: the name of the package that implements the tasks.
 //
-export const launchAvail = (packageName: string) => ({
-  stopProcessAtPort: [9955, 7007],
-  processes: [
+export const launchAvail = (packageName: string): {
+  stopProcessAtPort?: number[];
+  name: string;
+  args: string[];
+  waitToExit?: boolean;
+  logs?: string;
+  type?: string;
+  dependsOn?: string[];
+}[] => [
     {
+      stopProcessAtPort: [9955, 7007],
       name: ComponentNames.AVAIL_NODE,
       args: ["task", "-f", packageName, "avail-node:start"],
       waitToExit: false,
@@ -30,6 +37,7 @@ export const launchAvail = (packageName: string) => ({
     {
       name: ComponentNames.AVAIL_NODE_WAIT,
       args: ["task", "-f", packageName, "avail-node:wait"],
+      dependsOn: [ComponentNames.AVAIL_NODE],
     },
     {
       name: ComponentNames.AVAIL_CLIENT,
@@ -40,7 +48,8 @@ export const launchAvail = (packageName: string) => ({
         "avail-light-client:deploy",
       ],
       waitToExit: false,
-      type: "system-dependency",
+      type: "system-dependency",  
+      dependsOn: [ComponentNames.AVAIL_NODE_WAIT],
     },
     {
       name: ComponentNames.AVAIL_CLIENT_WAIT,
@@ -50,6 +59,6 @@ export const launchAvail = (packageName: string) => ({
         packageName,
         "avail-light-client:wait",
       ],
+      dependsOn: [ComponentNames.AVAIL_CLIENT],
     },
-  ],
-});
+  ];

--- a/packages/build-tools/orchestrator/scripts/launch-cardano.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-cardano.ts
@@ -15,10 +15,17 @@ import { ComponentNames } from "@paima/log";
 //
 // packageName: the name of the package that implements the tasks.
 //
-export const launchCardano = (packageName: string) => ({
-  stopProcessAtPort: [8090, 10000, 50051, 3001],
-  processes: [
+export const launchCardano = (packageName: string): {
+  stopProcessAtPort?: number[];
+  name: string;
+  args: string[];
+  waitToExit?: boolean;
+  logs?: string;
+  type?: string;
+  dependsOn?: string[];
+}[] => [
     {
+      stopProcessAtPort: [8090, 10000, 50051, 3001],
       name: ComponentNames.YACI_DEVKIT,
       args: ["task", "-f", packageName, "devkit:start"],
       waitToExit: false,
@@ -28,16 +35,18 @@ export const launchCardano = (packageName: string) => ({
     {
       name: ComponentNames.YACI_DEVKIT_WAIT,
       args: ["task", "-f", packageName, "devkit:wait"],
+      dependsOn: [ComponentNames.YACI_DEVKIT],
     },
     {
       name: ComponentNames.DOLOS,
       args: ["task", "-f", packageName, "dolos:start"],
       waitToExit: false,
       type: "system-dependency",
+      dependsOn: [ComponentNames.YACI_DEVKIT_WAIT],
     },
     {
       name: ComponentNames.DOLOS_WAIT,
       args: ["task", "-f", packageName, "dolos:wait"],
+      dependsOn: [ComponentNames.DOLOS],
     },
-  ],
-});
+  ];

--- a/packages/build-tools/orchestrator/scripts/launch-evm.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-evm.ts
@@ -15,32 +15,32 @@ import { ComponentNames } from "@paima/log";
 // packageName: the name of the package that implements the tasks.
 //
 export const launchEvm = (packageName: string): {
-  stopProcessAtPort: number[];
-  processes: {
-    name: string;
-    args: string[];
-    waitToExit?: boolean;
-    logs?: string;
-    type?: string;
-  }[];
-} => ({
-  stopProcessAtPort: [8545, 8546],
-  processes: [
+  stopProcessAtPort?: number[];
+  name: string;
+  args: string[];
+  waitToExit?: boolean;
+  logs?: string;
+  type?: string;
+  dependsOn?: string[];
+}[] => [
     {
+      stopProcessAtPort: [8545, 8546],
       name: ComponentNames.HARDHAT,
       args: ["task", "-f", packageName, "chain:start"],
       waitToExit: false,
       logs: "otel-compatible",
       type: "system-dependency",
+      dependsOn: [],
     },
     {
       name: ComponentNames.HARDHAT_WAIT,
       args: ["task", "-f", packageName, "chain:wait"],
+      dependsOn: [ComponentNames.HARDHAT],
     },
     {
       name: ComponentNames.DEPLOY_EVM_CONTRACTS,
       args: ["task", "-f", packageName, "deploy"],
       type: "system-dependency",
+      dependsOn: [ComponentNames.HARDHAT_WAIT],
     },
-  ],
-});
+  ];

--- a/packages/build-tools/orchestrator/scripts/launch-midnight.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-midnight.ts
@@ -17,10 +17,17 @@ import { ComponentNames } from "@paima/log";
 //
 // packageName: the name of the package that implements the tasks.
 //
-export const launchMidnight = (packageName: string) => ({
-  stopProcessAtPort: [9944, 8088, 6300],
-  processes: [
+export const launchMidnight = (packageName: string): {
+  stopProcessAtPort?: number[];
+  name: string;
+  args: string[];
+  waitToExit?: boolean;
+  logs?: string;
+  type?: string;
+  dependsOn?: string[];
+}[] => [
     {
+      stopProcessAtPort: [9944, 8088, 6300],
       name: ComponentNames.MIDNIGHT_NODE,
       args: [
         "task",
@@ -31,6 +38,7 @@ export const launchMidnight = (packageName: string) => ({
       waitToExit: false,
       type: "system-dependency",
       logs: "none",
+      dependsOn: [],
     },
     {
       name: ComponentNames.MIDNIGHT_INDEXER,
@@ -42,6 +50,7 @@ export const launchMidnight = (packageName: string) => ({
       ],
       waitToExit: false,
       type: "system-dependency",
+      dependsOn: [ComponentNames.MIDNIGHT_NODE],
     },
     {
       name: ComponentNames.MIDNIGHT_PROOF_SERVER,
@@ -53,6 +62,7 @@ export const launchMidnight = (packageName: string) => ({
       ],
       waitToExit: false,
       type: "system-dependency",
+      dependsOn: [ComponentNames.MIDNIGHT_NODE]
     },
     {
       name: ComponentNames.MIDNIGHT_NODE_WAIT,
@@ -62,6 +72,7 @@ export const launchMidnight = (packageName: string) => ({
         packageName,
         "midnight-node:wait",
       ],
+      dependsOn: [ComponentNames.MIDNIGHT_NODE],
     },
     {
       name: ComponentNames.MIDNIGHT_INDEXER_WAIT,
@@ -71,6 +82,7 @@ export const launchMidnight = (packageName: string) => ({
         packageName,
         "midnight-indexer:wait",
       ],
+      dependsOn: [ComponentNames.MIDNIGHT_INDEXER],
     },
     {
       name: ComponentNames.MIDNIGHT_PROOF_SERVER_WAIT,
@@ -80,6 +92,7 @@ export const launchMidnight = (packageName: string) => ({
         packageName,
         "midnight-proof-server:wait",
       ],
+      dependsOn: [ComponentNames.MIDNIGHT_PROOF_SERVER],
     },
     {
       name: ComponentNames.MIDNIGHT_CONTRACT,
@@ -89,6 +102,10 @@ export const launchMidnight = (packageName: string) => ({
         packageName,
         "midnight-contract:deploy",
       ],
+      dependsOn: [
+        ComponentNames.MIDNIGHT_NODE_WAIT,
+        ComponentNames.MIDNIGHT_INDEXER_WAIT,
+        ComponentNames.MIDNIGHT_PROOF_SERVER_WAIT,
+      ],
     },
-  ],
-});
+  ];

--- a/packages/build-tools/orchestrator/src/start.ts
+++ b/packages/build-tools/orchestrator/src/start.ts
@@ -26,6 +26,24 @@ import { type Static, Type } from "@sinclair/typebox";
 let appConfig: OrchestratorConfigType | null = null;
 let pFactory: ReturnType<typeof processFactory> | null = null;
 
+const ProcessLaunch = Type.Object({
+  name: Type.String(),
+  description: Type.String({ default: '' }),
+  stopProcessAtPort: Type.Array(Type.Number(), { default: [] }),
+  dependsOn: Type.Array(Type.String(), { default: [] }),
+  args: Type.Array(Type.String()),
+  waitToExit: Type.Boolean({ default: true }),
+  link: Type.String({ default: '' }),
+  logs: Type.Union(
+    [Type.Literal('otel-compatible'), Type.Literal('raw'), Type.Literal('none')],
+    { default: 'raw' }
+  ),
+  type: Type.Union(
+    [Type.Literal('system-dependency'), Type.Literal('secondary')],
+    { default: 'secondary' }
+  ),
+});
+
 /**
  * Orchestrator configurations
  * logs: log output mode
@@ -57,31 +75,7 @@ export const OrchestratorConfig = Type.Object({
 
   // Custom user defined processes to launch.
   // For example you can launch hardhat evm chains, wait to be ready and deploy contracts.
-  processesToLaunch: Type.Array(
-    Type.Object({
-      description: Type.String({ default: "" }),
-      stopProcessAtPort: Type.Array(Type.Number(), { default: [] }),
-      processes: Type.Array(
-        Type.Object({
-          name: Type.String(),
-          args: Type.Array(Type.String()),
-          waitToExit: Type.Boolean({ default: true }),
-          link: Type.String({ default: "" }),
-          logs: Type.Union([
-            Type.Literal("otel-compatible"),
-            Type.Literal("raw"),
-            Type.Literal("none"),
-          ], { default: "raw" }),
-          type: Type.Union([
-            Type.Literal("system-dependency"),
-            Type.Literal("secondary"),
-          ], { default: "secondary" }),
-        }),
-        { default: [] },
-      ),
-    }),
-    { default: [] },
-  ),
+  processesToLaunch: Type.Array(ProcessLaunch, { default: [] }),
 
   // This can be customized for different locations of the packages.
   // nightly: jsr:@paimaexample
@@ -102,17 +96,27 @@ export const OrchestratorConfig = Type.Object({
 
     // DevOps
     [ComponentNames.COLLECTOR]: Type.Boolean({ default: true }),
-    [ComponentNames.DOCS]: Type.Boolean({ default: true }),
   }, { default: {} }),
 });
 
 type OrchestratorConfigType = Static<typeof OrchestratorConfig>;
 
-export async function start(
-  config: OrchestratorConfigType,
-): Promise<void> {
-  appConfig = config;
-  pFactory = processFactory(config);
+type Task = {
+  name: string;
+  config: Static<typeof ProcessLaunch> | SystemProcess;
+  dependencies: Set<string>;
+  dependents: Set<string>;
+  status: 'pending' | 'running' | 'finished' | 'failed';
+  process?: ProcessComponent;
+};
+
+type SystemProcess = {
+  name: string;
+  dependsOn: string[];
+  launch: () => Promise<ProcessComponent>;
+};
+
+const setupLogging = (config: OrchestratorConfigType): void => {
   // Let's setup the output mode
   // Config options:
   //   none: no logs
@@ -141,100 +145,183 @@ export async function start(
       initTelemetry();
       break;
   }
+}
 
+export async function start(
+  config: OrchestratorConfigType,
+): Promise<void> {
+  appConfig = config;
+  pFactory = processFactory(config);
+  setupLogging(config);
   try {
+
+    const tasks = new Map<string, Task>();
+    const processesToRun: (Static<typeof ProcessLaunch> | SystemProcess)[] = [...config.processesToLaunch];
+
+    // Build task graph
+    for (const processConfig of processesToRun) {
+      if (tasks.has(processConfig.name)) {
+        console.error(`Error: Duplicate process name "${processConfig.name}" found. Process names must be unique.`);
+        await shutdown(1);
+        return;
+      }
+      tasks.set(processConfig.name, {
+        name: processConfig.name,
+        config: processConfig,
+        dependencies: new Set(processConfig.dependsOn),
+        dependents: new Set(),
+        status: 'pending',
+      });
+    }
+
+    for (const task of tasks.values()) {
+      for (const depName of task.dependencies) {
+        const depTask = tasks.get(depName);
+        if (depTask) {
+          depTask.dependents.add(task.name);
+        } else {
+          console.error(`Error: Dependency "${depName}" for process "${task.name}" not found.`);
+          await shutdown(1);
+          return;
+        }
+      }
+    }
+
+    // Start System Processes
     const startProcess = processFactory(config);
-    // This is a 2D array of functions that launch processes.
-    // The outer array is for processes that are launched in sequence.
-    // The inner array is for processes that are launched in parallel.
-    const processesToLaunch: (false | (() => Promise<ProcessComponent>))[][] =
-      [];
 
-    // fast-fail if there are type errors in the project
+    // Add system processes
     if (config.processes[ComponentNames.CHECKER]) {
-      processesToLaunch.push([startProcess[ComponentNames.CHECKER]]);
+      await startProcess[ComponentNames.CHECKER]();
     }
-
     if (config.processes[ComponentNames.TMUX]) {
-      processesToLaunch.push([startProcess[ComponentNames.TMUX]]);
+      await startProcess[ComponentNames.TMUX]();
     }
-
     if (config.processes[ComponentNames.COLLECTOR]) {
-      processesToLaunch.push([startProcess[ComponentNames.COLLECTOR]]);
+      await startProcess[ComponentNames.COLLECTOR]();
+    }
+    if (config.processes[ComponentNames.PAIMA_PGLITE]) {
+      await startProcess[ComponentNames.PAIMA_PGLITE]();
+    }
+    if (config.processes[ComponentNames.APPLY_MIGRATIONS]) {
+      await startProcess[ComponentNames.APPLY_MIGRATIONS]();
     }
 
-    // First batch of processes that have no other dependencies
-    processesToLaunch.push([
-      config.processes[ComponentNames.DOCS] &&
-      startProcess[ComponentNames.DOCS],
-      config.processes[ComponentNames.PAIMA_PGLITE] &&
-      startProcess[ComponentNames.PAIMA_PGLITE],
-      config.processes[ComponentNames.APPLY_MIGRATIONS] &&
-      startProcess[ComponentNames.APPLY_MIGRATIONS],
-    ]);
 
-    // Al main system dependencies are launched.
-    // Start user defined processes.
-    const pipelines: (() => Promise<ProcessComponent>)[][] = [];
-    for (const processList of config.processesToLaunch) {
-      let first = true;
-      const pipeline: (() => Promise<ProcessComponent>)[] = [];
-      for (const process of processList.processes) {
-        const { name, args, waitToExit, logs, type, link } = process;
-        pipeline.push(async (): Promise<ProcessComponent> => {
-          if (first && processList.stopProcessAtPort.length > 0) {
-            await dkill({ ports: processList.stopProcessAtPort });
-            first = false;
-          }
-          let logHandler_: typeof logHandler;
-          switch (logs) {
-            case "none":
-              logHandler_ = () => {};
-              break;
-            case "otel-compatible":
-              logHandler_ = logHandler;
-              break;
-            case "raw":
-              logHandler_ = rawLogHandler;
-              break;
-          }
-          const processComponent = $({
-            args: args,
-            component: name,
-            log: logHandler_,
-            abortController: type === "system-dependency"
-              ? abortControllers.system
-              : abortControllers.noncritical,
-            link: link,
-          });
-          if (waitToExit) {
-            await processComponent.process.status;
-          }
-          return processComponent;
+    // Start User-defined Processes
+    const pending = new Set<string>(tasks.keys());
+    const runningWaitToFinish = new Map<string, Promise<void>>();
+    const runningProcesses = new Map<string, Promise<void>>();
+    const finished = new Set<string>();
+
+    const launchTask = async (task: Task): Promise<void> => {
+      task.status = 'running';
+
+      let processComponent: ProcessComponent;
+      if ('launch' in task.config) { // System process
+        processComponent = await task.config.launch();
+      } else { // User-defined process
+        const { name, args, logs, type, link, stopProcessAtPort } = task.config;
+        if (stopProcessAtPort.length > 0) {
+          await dkill({ ports: stopProcessAtPort });
+        }
+        let logHandler_: typeof logHandler;
+        switch (logs) {
+          case "none":
+            logHandler_ = () => {};
+            break;
+          case "otel-compatible":
+            logHandler_ = logHandler;
+            break;
+          case "raw":
+            logHandler_ = rawLogHandler;
+            break;
+        }
+        processComponent = $({
+          args: args,
+          component: name,
+          log: logHandler_,
+          abortController: type === "system-dependency"
+            ? abortControllers.system
+            : abortControllers.noncritical,
+          link: link,
         });
       }
-      pipelines.push(pipeline);
-    }
-    // Now we transpose the pipelines, to make them run in parallel.
-    const maxLength = Math.max(...pipelines.map((p) => p.length));
-    for (let i = 0; i < maxLength; i++) {
-      const batch: (false | (() => Promise<ProcessComponent>))[] = [];
-      for (const pipeline of pipelines) {
-        batch.push(pipeline[i] ? pipeline[i] : false);
+      task.process = processComponent;
+
+      const finish = (): void => {
+        task.status = 'finished';
+        finished.add(task.name);
+        runningWaitToFinish.delete(task.name);
+        runningProcesses.delete(task.name);
+
+        for (const dependentName of task.dependents) {
+          const dependentTask = tasks.get(dependentName)!;
+          dependentTask.dependencies.delete(task.name);
+        }
+        // Wake up the main loop
+        if (waiter) {
+          waiter();
+          waiter = null;
+        }
+      };
+      
+      const waitToExit = 'waitToExit' in task.config ? task.config.waitToExit : true;
+
+      if (waitToExit) {
+        task.process.process.status.then(finish).catch(async err => {
+            console.error(`Task ${task.name} failed with error: ${err}`);
+            task.status = 'failed';
+            await shutdown(1, err);
+        });
+      } else {
+        finish();
       }
-      processesToLaunch.push(batch);
+    };
+
+    let waiter: (() => void) | null = null;
+    
+    while (pending.size > 0 || runningWaitToFinish.size > 0) {
+        const executableTasks = Array.from(pending)
+            .map(name => tasks.get(name)!)
+            .filter(task => task.dependencies.size === 0);
+
+        if (executableTasks.length > 0) {
+            for (const task of executableTasks) {
+                pending.delete(task.name);
+                const taskPromise = launchTask(task);
+                const waitToExit = 'waitToExit' in task.config ? task.config.waitToExit : true;
+                if (waitToExit) {
+                  runningWaitToFinish.set(task.name, taskPromise);
+                } else {
+                  runningProcesses.set(task.name, taskPromise);
+                }
+            }
+        } else if (runningWaitToFinish.size > 0) {
+            for (const pendingTaskName of pending) {
+                const pendingTask = tasks.get(pendingTaskName)!;
+            }
+            await new Promise<void>(resolve => {
+                waiter = resolve;
+            });
+        } else if (pending.size > 0) {
+            console.error('Error: Circular dependency or missing dependency detected.');
+            console.error('Pending tasks:');
+            for (const pendingTaskName of pending) {
+                const pendingTask = tasks.get(pendingTaskName)!;
+                console.error(`  - ${pendingTask.name} is waiting for: ${[...pendingTask.dependencies].join(', ')}`);
+            }
+            await shutdown(1);
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
     }
 
-    processesToLaunch.push([
-      // Start the main process
-      config.processes[ComponentNames.PAIMA_SYNC] &&
-      startProcess[ComponentNames.PAIMA_SYNC],
-    ]);
+    // Wait for all processes to finish
+    // Launch Paima Engine Main Sync Process
+    await startProcess[ComponentNames.PAIMA_SYNC]();
 
-    // Launch outer processes in sequence, and inner processes in parallel
-    for (const batch of processesToLaunch) {
-      await Promise.all(batch.map((p) => p && p()));
-    }
+    
   } catch (e) {
     if (!(e instanceof AbortProcessStart)) {
       await shutdown(1, e);
@@ -289,20 +376,6 @@ export const processFactory = (config: OrchestratorConfigType): Record<
     });
     await explorer.process.status;
     return explorer;
-  },
-
-  [ComponentNames.DOCS]: async (): Promise<ProcessComponent> => {
-    if (config.kill.auto) {
-      await dkill({ ports: [ENV.DOCS_PORT] });
-    }
-
-    const docs = $({
-      args: ["task", "-f", config.packageName + "/docs", "start"],
-      component: ComponentNames.DOCS,
-      abortController: abortControllers.developerUI,
-    });
-    void docs.process.status;
-    return docs;
   },
 
   [ComponentNames.COLLECTOR]: async (): Promise<ProcessComponent> => {

--- a/packages/paima-sdk/log/src/const.ts
+++ b/packages/paima-sdk/log/src/const.ts
@@ -34,7 +34,6 @@ export const PaimaToolsComponents = {
   TMUX: "tmux",
   COLLECTOR: "collector",
   EXPLORER: "explorer",
-  DOCS: "docs",
   DEPLOY_EVM_CONTRACTS: "deploy-evm-contracts",
   MIDNIGHT_CONTRACT: "midnight-contract",
 };


### PR DESCRIPTION
Now orchestrator takes a argument `dependsOn`, and it uses it to calculate the execution path 

For example the EVM Launch Template
```
[
    {
      stopProcessAtPort: [8545, 8546],
      name: ComponentNames.HARDHAT,
      args: ["task", "-f", packageName, "chain:start"],
      waitToExit: false,
      logs: "otel-compatible",
      type: "system-dependency",
      dependsOn: [],
    },
    {
      name: ComponentNames.HARDHAT_WAIT,
      args: ["task", "-f", packageName, "chain:wait"],
      dependsOn: [ComponentNames.HARDHAT],
    },
    {
      name: ComponentNames.DEPLOY_EVM_CONTRACTS,
      args: ["task", "-f", packageName, "deploy"],
      type: "system-dependency",
      dependsOn: [ComponentNames.HARDHAT_WAIT],
    },
  ]
  ```