### PR TITLE
Support reading from utxorpc

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -25,5 +25,11 @@
         "no-slow-types" // would be nice to have, but this is a lot of work
       ]
     }
+  },
+  "scopes": {
+    "file:/home/simon/cardano/node-sdk/lib/browser/index.mjs": {
+      "@utxorpc/spec": "npm:@utxorpc/spec@^0.18.1",
+      "buffer": "npm:buffer@^6.0.3"
+    }
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -25,11 +25,5 @@
         "no-slow-types" // would be nice to have, but this is a lot of work
       ]
     }
-  },
-  "scopes": {
-    "file:/home/simon/cardano/node-sdk/lib/browser/index.mjs": {
-      "@utxorpc/spec": "npm:@utxorpc/spec@^0.18.1",
-      "buffer": "npm:buffer@^6.0.3"
-    }
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -13,6 +13,7 @@
     "jsr:@oak/commons@1": "1.0.1",
     "jsr:@oak/oak@^17.1.4": "17.2.0",
     "jsr:@paimaexample/log@0.3.126": "0.3.126",
+    "jsr:@std/assert@*": "1.0.16",
     "jsr:@std/assert@1": "1.0.16",
     "jsr:@std/assert@^1.0.12": "1.0.16",
     "jsr:@std/assert@~1.0.6": "1.0.16",
@@ -53,10 +54,12 @@
     "npm:@bloxbean/yaci-devkit@*": "0.10.6",
     "npm:@bloxbean/yaci-devkit@0.10.6": "0.10.6",
     "npm:@cardano-foundation/cardano-verify-datasignature@1.0.11": "1.0.11",
+    "npm:@cardano-sdk/core@~0.46.11": "0.46.11_rxjs@7.8.2",
+    "npm:@cardano-sdk/util@~0.17.1": "0.17.1",
     "npm:@coderspirit/nominal@^4.1.1": "4.1.1_typescript@5.6.3",
     "npm:@dcspark/carp-client@^3.3.0": "3.3.0",
     "npm:@dcspark/cip34-js@3.0.1": "3.0.1",
-    "npm:@deno/vite-plugin@^1.0.4": "1.0.6_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:@deno/vite-plugin@^1.0.4": "1.0.6_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:@docusaurus/core@3.8.1": "3.8.1_@mdx-js+react@3.1.1__@types+react@18.3.1__react@18.3.1_react@18.3.1_react-dom@18.3.1__react@18.3.1_@types+react@18.3.1_webpack@5.104.1__acorn@8.15.0_react-router@5.3.4__react@18.3.1_typescript@5.6.3",
     "npm:@docusaurus/module-type-aliases@3.8.1": "3.8.1_react@18.3.1_react-dom@18.3.1__react@18.3.1",
     "npm:@docusaurus/plugin-client-redirects@3.8.1": "3.8.1_react@18.3.1_react-dom@18.3.1__react@18.3.1_@mdx-js+react@3.1.1__@types+react@18.3.1__react@18.3.1_@types+react@18.3.1_typescript@5.6.3",
@@ -101,9 +104,9 @@
     "npm:@midnight-ntwrk/zswap@4.0.0": "4.0.0",
     "npm:@midnight-ntwrk/zswap@^4.0.0-alpha.11": "4.0.0",
     "npm:@nomicfoundation/hardhat-errors@3.0.1": "3.0.1",
-    "npm:@nomicfoundation/hardhat-ignition-viem@3.0.2": "3.0.2_@nomicfoundation+hardhat-ignition@3.0.6__@nomicfoundation+hardhat-verify@3.0.8___hardhat@3.0.4____zod@3.25.76___zod@3.25.76__hardhat@3.0.4___zod@3.25.76_@nomicfoundation+hardhat-verify@3.0.8__hardhat@3.0.4___zod@3.25.76__zod@3.25.76_@nomicfoundation+hardhat-viem@3.0.0__hardhat@3.0.4___zod@3.25.76__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__typescript@5.6.3_@nomicfoundation+ignition-core@3.0.2_hardhat@3.0.4__zod@3.25.76_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_typescript@5.6.3",
+    "npm:@nomicfoundation/hardhat-ignition-viem@3.0.2": "3.0.2_@nomicfoundation+hardhat-ignition@3.0.6__@nomicfoundation+hardhat-verify@3.0.8___hardhat@3.0.4____zod@3.25.76___zod@3.25.76__hardhat@3.0.4___zod@3.25.76_@nomicfoundation+hardhat-verify@3.0.8__hardhat@3.0.4___zod@3.25.76__zod@3.25.76_@nomicfoundation+hardhat-viem@3.0.0__hardhat@3.0.4___zod@3.25.76__viem@2.23.10___typescript@5.6.3___ws@8.18.1__typescript@5.6.3_@nomicfoundation+ignition-core@3.0.2_hardhat@3.0.4__zod@3.25.76_viem@2.23.10__typescript@5.6.3__ws@8.18.1_typescript@5.6.3",
     "npm:@nomicfoundation/hardhat-utils@3.0.0": "3.0.0",
-    "npm:@nomicfoundation/hardhat-viem@3.0.0": "3.0.0_hardhat@3.0.4__zod@3.25.76_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_typescript@5.6.3",
+    "npm:@nomicfoundation/hardhat-viem@3.0.0": "3.0.0_hardhat@3.0.4__zod@3.25.76_viem@2.23.10__typescript@5.6.3__ws@8.18.1_typescript@5.6.3",
     "npm:@nomicfoundation/ignition-core@3.0.2": "3.0.2",
     "npm:@opentelemetry/api-logs@0.56.0": "0.56.0",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
@@ -139,13 +142,12 @@
     "npm:@types/react@18.3.1": "18.3.1",
     "npm:@types/react@19.1.0": "19.1.0",
     "npm:@types/react@19.1.2": "19.1.2",
-    "npm:@utxorpc/sdk@~0.6.8": "0.6.8_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1",
-    "npm:@utxorpc/spec@0.16": "0.16.0",
-    "npm:@vitejs/plugin-react@^4.4.1": "4.7.0_vite@7.1.3__picomatch@4.0.3_@babel+core@7.28.6_@types+node@24.2.0",
+    "npm:@utxorpc/spec@~0.18.1": "0.18.1",
+    "npm:@vitejs/plugin-react@^4.4.1": "4.7.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@babel+core@7.28.6_@types+node@24.2.0",
     "npm:@wagmi/cli@2.3.1": "2.3.1_typescript@5.6.3_zod@3.25.76_esbuild@0.25.12_picomatch@3.0.1",
     "npm:@xhmikosr/bin-wrapper@5": "5.0.1",
     "npm:@xhmikosr/bin-wrapper@^13.2.0": "13.2.0",
-    "npm:abitype@1.1.0": "1.1.0_typescript@5.6.3_zod@4.3.5",
+    "npm:abitype@1.1.0": "1.1.0_typescript@5.6.3",
     "npm:aedes-server-factory@~0.2.1": "0.2.1",
     "npm:aedes@~0.51.3": "0.51.3",
     "npm:algosdk@^3.4.0": "3.5.2",
@@ -228,14 +230,14 @@
     "npm:viem@2.23.10": "2.23.10_typescript@5.6.3_ws@8.18.1",
     "npm:viem@2.37.3": "2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
     "npm:viem@^2.21.3": "2.44.4_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
-    "npm:vite-plugin-node-stdlib-browser@*": "0.2.1_node-stdlib-browser@1.3.1_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:vite-plugin-static-copy@^3.1.1": "3.1.4_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:vite-plugin-top-level-await@^1.6.0": "1.6.0_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:vite-plugin-wasm@^3.5.0": "3.5.0_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:vite@*": "7.1.3_picomatch@4.0.3_@types+node@24.2.0",
-    "npm:vite@7.1.3": "7.1.3_picomatch@4.0.3_@types+node@24.2.0",
-    "npm:vitest@^3.2.4": "3.2.4_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0",
-    "npm:wagmi@^2.16.9": "2.19.5_@tanstack+react-query@5.90.17__react@18.3.1_react@18.3.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1",
+    "npm:vite-plugin-node-stdlib-browser@*": "0.2.1_node-stdlib-browser@1.3.1_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:vite-plugin-static-copy@^3.1.1": "3.1.4_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:vite-plugin-top-level-await@^1.6.0": "1.6.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:vite-plugin-wasm@^3.5.0": "3.5.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
+    "npm:vite@*": "7.1.3_@types+node@24.2.0_picomatch@4.0.3",
+    "npm:vite@7.1.3": "7.1.3_@types+node@24.2.0_picomatch@4.0.3",
+    "npm:vitest@^3.2.4": "3.2.4_@types+node@24.2.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3",
+    "npm:wagmi@^2.16.9": "2.19.5_@tanstack+react-query@5.90.17__react@18.3.1_react@18.3.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.23.10___typescript@5.6.3___ws@8.18.1__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1",
     "npm:wait-on@8.0.3": "8.0.3",
     "npm:web3-utils@^4.3.3": "4.3.3",
     "npm:web3@^4.16.0": "4.16.0_typescript@5.6.3",
@@ -1558,6 +1560,16 @@
         "zustand@5.0.3_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1"
       ]
     },
+    "@biglup/is-cid@1.0.3": {
+      "integrity": "sha512-R0XPZ/IQhU2TtetSFI9vI+7kJOJYNiCncn5ixEBW+/LNaZCo2HK37Mq3pRNzrM4FryuAkyeqY7Ujmj3I3e3t9g==",
+      "dependencies": [
+        "@multiformats/mafmt",
+        "@multiformats/multiaddr@12.5.1",
+        "iso-url",
+        "multiformats@13.4.2",
+        "uint8arrays@5.1.0"
+      ]
+    },
     "@bloxbean/yaci-devkit-linux-x64@0.10.6": {
       "integrity": "sha512-etXqT0oK6c/xsMXgq3hQXTcBA/x6G6LzenE3FHS7AeNwERihuIOwdUxlUYI6QP+QZBRDKk98+sD7HBR3I0x1vQ==",
       "bin": true
@@ -1591,6 +1603,81 @@
         "@stricahq/cip08",
         "@stricahq/typhonjs",
         "blakejs"
+      ]
+    },
+    "@cardano-ogmios/client@6.9.0_ws@7.5.10": {
+      "integrity": "sha512-IsoUVsaMXiYyhWrdVKYOA5PDlX0EZ2gaq4lfk4JelRw6mcWVxemUrMaU2ndvugO9LQ3SCM1nESPgMIU0xe5FWw==",
+      "dependencies": [
+        "@cardano-ogmios/schema",
+        "@cardanosolutions/json-bigint",
+        "@types/json-bigint",
+        "bech32@2.0.0",
+        "cross-fetch@3.2.0",
+        "fastq",
+        "isomorphic-ws@4.0.1_ws@7.5.10",
+        "nanoid",
+        "ts-custom-error",
+        "ws@7.5.10"
+      ]
+    },
+    "@cardano-ogmios/schema@6.9.0": {
+      "integrity": "sha512-e7QVLF+dQMIv9p+p5CWQjMfBmkERYRa2wK2AjyehQZCJnecZ0gvTbRqewdX5VW4mVXf6KUfFyphsxWK46Pg6LA=="
+    },
+    "@cardano-sdk/core@0.46.11_rxjs@7.8.2": {
+      "integrity": "sha512-N/f0Gna41Jsw/KFdulqgpTks4VoeNG1rhTYmGkgtUkMqBTYK+IdaOwMH4QrNxz08VpbOGv76Km3phqGuvTUinQ==",
+      "dependencies": [
+        "@biglup/is-cid",
+        "@cardano-ogmios/client",
+        "@cardano-ogmios/schema",
+        "@cardano-sdk/crypto",
+        "@cardano-sdk/util",
+        "@foxglove/crc@0.0.3",
+        "@scure/base@1.2.6",
+        "fraction.js@4.0.1",
+        "ip-address@9.0.5",
+        "lodash",
+        "rxjs",
+        "ts-custom-error",
+        "ts-log",
+        "web-encoding"
+      ],
+      "optionalPeers": [
+        "rxjs"
+      ]
+    },
+    "@cardano-sdk/crypto@0.4.4": {
+      "integrity": "sha512-jvElFox4TPlTZRtjfw0HlkucRD90EeijfhMT0uD0N6ptkn8sRQXUFO+z+1Zcp9v9L2V324N7+2ThpjjBEoUdXQ==",
+      "dependencies": [
+        "@cardano-sdk/util",
+        "blake2b",
+        "i",
+        "libsodium-wrappers-sumo",
+        "lodash",
+        "pbkdf2",
+        "ts-custom-error",
+        "ts-log"
+      ]
+    },
+    "@cardano-sdk/util@0.17.1": {
+      "integrity": "sha512-TCYe+wRguW1WgRlbWqhGPhcSBkzVzdIcCVgDDN7wiQk2dew0EWVqjsKeqDZdfwzy/s2kr/ZOgXIGywBn/Bzu/Q==",
+      "dependencies": [
+        "bech32@2.0.0",
+        "lodash",
+        "serialize-error",
+        "ts-custom-error",
+        "ts-log"
+      ]
+    },
+    "@cardanosolutions/json-bigint@1.1.0": {
+      "integrity": "sha512-Pdgz18cSwLKKgheOqW/dqbzNI+CliNT4AdaKaKY/P++J9qLxIB8MITCurlzbaFWV3W4nmK0CRQwI1yvuArmjFg=="
+    },
+    "@chainsafe/is-ip@2.1.0": {
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w=="
+    },
+    "@chainsafe/netmask@2.0.0": {
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": [
+        "@chainsafe/is-ip"
       ]
     },
     "@chevrotain/cst-dts-gen@11.0.3": {
@@ -1675,27 +1762,6 @@
     },
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
-    },
-    "@connectrpc/connect-node@1.4.0_@bufbuild+protobuf@1.10.1_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1": {
-      "integrity": "sha512-0ANnrr6SvsjevsWEgdzHy7BaHkluZyS6s4xNoVt7RBHFR5V/kT9lPokoIbYUOU9JHzdRgTaS3x5595mwUsu15g==",
-      "dependencies": [
-        "@bufbuild/protobuf",
-        "@connectrpc/connect",
-        "undici@5.29.0"
-      ]
-    },
-    "@connectrpc/connect-web@1.4.0_@bufbuild+protobuf@1.10.1_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1": {
-      "integrity": "sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==",
-      "dependencies": [
-        "@bufbuild/protobuf",
-        "@connectrpc/connect"
-      ]
-    },
-    "@connectrpc/connect@1.4.0_@bufbuild+protobuf@1.10.1": {
-      "integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
-      "dependencies": [
-        "@bufbuild/protobuf"
-      ]
     },
     "@csstools/cascade-layer-name-parser@2.0.5_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
       "integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A==",
@@ -2113,7 +2179,7 @@
     "@dcspark/cip34-js@3.0.1": {
       "integrity": "sha512-xUChOH4fDAuAPImnRQs/5XXzBF6oWeLsRcwjjL5mFC2CXFAxhJrOavijQpbl67IcYUypOVSLg+8c2FCJonfH3Q=="
     },
-    "@deno/vite-plugin@1.0.6_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "@deno/vite-plugin@1.0.6_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
       "integrity": "sha512-Sh5XqvFuKAwjARTesi0n6xRpEXm1V0UeqKh+SxIrexCofxOaieNDMqXZD02RiZCg0mrJ43V8eCMuVrDfq6mLmg==",
       "dependencies": [
         "vite"
@@ -2121,6 +2187,13 @@
     },
     "@discoveryjs/json-ext@0.5.7": {
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
+    },
+    "@dnsquery/dns-packet@6.1.1": {
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "dependencies": [
+        "@leichtgewicht/ip-codec",
+        "utf8-codec"
+      ]
     },
     "@docsearch/css@3.9.0": {
       "integrity": "sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA=="
@@ -2655,7 +2728,7 @@
         "js-yaml@4.1.1",
         "lodash",
         "micromatch",
-        "p-queue",
+        "p-queue@6.6.2",
         "prompts",
         "resolve-pathname",
         "tslib@2.8.1",
@@ -3206,9 +3279,6 @@
         "fast-uri"
       ]
     },
-    "@fastify/busboy@2.1.1": {
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
-    },
     "@fastify/cors@11.2.0": {
       "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
       "dependencies": [
@@ -3282,15 +3352,18 @@
         "yaml"
       ]
     },
+    "@foxglove/crc@0.0.3": {
+      "integrity": "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA=="
+    },
     "@foxglove/crc@1.0.1": {
       "integrity": "sha512-8XeHQma6qxTcVNEnEl433hhdfTUhp4tj3sN+0bIL5+YKpBghQxp3f/sgKQpo4PNMnVB13SliC4wtT9ecNqECjQ=="
     },
-    "@gemini-wallet/core@0.3.2_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_typescript@5.6.3": {
+    "@gemini-wallet/core@0.3.2_viem@2.23.10__typescript@5.6.3__ws@8.18.1_typescript@5.6.3": {
       "integrity": "sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ==",
       "dependencies": [
         "@metamask/rpc-errors@7.0.2",
         "eventemitter3@5.0.1",
-        "viem@2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10"
+        "viem@2.23.10_typescript@5.6.3_ws@8.18.1"
       ]
     },
     "@graphql-typed-document-node/core@3.2.0_graphql@16.12.0": {
@@ -3428,6 +3501,17 @@
     },
     "@leichtgewicht/ip-codec@2.0.5": {
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "@libp2p/interface@3.1.0": {
+      "integrity": "sha512-RE7/XyvC47fQBe1cHxhMvepYKa5bFCUyFrrpj8PuM0E7JtzxU7F+Du5j4VXbg2yLDcToe0+j8mB7jvwE2AThYw==",
+      "dependencies": [
+        "@multiformats/dns",
+        "@multiformats/multiaddr@13.0.1",
+        "main-event",
+        "multiformats@13.4.2",
+        "progress-events",
+        "uint8arraylist"
+      ]
     },
     "@lit-labs/ssr-dom-shim@1.5.1": {
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="
@@ -3731,13 +3815,16 @@
         "@midnight-ntwrk/onchain-runtime-v1",
         "@types/object-inspect",
         "object-inspect"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/compact-runtime/0.11.0-rc.1/811dda48339e7be77aa8f88e4e99c0f022a1c3f3"
     },
     "@midnight-ntwrk/ledger-v6@6.1.0-alpha.6": {
-      "integrity": "sha512-EwmapuQx2eREsunLHM8eyy5M9T6mAtgybyANsnZ89LjFKDOSFQcZG/MDNq45IK5gv1UMHBKI+HJo+CQ7gbYIkA=="
+      "integrity": "sha512-EwmapuQx2eREsunLHM8eyy5M9T6mAtgybyANsnZ89LjFKDOSFQcZG/MDNq45IK5gv1UMHBKI+HJo+CQ7gbYIkA==",
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/ledger-v6/6.1.0-alpha.6/f403540eca387202cd690dba171e97c682924ecd"
     },
     "@midnight-ntwrk/ledger@4.0.0": {
-      "integrity": "sha512-cnJisY8uQ4NO54miDnjs/ov6n102ZPfKEPxtiDKVEdlKijcc70jz/CI2yBCc0itlwwaqma7FM2Ou5N4pWpbwbg=="
+      "integrity": "sha512-cnJisY8uQ4NO54miDnjs/ov6n102ZPfKEPxtiDKVEdlKijcc70jz/CI2yBCc0itlwwaqma7FM2Ou5N4pWpbwbg==",
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/ledger/4.0.0/2cf7370ff6e27482cce60724f114935512b5e473"
     },
     "@midnight-ntwrk/midnight-js-contracts@3.0.0-alpha.11": {
       "integrity": "sha512-zk/Nfs24yFggbv6WpnGW5UCUABwce+YksX83qWyrX3oG2OSXlyurW3/hM8w1yEgzlNipgcbt6Lo5jY3DYLjTMQ==",
@@ -3745,14 +3832,16 @@
         "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.11",
         "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.11",
         "@midnight-ntwrk/midnight-js-utils@3.0.0-alpha.11"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-contracts/3.0.0-alpha.11/74a6f94d8b2de0c8f8ba1706b99c03e696853ef4"
     },
     "@midnight-ntwrk/midnight-js-fetch-zk-config-provider@2.1.0": {
       "integrity": "sha512-oWztVa4A+/trjSFjEFID6pCYYip/r3JoMfjtoboby17Um/wncUTxu35dZybgmhQzM0BiGKuyq7zVVodI5bbl/Q==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-types@2.1.0",
         "cross-fetch@4.1.0"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/2.1.0/d5f394117dd68f8abe4cb989324bcde331db4ba5"
     },
     "@midnight-ntwrk/midnight-js-http-client-proof-provider@3.0.0-alpha.11": {
       "integrity": "sha512-k4BMjor03gw0iaPiZWRiGWwjxCAZm1kdSJ2/KD2JAGY6weGbj+Vxv9SaHu5DQf7goWgdFUoVWlpf3FhQ9QEm2Q==",
@@ -3764,7 +3853,8 @@
         "cross-fetch@4.1.0",
         "fetch-retry",
         "lodash"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-http-client-proof-provider/3.0.0-alpha.11/bdd2d12ab846ad974f552a009d94d2e0fc0676b6"
     },
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider@3.0.0-alpha.11_graphql@16.12.0_graphql-ws@6.0.6__graphql@16.12.0__ws@8.19.0___bufferutil@4.1.0___utf-8-validate@5.0.10_react@18.3.1_react-dom@18.3.1__react@18.3.1_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10_@types+react@18.3.1": {
       "integrity": "sha512-5LgjP9uNcJ5ynq2pTG9Y2IVEpU0abcmkOtExd9afPQyv+admGdnwJ1PHXP20SIlwNjb2+Ss1KIkuFTieU45r5Q==",
@@ -3781,7 +3871,8 @@
         "rxjs",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10",
         "zen-observable-ts"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-indexer-public-data-provider/3.0.0-alpha.11/c1cc295e76bf6c2f60767828a349f312523da431"
     },
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider@3.0.0-alpha.12_graphql@16.12.0_graphql-ws@6.0.6__graphql@16.12.0__ws@8.19.0___bufferutil@4.1.0___utf-8-validate@5.0.10_react@18.3.1_react-dom@18.3.1__react@18.3.1_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10_@types+react@18.3.1": {
       "integrity": "sha512-he4ZogEWVDeVnsOljP0XO/DPAVeLW4zIpMjkW40SOB/Bb+JDNmx/i+sNogZIbylDwdNOj8lYMWaanzQNRr+cTw==",
@@ -3798,7 +3889,8 @@
         "rxjs",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10",
         "zen-observable-ts"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-indexer-public-data-provider/3.0.0-alpha.12/d66074c8f5452fca011819d898fcfffa2cde98ec"
     },
     "@midnight-ntwrk/midnight-js-level-private-state-provider@3.0.0-alpha.11_fp-ts@2.16.11": {
       "integrity": "sha512-hrB5oSCNV027/ANDF19D4zxhhF/BSkDKy5zW1wEzyhI+tAghkVPULofnNcTUD4GTI/8SSzqgwj8YUv+24tNdIA==",
@@ -3811,74 +3903,87 @@
         "level",
         "lodash",
         "superjson"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-level-private-state-provider/3.0.0-alpha.11/ab032ce2cfc1c626a837214e425a66a695b89ae1"
     },
     "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.11": {
-      "integrity": "sha512-E4I69HpRRai34Upbb4rk3inUdWPlUvnsrRm4GwjKe6Oe/Gt+GizBVI8BZl0R5XLxvx0/4oklPapYOXpkhT9tqQ=="
+      "integrity": "sha512-E4I69HpRRai34Upbb4rk3inUdWPlUvnsrRm4GwjKe6Oe/Gt+GizBVI8BZl0R5XLxvx0/4oklPapYOXpkhT9tqQ==",
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-network-id/3.0.0-alpha.11/7193828eb6477d872b89ab31be40ddc31558b6e6"
     },
     "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.12": {
-      "integrity": "sha512-C2tFkUMo38CxH+/jLLQ5ykl/AV38PnHZIfnyM8gkq7Noj0KYTmktkCYRZhkipeaoYVRwDHQS0K1SiGlwdRKi7A=="
+      "integrity": "sha512-C2tFkUMo38CxH+/jLLQ5ykl/AV38PnHZIfnyM8gkq7Noj0KYTmktkCYRZhkipeaoYVRwDHQS0K1SiGlwdRKi7A==",
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-network-id/3.0.0-alpha.12/0aa85ec4828c981699730088eaac260219eddbd7"
     },
     "@midnight-ntwrk/midnight-js-node-zk-config-provider@3.0.0-alpha.11": {
       "integrity": "sha512-LglvcwSQSLSE6HJF96QnBe+k+gbJAQftyV1PdcyvOuDkbHCFYkYZUsiYT3Ma8m/yN8UgC9nPltTlOw8tX30HJw==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.11"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-node-zk-config-provider/3.0.0-alpha.11/2fcbb352f8486524b52ba89d3d185c5a44dc1b07"
     },
     "@midnight-ntwrk/midnight-js-types@2.1.0": {
       "integrity": "sha512-bU7f2gdXt1/BR2XatKNPx9o6FDq1exYcWLQg4kn78d1SX39OVD33PVOavg2mFMoeC00YpcG2T1xH0eD/CMwXgA==",
       "dependencies": [
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-types/2.1.0/7879d71a3d31f74a7021bb2b698eb6782b7d62c4"
     },
     "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.11": {
       "integrity": "sha512-gdNVrAmN6mo1jNWUsQERneZ38ie1idmqJSOK7qj4/yG6mjTjFjWNvyeC1WxFXmDotqRpW5LiAR9hT/VIWzh2Xw==",
       "dependencies": [
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-types/3.0.0-alpha.11/061d9f8558fba96cbb0938a7073d5878d0f5f213"
     },
     "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.12": {
       "integrity": "sha512-ClyjWjWAJ2BJJtxAHoa4gLiIakfoFnLh0mW1QSTUaHzuwtXW673UlixS2XVb2f8HUs6/YqGW0nBOvGFtaRsDfg==",
       "dependencies": [
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-types/3.0.0-alpha.12/53a58ac880a7fe1d1f179e1ec053cd6566e55979"
     },
     "@midnight-ntwrk/midnight-js-utils@3.0.0-alpha.11": {
       "integrity": "sha512-gdETtSPdEsc58oBtM+5aev0tFKoEulyoX6PnNt2vSsJVan825yPoF0cEgGUVMxkTIkWgDFmhSKeJ0pAhuO8TZA==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.11",
         "@scure/base@2.0.0"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-utils/3.0.0-alpha.11/b9d7023a14ad31b046588fc94ab4c39aab101f8a"
     },
     "@midnight-ntwrk/midnight-js-utils@3.0.0-alpha.12": {
       "integrity": "sha512-I+WBbhJvK7k6mPHAixRWA3tfgYhiGc0WS3yNUu1nD31MpdlBzl+XrJe+yPhY2KYecxIohPHkxWSKW2fFvxB6Og==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.12",
         "@scure/base@2.0.0"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-utils/3.0.0-alpha.12/de290661a133e8aba9f9406cce84356aae67aa00"
     },
     "@midnight-ntwrk/onchain-runtime-v1@1.0.0-alpha.5": {
-      "integrity": "sha512-f2l6PaWFycNukB8kk8w/E5TuR2P8DX1TJ1papbIoEFPYJadHozzMwg0OW9IEYWNIDw3S/adL0B9Qx7F8VODlPQ=="
+      "integrity": "sha512-f2l6PaWFycNukB8kk8w/E5TuR2P8DX1TJ1papbIoEFPYJadHozzMwg0OW9IEYWNIDw3S/adL0B9Qx7F8VODlPQ==",
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/onchain-runtime-v1/1.0.0-alpha.5/c7f885988b50886d1d78a0d25141c77302cef984"
     },
     "@midnight-ntwrk/wallet-api@5.0.0_rxjs@7.8.2": {
       "integrity": "sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==",
       "dependencies": [
         "@midnight-ntwrk/zswap",
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-api/5.0.0/3fdac91d3019d1e0e8f440a6444d9fd840f72741"
     },
     "@midnight-ntwrk/wallet-sdk-abstractions@1.0.0-beta.9": {
       "integrity": "sha512-p1KPyDTa8yGrGEkzS+YFQ1WwRLSxEd4Q9AjxAkAT6Vi0ATKhD8v+i9tlnAawSvwlqwBJOQTByrt4WpfrZcdmrg==",
       "dependencies": [
         "effect"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-abstractions/1.0.0-beta.9/512269a27eb670465450bfce200c4b720b9f89d8"
     },
     "@midnight-ntwrk/wallet-sdk-address-format@2.0.0_@midnight-ntwrk+zswap@4.0.0": {
       "integrity": "sha512-S/3uIfXXUcklYocO0UPey+15uI095CFuCyJRYgxnTmkIXrgjOn8IfSHnReHDtE6JKkvdN2EXlYVt4ufRdCMuPA==",
       "dependencies": [
         "@midnight-ntwrk/zswap",
         "@scure/base@1.2.6"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-address-format/2.0.0/655a703be8e7281b08cfe84c0478026f5212d240"
     },
     "@midnight-ntwrk/wallet-sdk-address-format@3.0.0-beta.9": {
       "integrity": "sha512-HU60iB1uLTJj++wnOpJgrBGMbOk3nmzjCL2kkVDuvo8Q9xr9SHAuuUx8IiWRGJeoYIuU1ZIROJvxeKTkQF9rdA==",
@@ -3886,13 +3991,15 @@
         "@midnight-ntwrk/ledger-v6",
         "@scure/base@1.2.6",
         "@subsquid/scale-codec"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-address-format/3.0.0-beta.9/cf3025932bb42818a6e5184c88b19e7ddf48032d"
     },
     "@midnight-ntwrk/wallet-sdk-capabilities@2.0.0_@midnight-ntwrk+zswap@4.0.0": {
       "integrity": "sha512-zl1uZwy8bMlpNfze6rRTEMZiOCKr4dYBYoIVKLPkck1vKcz3nhsjFAkNfsYtFyND/K7/7mLZBtuHxGWX4gYxXQ==",
       "dependencies": [
         "@midnight-ntwrk/zswap"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-capabilities/2.0.0/2be32fb38122603c262184c024bf8b99e8ce3573"
     },
     "@midnight-ntwrk/wallet-sdk-capabilities@3.0.0-beta.9": {
       "integrity": "sha512-tpgjk9c1KpNMwoEw7t3ZXeKPAXdfR9FazzVELV2TcnXW7D4daFE5jcrcIKNTZQ2OCZUPyxo4WzGtzKOORKuDXw==",
@@ -3900,7 +4007,8 @@
         "@midnight-ntwrk/wallet-sdk-address-format@3.0.0-beta.9",
         "@midnight-ntwrk/wallet-sdk-hd",
         "effect"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-capabilities/3.0.0-beta.9/346cf9cb1148418b073ade60b98c38e922f4fd0d"
     },
     "@midnight-ntwrk/wallet-sdk-dust-wallet@1.0.0-beta.11_ws@8.18.1": {
       "integrity": "sha512-HFC7cuyjOREMHtbGi6L873pv3QUHjC6bDf/xWnkwJ7H753lgf3fz1xwYi8S9PuR6FjEwruLwflRhv+p2vwjyjw==",
@@ -3917,7 +4025,8 @@
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect",
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-dust-wallet/1.0.0-beta.11/a2f73c964f9a59cab2966b062363fed78bcee0a1"
     },
     "@midnight-ntwrk/wallet-sdk-facade@1.0.0-beta.12_ws@8.18.1": {
       "integrity": "sha512-+ARnm4nnQ/sG+wO0BVcl5yygJhALk1MIhD/+4/C4xmbWaSte6gStLD3p1M4yb3DehgxGhn7pxgo00D4yvw2Veg==",
@@ -3930,7 +4039,8 @@
         "@midnight-ntwrk/wallet-sdk-shielded@1.0.0-beta.12_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10",
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet",
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-facade/1.0.0-beta.12/56afbecb5f464ae8a43fb1d0ce70af2d7fe30f5a"
     },
     "@midnight-ntwrk/wallet-sdk-hd@3.0.0-beta.7": {
       "integrity": "sha512-9WGZsAILQ8IMEhCaDesbpXobyAmvLbUAws/zL/YzOCzITUVxH4VIi51FnIu/wiZXHcjXdqfRAZZBYhFcVOsI4Q==",
@@ -3938,7 +4048,8 @@
         "@scure/base@1.2.6",
         "@scure/bip32@1.7.0",
         "@scure/bip39@1.6.0"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-hd/3.0.0-beta.7/40f050d92d726cd87f45ff701476e341d83403f7"
     },
     "@midnight-ntwrk/wallet-sdk-indexer-client@1.0.0-beta.12_effect@3.19.14_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-n1B0vX3i60xs/rdFk+2QQIk6V5QODI/0Z4jzroiOLP3PRsKRptimr+WoBuz+o4NBMwyEve25sgh7f34frEuOGg==",
@@ -3951,7 +4062,8 @@
         "graphql",
         "graphql-http",
         "graphql-ws@6.0.6_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-indexer-client/1.0.0-beta.12/e6bc51605d7e2a8e9e42d71b691eedfca2191791"
     },
     "@midnight-ntwrk/wallet-sdk-indexer-client@1.0.0-beta.13_effect@3.19.14_graphql@16.12.0_ws@8.18.1": {
       "integrity": "sha512-f0S94gDk9VMD4WC+bTntqNndv2tRQeeg38hPcuhGwdI0wDmQAbhEeu7kVDk5T3cW39J7KJx6w0a1ppxqlISEXg==",
@@ -3964,7 +4076,8 @@
         "graphql",
         "graphql-http",
         "graphql-ws@6.0.6_graphql@16.12.0_ws@8.18.1"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-indexer-client/1.0.0-beta.13/da11a811beb42ef7c9c1c87b1175834c4848731c"
     },
     "@midnight-ntwrk/wallet-sdk-indexer-client@1.0.0-beta.13_effect@3.19.14_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-f0S94gDk9VMD4WC+bTntqNndv2tRQeeg38hPcuhGwdI0wDmQAbhEeu7kVDk5T3cW39J7KJx6w0a1ppxqlISEXg==",
@@ -3977,7 +4090,8 @@
         "graphql",
         "graphql-http",
         "graphql-ws@6.0.6_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-indexer-client/1.0.0-beta.13/da11a811beb42ef7c9c1c87b1175834c4848731c"
     },
     "@midnight-ntwrk/wallet-sdk-node-client@1.0.0-beta.10": {
       "integrity": "sha512-UMESShY4QXv7J9MfaAHjCEFTN7/oaP5gt01JjZ+uJ2LbivN4gQv+6B3OpNzTR7GImVQYvdntz3xZ850dH2hotA==",
@@ -3997,7 +4111,8 @@
         "effect",
         "rxjs",
         "testcontainers"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-node-client/1.0.0-beta.10/c6fb0a9dcf203d147bb11399e26d89e893073ea0"
     },
     "@midnight-ntwrk/wallet-sdk-prover-client@1.0.0-beta.10_effect@3.19.14": {
       "integrity": "sha512-ctAYUOwNr5bZnf77uykVrVhbqaCcpzeLApLs+EBCyliUXzLPQoj3r3Cl6rauKncJshw8HvdTPHBUSFpRPJYLMQ==",
@@ -4007,7 +4122,8 @@
         "@midnight-ntwrk/wallet-sdk-abstractions",
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-prover-client/1.0.0-beta.10/700f3dee04a8daa67dfe43797aebcd79a686d734"
     },
     "@midnight-ntwrk/wallet-sdk-runtime@1.0.0-beta.8": {
       "integrity": "sha512-tKdohxKLGEsSR9JMBTIf6kzIgIurXMdmIQznMWqmZ0nT2E6FxbrcjCRPoXuNkfmSsWAYwdvx+AZdvq8NljerQw==",
@@ -4016,7 +4132,8 @@
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect",
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-runtime/1.0.0-beta.8/8da13169a64f4ed32b6da687e89419ed6dd2a922"
     },
     "@midnight-ntwrk/wallet-sdk-shielded@1.0.0-beta.11_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-6iMYv1lM2wW8a6/532Oj3X+N29m3T8lXRNzZatUWlSOJ43Eb3JklqVsEXLiaX+acSf0n6gpOMWgWgIkTSFrVsg==",
@@ -4037,7 +4154,8 @@
         "rxjs",
         "scale-ts",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-shielded/1.0.0-beta.11/dd45fc4d556171ccce500176b8ee3bee73be08de"
     },
     "@midnight-ntwrk/wallet-sdk-shielded@1.0.0-beta.12_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-XVNHIPoytYIdnPUCyO0JrchGTQb0KN17NeCGPJPMmK/oreh9gOI2NiqgnHmXPJn+a73Z+FGEfVPDaTb9AfAcXg==",
@@ -4058,13 +4176,15 @@
         "rxjs",
         "scale-ts",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-shielded/1.0.0-beta.12/ad87dc989c2a4b4b7d49edaf249a37b2f613a1d8"
     },
     "@midnight-ntwrk/wallet-sdk-unshielded-state@1.0.0-beta.11": {
       "integrity": "sha512-IwaqiKRRJ9d9DSbGnB6gLlcrtJaukTX02MbAuThH5U4aEJAd8qPxEaxbF6KIqfAjHF/B2jlnuBEaR6+G/iaizA==",
       "dependencies": [
         "effect"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-unshielded-state/1.0.0-beta.11/a0f509d8388642aa28ad00e075f81f9dcf46697d"
     },
     "@midnight-ntwrk/wallet-sdk-unshielded-wallet@1.0.0-beta.14_ws@8.18.1": {
       "integrity": "sha512-rPZOVOm55JRYi9Be+3kPUUjVFg4TOjRJ6wUXyoEMwq9YOdRowLCZdOK/svvrqd/FqHrLRz7Z6brXmJJ09zhXWA==",
@@ -4079,7 +4199,8 @@
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect",
         "rxjs"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-unshielded-wallet/1.0.0-beta.14/e2b616c71cb5c5a881f709dc50821011cc549d49"
     },
     "@midnight-ntwrk/wallet-sdk-utilities@1.0.0-beta.7": {
       "integrity": "sha512-f7gVrsmcXKl/peAFiWxbftt+mFIBqoCtOOy9+ZdqBmzjpvegIYDURg/q9NiWUTviBb0w99MxoIa732Cpdtm/AQ==",
@@ -4088,7 +4209,8 @@
         "portfinder",
         "rxjs",
         "testcontainers"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-utilities/1.0.0-beta.7/9f2215eff2b5542e7299ee29f6e6d1f588dd0cb0"
     },
     "@midnight-ntwrk/wallet@5.0.0_rxjs@7.8.2_@midnight-ntwrk+zswap@4.0.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-30NjR0w4lOtFrJmwrV0MiFg6QtoKLmCd3e0vy5RxKOvdE8Au6N7O9jiEyZc13c2pk4Pj9ShKL8qukybQhhCuTQ==",
@@ -4102,10 +4224,12 @@
         "rxjs",
         "scale-ts",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ]
+      ],
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet/5.0.0/0019bbe327e49af96b27b9dc99bbe2015397a4e2"
     },
     "@midnight-ntwrk/zswap@4.0.0": {
-      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw=="
+      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw==",
+      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/zswap/4.0.0/cf83884fe94a4f03aadfc82e5161c05d54822053"
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3": {
       "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
@@ -4136,6 +4260,44 @@
       "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
       "os": ["win32"],
       "cpu": ["x64"]
+    },
+    "@multiformats/dns@1.0.13": {
+      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
+      "dependencies": [
+        "@dnsquery/dns-packet",
+        "@libp2p/interface",
+        "hashlru",
+        "p-queue@9.1.0",
+        "progress-events",
+        "uint8arrays@5.1.0"
+      ]
+    },
+    "@multiformats/mafmt@12.1.6": {
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "dependencies": [
+        "@multiformats/multiaddr@12.5.1"
+      ]
+    },
+    "@multiformats/multiaddr@12.5.1": {
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "dependencies": [
+        "@chainsafe/is-ip",
+        "@chainsafe/netmask",
+        "@multiformats/dns",
+        "abort-error",
+        "multiformats@13.4.2",
+        "uint8-varint",
+        "uint8arrays@5.1.0"
+      ]
+    },
+    "@multiformats/multiaddr@13.0.1": {
+      "integrity": "sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==",
+      "dependencies": [
+        "@chainsafe/is-ip",
+        "multiformats@13.4.2",
+        "uint8-varint",
+        "uint8arrays@5.1.0"
+      ]
     },
     "@napi-rs/nice-android-arm-eabi@1.1.1": {
       "integrity": "sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==",
@@ -4474,7 +4636,7 @@
         "@nomicfoundation/hardhat-utils@3.0.5"
       ]
     },
-    "@nomicfoundation/hardhat-ignition-viem@3.0.2_@nomicfoundation+hardhat-ignition@3.0.6__@nomicfoundation+hardhat-verify@3.0.8___hardhat@3.0.4____zod@3.25.76___zod@3.25.76__hardhat@3.0.4___zod@3.25.76_@nomicfoundation+hardhat-verify@3.0.8__hardhat@3.0.4___zod@3.25.76__zod@3.25.76_@nomicfoundation+hardhat-viem@3.0.0__hardhat@3.0.4___zod@3.25.76__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__typescript@5.6.3_@nomicfoundation+ignition-core@3.0.2_hardhat@3.0.4__zod@3.25.76_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_typescript@5.6.3": {
+    "@nomicfoundation/hardhat-ignition-viem@3.0.2_@nomicfoundation+hardhat-ignition@3.0.6__@nomicfoundation+hardhat-verify@3.0.8___hardhat@3.0.4____zod@3.25.76___zod@3.25.76__hardhat@3.0.4___zod@3.25.76_@nomicfoundation+hardhat-verify@3.0.8__hardhat@3.0.4___zod@3.25.76__zod@3.25.76_@nomicfoundation+hardhat-viem@3.0.0__hardhat@3.0.4___zod@3.25.76__viem@2.23.10___typescript@5.6.3___ws@8.18.1__typescript@5.6.3_@nomicfoundation+ignition-core@3.0.2_hardhat@3.0.4__zod@3.25.76_viem@2.23.10__typescript@5.6.3__ws@8.18.1_typescript@5.6.3": {
       "integrity": "sha512-SbKUzPPIqDIkZyqCIKeEomoRJHmjyJR4QCVGXfQLV2XsPsMnXlT92i/KfQSRB8TrxXoDnobRFynUKRPLgNalUA==",
       "dependencies": [
         "@nomicfoundation/hardhat-errors@3.0.6",
@@ -4483,7 +4645,7 @@
         "@nomicfoundation/hardhat-viem",
         "@nomicfoundation/ignition-core@3.0.2",
         "hardhat",
-        "viem@2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10"
+        "viem@2.23.10_typescript@5.6.3_ws@8.18.1"
       ]
     },
     "@nomicfoundation/hardhat-ignition@3.0.6_@nomicfoundation+hardhat-verify@3.0.8__hardhat@3.0.4___zod@3.25.76__zod@3.25.76_hardhat@3.0.4__zod@3.25.76": {
@@ -4542,13 +4704,13 @@
         "zod@3.25.76"
       ]
     },
-    "@nomicfoundation/hardhat-viem@3.0.0_hardhat@3.0.4__zod@3.25.76_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_typescript@5.6.3": {
+    "@nomicfoundation/hardhat-viem@3.0.0_hardhat@3.0.4__zod@3.25.76_viem@2.23.10__typescript@5.6.3__ws@8.18.1_typescript@5.6.3": {
       "integrity": "sha512-4QHBfTgJuo1O8vK9AO2AQYKsIp9yg06aF9C+WydDr2XS7VLJYh3g3gZdszLbSD9eHWsuviN688VKbcmfIZNWvQ==",
       "dependencies": [
         "@nomicfoundation/hardhat-errors@3.0.6",
         "@nomicfoundation/hardhat-utils@3.0.5",
         "hardhat",
-        "viem@2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10"
+        "viem@2.23.10_typescript@5.6.3_ws@8.18.1"
       ]
     },
     "@nomicfoundation/hardhat-zod-utils@3.0.1_zod@3.25.76": {
@@ -7930,6 +8092,9 @@
         "@types/istanbul-lib-report"
       ]
     },
+    "@types/json-bigint@1.0.4": {
+      "integrity": "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag=="
+    },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
@@ -8185,23 +8350,13 @@
     "@ungap/structured-clone@1.3.0": {
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
-    "@utxorpc/sdk@0.6.8_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1": {
-      "integrity": "sha512-Mff6q2o7R2aam85KmjtAZDKPhJesMmnGFbk2M54lPO0FwrrWRfUf6DYezqWfYcjXgKQSHDuklAcdtF0weEENRA==",
-      "dependencies": [
-        "@connectrpc/connect",
-        "@connectrpc/connect-node",
-        "@connectrpc/connect-web",
-        "@utxorpc/spec",
-        "buffer@6.0.3"
-      ]
-    },
-    "@utxorpc/spec@0.16.0": {
-      "integrity": "sha512-EK2M0TBp14MrRCYDuFeJ+bAS39RxxLLh+CD08h/YvAgxSv/4ZOBCf1/sxHAGCBGGndB4heZYFeuQ+i1i8vP5lw==",
+    "@utxorpc/spec@0.18.1": {
+      "integrity": "sha512-XNUhgYImEQlmYxWzHhtRSHcKU/VhJ2fbZPzjBgtEyU/3iZgAev9JdjZc5GWEBXO8iWifqaqK1TarANwMbOftVQ==",
       "dependencies": [
         "@bufbuild/protobuf"
       ]
     },
-    "@vitejs/plugin-react@4.7.0_vite@7.1.3__picomatch@4.0.3_@babel+core@7.28.6_@types+node@24.2.0": {
+    "@vitejs/plugin-react@4.7.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@babel+core@7.28.6_@types+node@24.2.0": {
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dependencies": [
         "@babel/core",
@@ -8223,7 +8378,7 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@3.2.4_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "@vitest/mocker@3.2.4_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
       "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dependencies": [
         "@vitest/spy",
@@ -8299,7 +8454,7 @@
       ],
       "bin": true
     },
-    "@wagmi/connectors@6.2.0_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@tanstack+react-query@5.90.17__react@18.3.1_react@18.3.1_wagmi@2.19.5__@tanstack+react-query@5.90.17___react@18.3.1__react@18.3.1__typescript@5.6.3__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__@wagmi+core@2.22.1___typescript@5.6.3___viem@2.37.3____typescript@5.6.3____ws@8.18.3_____bufferutil@4.1.0_____utf-8-validate@5.0.10___@types+react@18.3.1___react@18.3.1___use-sync-external-store@1.4.0____react@18.3.1__@types+react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1": {
+    "@wagmi/connectors@6.2.0_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.23.10___typescript@5.6.3___ws@8.18.1__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@tanstack+react-query@5.90.17__react@18.3.1_react@18.3.1_wagmi@2.19.5__@tanstack+react-query@5.90.17___react@18.3.1__react@18.3.1__typescript@5.6.3__viem@2.23.10___typescript@5.6.3___ws@8.18.1__@wagmi+core@2.22.1___typescript@5.6.3___viem@2.23.10____typescript@5.6.3____ws@8.18.1___@types+react@18.3.1___react@18.3.1___use-sync-external-store@1.4.0____react@18.3.1__@types+react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1": {
       "integrity": "sha512-2NfkbqhNWdjfibb4abRMrn7u6rPjEGolMfApXss6HCDVt9AW2oVC6k8Q5FouzpJezElxLJSagWz9FW1zaRlanA==",
       "dependencies": [
         "@base-org/account",
@@ -8308,37 +8463,37 @@
         "@metamask/sdk",
         "@safe-global/safe-apps-provider",
         "@safe-global/safe-apps-sdk",
-        "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1",
+        "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1",
         "@walletconnect/ethereum-provider",
         "cbw-sdk@npm:@coinbase/wallet-sdk@3.9.3",
         "porto",
         "typescript",
-        "viem@2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10"
+        "viem@2.23.10_typescript@5.6.3_ws@8.18.1"
       ],
       "optionalPeers": [
         "typescript"
       ]
     },
-    "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1": {
+    "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1": {
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "dependencies": [
         "eventemitter3@5.0.1",
         "mipd",
         "typescript",
-        "viem@2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
+        "viem@2.23.10_typescript@5.6.3_ws@8.18.1",
         "zustand@5.0.0_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1"
       ],
       "optionalPeers": [
         "typescript"
       ]
     },
-    "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1_zod@4.3.5": {
+    "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1_zod@4.3.5": {
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "dependencies": [
         "eventemitter3@5.0.1",
         "mipd",
         "typescript",
-        "viem@2.37.3_typescript@5.6.3_zod@4.3.5_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
+        "viem@2.23.10_typescript@5.6.3_zod@4.3.5_ws@8.18.1",
         "zustand@5.0.0_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1"
       ],
       "optionalPeers": [
@@ -8392,7 +8547,7 @@
         "@walletconnect/window-getters@1.0.1",
         "es-toolkit",
         "events",
-        "uint8arrays"
+        "uint8arrays@3.1.0"
       ]
     },
     "@walletconnect/core@2.21.1_typescript@5.6.3": {
@@ -8414,7 +8569,7 @@
         "@walletconnect/window-getters@1.0.1",
         "es-toolkit",
         "events",
-        "uint8arrays"
+        "uint8arrays@3.1.0"
       ]
     },
     "@walletconnect/crypto@1.1.0": {
@@ -8560,7 +8715,7 @@
         "@noble/hashes@1.7.0",
         "@walletconnect/safe-json@1.0.2",
         "@walletconnect/time",
-        "uint8arrays"
+        "uint8arrays@3.1.0"
       ]
     },
     "@walletconnect/safe-json@1.0.0": {
@@ -8708,7 +8863,7 @@
         "bs58@6.0.0",
         "detect-browser@5.3.0",
         "query-string@7.1.3",
-        "uint8arrays",
+        "uint8arrays@3.1.0",
         "viem@2.23.2_typescript@5.6.3_ws@8.18.0"
       ]
     },
@@ -8730,7 +8885,7 @@
         "bs58@6.0.0",
         "detect-browser@5.3.0",
         "query-string@7.1.3",
-        "uint8arrays",
+        "uint8arrays@3.1.0",
         "viem@2.23.2_typescript@5.6.3_ws@8.18.0"
       ]
     },
@@ -9010,6 +9165,9 @@
     "@xtuc/long@4.2.2": {
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "@zxing/text-encoding@0.9.0": {
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="
+    },
     "a-sync-waterfall@1.0.1": {
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
@@ -9030,24 +9188,24 @@
         "zod@3.25.76"
       ]
     },
-    "abitype@1.0.8_typescript@5.6.3": {
+    "abitype@1.0.8_typescript@5.6.3_zod@4.3.5": {
       "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
       "dependencies": [
-        "typescript"
+        "typescript",
+        "zod@4.3.5"
       ],
       "optionalPeers": [
-        "typescript"
+        "typescript",
+        "zod@4.3.5"
       ]
     },
-    "abitype@1.1.0_typescript@5.6.3_zod@4.3.5": {
+    "abitype@1.1.0_typescript@5.6.3": {
       "integrity": "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==",
       "dependencies": [
-        "typescript",
-        "zod@4.3.5"
+        "typescript"
       ],
       "optionalPeers": [
-        "typescript",
-        "zod@4.3.5"
+        "typescript"
       ]
     },
     "abitype@1.2.3_typescript@5.6.3_zod@3.22.4": {
@@ -9088,6 +9246,9 @@
       "dependencies": [
         "event-target-shim"
       ]
+    },
+    "abort-error@1.0.1": {
+      "integrity": "sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg=="
     },
     "abstract-level@3.1.1": {
       "integrity": "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==",
@@ -9393,7 +9554,7 @@
     "argparse@1.0.10": {
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": [
-        "sprintf-js"
+        "sprintf-js@1.0.3"
       ]
     },
     "argparse@2.0.1": {
@@ -9468,7 +9629,7 @@
       "dependencies": [
         "browserslist",
         "caniuse-lite",
-        "fraction.js",
+        "fraction.js@5.3.4",
         "picocolors",
         "postcss",
         "postcss-value-parser"
@@ -12566,6 +12727,9 @@
     "fp-ts@2.16.11": {
       "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w=="
     },
+    "fraction.js@4.0.1": {
+      "integrity": "sha512-NQYzZw8MUsxSZFQo6E8tKOlmSd/BlDTNOR4puXFSHSwFwNaIlmbortQy5PDN/KnVQ4xWG2NtN0J0hjPw7eE06A=="
+    },
     "fraction.js@5.3.4": {
       "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="
     },
@@ -12985,6 +13149,9 @@
         "minimalistic-assert"
       ]
     },
+    "hashlru@2.3.0": {
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "hasown@2.0.2": {
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": [
@@ -13382,6 +13549,9 @@
         "uuid-parse"
       ]
     },
+    "i@0.3.7": {
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q=="
+    },
     "iconv-lite@0.4.24": {
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dependencies": [
@@ -13547,6 +13717,13 @@
     },
     "ip-address@10.1.0": {
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+    },
+    "ip-address@9.0.5": {
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": [
+        "jsbn",
+        "sprintf-js@1.1.3"
+      ]
     },
     "ip@2.0.1": {
       "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
@@ -13779,6 +13956,9 @@
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "iso-url@1.2.1": {
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+    },
     "isobject@3.0.1": {
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
@@ -13934,6 +14114,9 @@
         "argparse@2.0.1"
       ],
       "bin": true
+    },
+    "jsbn@1.1.0": {
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "jsesc@3.1.0": {
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
@@ -14121,6 +14304,15 @@
     "leven@3.1.0": {
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
     },
+    "libsodium-sumo@0.7.16": {
+      "integrity": "sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA=="
+    },
+    "libsodium-wrappers-sumo@0.7.16": {
+      "integrity": "sha512-gR0JEFPeN3831lB9+ogooQk0KH4K5LSMIO5Prd5Q5XYR2wHFtZfPg0eP7t1oJIWq+UIzlU4WVeBxZ97mt28tXw==",
+      "dependencies": [
+        "libsodium-sumo"
+      ]
+    },
     "light-my-request@6.6.0": {
       "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
       "dependencies": [
@@ -14273,6 +14465,9 @@
       "dependencies": [
         "@jridgewell/sourcemap-codec"
       ]
+    },
+    "main-event@1.0.1": {
+      "integrity": "sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw=="
     },
     "make-dir@3.1.0": {
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
@@ -15257,6 +15452,9 @@
       ],
       "bin": true
     },
+    "multiformats@13.4.2": {
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ=="
+    },
     "multiformats@9.9.0": {
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
@@ -15688,6 +15886,22 @@
         "typescript"
       ]
     },
+    "ox@0.6.9_typescript@5.6.3_zod@4.3.5": {
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "dependencies": [
+        "@adraffy/ens-normalize@1.11.1",
+        "@noble/curves@1.9.7",
+        "@noble/hashes@1.8.0",
+        "@scure/bip32@1.7.0",
+        "@scure/bip39@1.6.0",
+        "abitype@1.2.3_typescript@5.6.3_zod@4.3.5",
+        "eventemitter3@5.0.1",
+        "typescript"
+      ],
+      "optionalPeers": [
+        "typescript"
+      ]
+    },
     "ox@0.9.17_typescript@5.6.3_zod@4.3.5": {
       "integrity": "sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==",
       "dependencies": [
@@ -15715,23 +15929,6 @@
         "@scure/bip32@1.7.0",
         "@scure/bip39@1.6.0",
         "abitype@1.2.3_typescript@5.6.3_zod@3.25.76",
-        "eventemitter3@5.0.1",
-        "typescript"
-      ],
-      "optionalPeers": [
-        "typescript"
-      ]
-    },
-    "ox@0.9.3_typescript@5.6.3_zod@4.3.5": {
-      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
-      "dependencies": [
-        "@adraffy/ens-normalize@1.11.1",
-        "@noble/ciphers@1.3.0",
-        "@noble/curves@1.9.1",
-        "@noble/hashes@1.8.0",
-        "@scure/bip32@1.7.0",
-        "@scure/bip39@1.6.0",
-        "abitype@1.2.3_typescript@5.6.3_zod@4.3.5",
         "eventemitter3@5.0.1",
         "typescript"
       ],
@@ -15806,6 +16003,13 @@
         "p-timeout@3.2.0"
       ]
     },
+    "p-queue@9.1.0": {
+      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "dependencies": [
+        "eventemitter3@5.0.1",
+        "p-timeout@7.0.1"
+      ]
+    },
     "p-retry@4.6.2": {
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dependencies": [
@@ -15821,6 +16025,9 @@
     },
     "p-timeout@5.1.0": {
       "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+    },
+    "p-timeout@7.0.1": {
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="
     },
     "p-try@2.2.0": {
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
@@ -16205,18 +16412,18 @@
         "debug@4.4.3"
       ]
     },
-    "porto@0.2.35_@tanstack+react-query@5.90.17__react@18.3.1_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_react@18.3.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_wagmi@2.19.5__@tanstack+react-query@5.90.17___react@18.3.1__react@18.3.1__typescript@5.6.3__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__@wagmi+core@2.22.1___typescript@5.6.3___viem@2.37.3____typescript@5.6.3____ws@8.18.3_____bufferutil@4.1.0_____utf-8-validate@5.0.10___@types+react@18.3.1___react@18.3.1___use-sync-external-store@1.4.0____react@18.3.1__@types+react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1_zod@4.3.5": {
+    "porto@0.2.35_@tanstack+react-query@5.90.17__react@18.3.1_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.23.10___typescript@5.6.3___ws@8.18.1__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_react@18.3.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_wagmi@2.19.5__@tanstack+react-query@5.90.17___react@18.3.1__react@18.3.1__typescript@5.6.3__viem@2.23.10___typescript@5.6.3___ws@8.18.1__@wagmi+core@2.22.1___typescript@5.6.3___viem@2.23.10____typescript@5.6.3____ws@8.18.1___@types+react@18.3.1___react@18.3.1___use-sync-external-store@1.4.0____react@18.3.1__@types+react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1_zod@4.3.5": {
       "integrity": "sha512-gu9FfjjvvYBgQXUHWTp6n3wkTxVtEcqFotM7i3GEZeoQbvLGbssAicCz6hFZ8+xggrJWwi/RLmbwNra50SMmUQ==",
       "dependencies": [
         "@tanstack/react-query",
-        "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1_zod@4.3.5",
+        "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1_zod@4.3.5",
         "hono",
         "idb-keyval",
         "mipd",
         "ox@0.9.17_typescript@5.6.3_zod@4.3.5",
         "react@18.3.1",
         "typescript",
-        "viem@2.37.3_typescript@5.6.3_zod@4.3.5_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
+        "viem@2.23.10_typescript@5.6.3_zod@4.3.5_ws@8.18.1",
         "wagmi",
         "zod@4.3.5",
         "zustand@5.0.3_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1"
@@ -16902,6 +17109,9 @@
     },
     "process@0.11.10": {
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+    },
+    "progress-events@1.0.1": {
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw=="
     },
     "prompts@2.4.2": {
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
@@ -17875,6 +18085,12 @@
         "statuses@2.0.2"
       ]
     },
+    "serialize-error@8.1.0": {
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": [
+        "type-fest@0.20.2"
+      ]
+    },
     "serialize-javascript@6.0.2": {
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dependencies": [
@@ -18126,7 +18342,7 @@
     "socks@2.8.7": {
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dependencies": [
-        "ip-address",
+        "ip-address@10.1.0",
         "smart-buffer"
       ]
     },
@@ -18214,6 +18430,9 @@
     },
     "sprintf-js@1.0.3": {
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "sprintf-js@1.1.3": {
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "srcset@4.0.0": {
       "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw=="
@@ -18566,7 +18785,8 @@
         "minizlib@2.1.2",
         "mkdirp",
         "yallist@4.0.0"
-      ]
+      ],
+      "deprecated": true
     },
     "tar@7.5.2": {
       "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
@@ -18576,7 +18796,8 @@
         "minipass@7.1.2",
         "minizlib@3.1.0",
         "yallist@5.0.0"
-      ]
+      ],
+      "deprecated": true
     },
     "terser-webpack-plugin@5.3.16_webpack@5.104.1__acorn@8.15.0": {
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
@@ -18766,6 +18987,9 @@
     "trough@2.2.0": {
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
     },
+    "ts-custom-error@3.3.1": {
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="
+    },
     "ts-dedent@2.2.0": {
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="
     },
@@ -18777,6 +19001,9 @@
       "dependencies": [
         "tslib@2.8.1"
       ]
+    },
+    "ts-log@2.2.7": {
+      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg=="
     },
     "ts-parse-database-url@1.0.3": {
       "integrity": "sha512-7AIP9EZyKsgaeGpu+Yhu6xDQtwbKDfkw5zBUsuYXju79tFRj6u8w2W+5Ag5wtCS6LM1jOB4iIqDNyFYX758wVQ==",
@@ -18821,6 +19048,9 @@
     },
     "tweetnacl@1.0.3": {
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "type-fest@0.20.2": {
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "type-fest@0.21.3": {
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
@@ -18868,6 +19098,13 @@
     "ufo@1.6.3": {
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="
     },
+    "uint8-varint@2.0.4": {
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "dependencies": [
+        "uint8arraylist",
+        "uint8arrays@5.1.0"
+      ]
+    },
     "uint8array-extras@1.5.0": {
       "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
     },
@@ -18880,10 +19117,22 @@
     "uint8array-tools@0.0.9": {
       "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A=="
     },
+    "uint8arraylist@2.4.8": {
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "dependencies": [
+        "uint8arrays@5.1.0"
+      ]
+    },
     "uint8arrays@3.1.0": {
       "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
       "dependencies": [
-        "multiformats"
+        "multiformats@9.9.0"
+      ]
+    },
+    "uint8arrays@5.1.0": {
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": [
+        "multiformats@13.4.2"
       ]
     },
     "unbzip2-stream@1.4.3": {
@@ -18904,12 +19153,6 @@
     },
     "undici-types@7.18.2": {
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
-    },
-    "undici@5.29.0": {
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dependencies": [
-        "@fastify/busboy"
-      ]
     },
     "undici@6.23.0": {
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="
@@ -19112,6 +19355,9 @@
       ],
       "scripts": true
     },
+    "utf8-codec@1.0.0": {
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w=="
+    },
     "util-deprecate@1.0.2": {
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
@@ -19231,9 +19477,26 @@
         "@noble/hashes@1.7.1",
         "@scure/bip32@1.6.2",
         "@scure/bip39@1.5.4",
-        "abitype@1.0.8_typescript@5.6.3",
+        "abitype@1.0.8_typescript@5.6.3_zod@4.3.5",
         "isows@1.0.6_ws@8.18.1",
         "ox@0.6.9_typescript@5.6.3",
+        "typescript",
+        "ws@8.18.1"
+      ],
+      "optionalPeers": [
+        "typescript"
+      ]
+    },
+    "viem@2.23.10_typescript@5.6.3_zod@4.3.5_ws@8.18.1": {
+      "integrity": "sha512-va6Wde+v96PdfzdPEspCML1MjAqe+88O8BD+R9Kun/4s5KMUNcqfHbXdZP0ZZ2Zms80styvH2pDRAqCho6TqkA==",
+      "dependencies": [
+        "@noble/curves@1.8.1",
+        "@noble/hashes@1.7.1",
+        "@scure/bip32@1.6.2",
+        "@scure/bip39@1.5.4",
+        "abitype@1.0.8_typescript@5.6.3_zod@4.3.5",
+        "isows@1.0.6_ws@8.18.1",
+        "ox@0.6.9_typescript@5.6.3_zod@4.3.5",
         "typescript",
         "ws@8.18.1"
       ],
@@ -19248,7 +19511,7 @@
         "@noble/hashes@1.7.1",
         "@scure/bip32@1.6.2",
         "@scure/bip39@1.5.4",
-        "abitype@1.0.8_typescript@5.6.3",
+        "abitype@1.0.8_typescript@5.6.3_zod@4.3.5",
         "isows@1.0.6_ws@8.18.0",
         "ox@0.6.7_typescript@5.6.3",
         "typescript",
@@ -19265,26 +19528,9 @@
         "@noble/hashes@1.8.0",
         "@scure/bip32@1.7.0",
         "@scure/bip39@1.6.0",
-        "abitype@1.1.0_typescript@5.6.3_zod@4.3.5",
+        "abitype@1.1.0_typescript@5.6.3",
         "isows@1.0.7_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
         "ox@0.9.3_typescript@5.6.3",
-        "typescript",
-        "ws@8.18.3_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ],
-      "optionalPeers": [
-        "typescript"
-      ]
-    },
-    "viem@2.37.3_typescript@5.6.3_zod@4.3.5_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10": {
-      "integrity": "sha512-hwoZqkFSy13GCFzIftgfIH8hNENvdlcHIvtLt73w91tL6rKmZjQisXWTahi1Vn5of8/JQ1FBKfwUus3YkDXwbw==",
-      "dependencies": [
-        "@noble/curves@1.9.1",
-        "@noble/hashes@1.8.0",
-        "@scure/bip32@1.7.0",
-        "@scure/bip39@1.6.0",
-        "abitype@1.1.0_typescript@5.6.3_zod@4.3.5",
-        "isows@1.0.7_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10",
-        "ox@0.9.3_typescript@5.6.3_zod@4.3.5",
         "typescript",
         "ws@8.18.3_bufferutil@4.1.0_utf-8-validate@5.0.10"
       ],
@@ -19354,7 +19600,7 @@
       ],
       "bin": true
     },
-    "vite-plugin-node-stdlib-browser@0.2.1_node-stdlib-browser@1.3.1_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "vite-plugin-node-stdlib-browser@0.2.1_node-stdlib-browser@1.3.1_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
       "integrity": "sha512-6u2i613Dkqj5KaTNIrnZvE6y3/awWAp0S5TjucTvGxdhetftB1Mgvblc+nwYzlw6sntPlac8UOC7ttXNh+LZKA==",
       "dependencies": [
         "@rollup/plugin-inject",
@@ -19362,7 +19608,7 @@
         "vite"
       ]
     },
-    "vite-plugin-static-copy@3.1.4_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "vite-plugin-static-copy@3.1.4_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
       "integrity": "sha512-iCmr4GSw4eSnaB+G8zc2f4dxSuDjbkjwpuBLLGvQYR9IW7rnDzftnUjOH5p4RYR+d4GsiBqXRvzuFhs5bnzVyw==",
       "dependencies": [
         "chokidar@3.6.0",
@@ -19372,7 +19618,7 @@
         "vite"
       ]
     },
-    "vite-plugin-top-level-await@1.6.0_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "vite-plugin-top-level-await@1.6.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
       "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
       "dependencies": [
         "@rollup/plugin-virtual",
@@ -19382,13 +19628,13 @@
         "vite"
       ]
     },
-    "vite-plugin-wasm@3.5.0_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "vite-plugin-wasm@3.5.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0": {
       "integrity": "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==",
       "dependencies": [
         "vite"
       ]
     },
-    "vite@7.1.3_picomatch@4.0.3_@types+node@24.2.0": {
+    "vite@7.1.3_@types+node@24.2.0_picomatch@4.0.3": {
       "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
       "dependencies": [
         "@types/node@24.2.0",
@@ -19407,7 +19653,7 @@
       ],
       "bin": true
     },
-    "vitest@3.2.4_vite@7.1.3__picomatch@4.0.3_@types+node@24.2.0": {
+    "vitest@3.2.4_@types+node@24.2.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3": {
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dependencies": [
         "@types/chai",
@@ -19472,16 +19718,16 @@
     "vscode-uri@3.0.8": {
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     },
-    "wagmi@2.19.5_@tanstack+react-query@5.90.17__react@18.3.1_react@18.3.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.37.3___typescript@5.6.3___ws@8.18.3____bufferutil@4.1.0____utf-8-validate@5.0.10__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1": {
+    "wagmi@2.19.5_@tanstack+react-query@5.90.17__react@18.3.1_react@18.3.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@wagmi+core@2.22.1__typescript@5.6.3__viem@2.23.10___typescript@5.6.3___ws@8.18.1__@types+react@18.3.1__react@18.3.1__use-sync-external-store@1.4.0___react@18.3.1_@types+react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1": {
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "dependencies": [
         "@tanstack/react-query",
         "@wagmi/connectors",
-        "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.37.3__typescript@5.6.3__ws@8.18.3___bufferutil@4.1.0___utf-8-validate@5.0.10_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1",
+        "@wagmi/core@2.22.1_typescript@5.6.3_viem@2.23.10__typescript@5.6.3__ws@8.18.1_@types+react@18.3.1_react@18.3.1_use-sync-external-store@1.4.0__react@18.3.1",
         "react@18.3.1",
         "typescript",
         "use-sync-external-store@1.4.0_react@18.3.1",
-        "viem@2.37.3_typescript@5.6.3_ws@8.18.3__bufferutil@4.1.0__utf-8-validate@5.0.10"
+        "viem@2.23.10_typescript@5.6.3_ws@8.18.1"
       ],
       "optionalPeers": [
         "typescript"
@@ -19515,6 +19761,15 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": [
         "defaults@1.0.4"
+      ]
+    },
+    "web-encoding@1.1.5": {
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dependencies": [
+        "util"
+      ],
+      "optionalDependencies": [
+        "@zxing/text-encoding"
       ]
     },
     "web-namespaces@2.0.1": {
@@ -20276,7 +20531,14 @@
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   },
+  "remote": {
+    "https://raw.githubusercontent.com/utxorpc/node-sdk/626068a7a2737d81e399c546ce79f9ad3836b5f8/package.json": "f3ad0f06c32f5577edc70a6dfac8d7f0ac16fa33d422e30cb6a9b2c0a077c4ad"
+  },
   "workspace": {
+    "dependencies": [
+      "npm:@utxorpc/spec@~0.18.1",
+      "npm:buffer@^6.0.3"
+    ],
     "members": {
       "docs/site": {
         "packageJson": {
@@ -20727,6 +20989,7 @@
           "npm:@dcspark/cip34-js@3.0.1",
           "npm:@midnight-ntwrk/onchain-runtime-v1@1.0.0-alpha.5",
           "npm:@sinclair/typebox@0.34.41",
+          "npm:@utxorpc/spec@~0.18.1",
           "npm:abitype@1.1.0",
           "npm:assert-never@^1.4.0",
           "npm:buffer@^6.0.3",
@@ -20908,12 +21171,14 @@
       },
       "packages/node-sdk/sync": {
         "dependencies": [
+          "npm:@cardano-sdk/core@~0.46.11",
+          "npm:@cardano-sdk/util@~0.17.1",
           "npm:@midnight-ntwrk/midnight-js-indexer-public-data-provider@3.0.0-alpha.12",
           "npm:@midnight-ntwrk/onchain-runtime-v1@1.0.0-alpha.5",
           "npm:@sinclair/typebox@0.34.41",
-          "npm:@utxorpc/sdk@~0.6.8",
-          "npm:@utxorpc/spec@0.16",
+          "npm:@utxorpc/spec@~0.18.1",
           "npm:avail-js-sdk@~0.4.2",
+          "npm:buffer@^6.0.3",
           "npm:denque@^2.1.0",
           "npm:effection@3.5.0",
           "npm:graphql-ws@^6.0.6",

--- a/deno.lock
+++ b/deno.lock
@@ -142,6 +142,7 @@
     "npm:@types/react@18.3.1": "18.3.1",
     "npm:@types/react@19.1.0": "19.1.0",
     "npm:@types/react@19.1.2": "19.1.2",
+    "npm:@utxorpc/sdk@0.8": "0.8.0_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1",
     "npm:@utxorpc/spec@~0.18.1": "0.18.1",
     "npm:@vitejs/plugin-react@^4.4.1": "4.7.0_vite@7.1.3__@types+node@24.2.0__picomatch@4.0.3_@babel+core@7.28.6_@types+node@24.2.0",
     "npm:@wagmi/cli@2.3.1": "2.3.1_typescript@5.6.3_zod@3.25.76_esbuild@0.25.12_picomatch@3.0.1",
@@ -1763,6 +1764,27 @@
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@connectrpc/connect-node@1.4.0_@bufbuild+protobuf@1.10.1_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1": {
+      "integrity": "sha512-0ANnrr6SvsjevsWEgdzHy7BaHkluZyS6s4xNoVt7RBHFR5V/kT9lPokoIbYUOU9JHzdRgTaS3x5595mwUsu15g==",
+      "dependencies": [
+        "@bufbuild/protobuf",
+        "@connectrpc/connect",
+        "undici@5.29.0"
+      ]
+    },
+    "@connectrpc/connect-web@1.4.0_@bufbuild+protobuf@1.10.1_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1": {
+      "integrity": "sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==",
+      "dependencies": [
+        "@bufbuild/protobuf",
+        "@connectrpc/connect"
+      ]
+    },
+    "@connectrpc/connect@1.4.0_@bufbuild+protobuf@1.10.1": {
+      "integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
+      "dependencies": [
+        "@bufbuild/protobuf"
+      ]
+    },
     "@csstools/cascade-layer-name-parser@2.0.5_@csstools+css-parser-algorithms@3.0.5__@csstools+css-tokenizer@3.0.4_@csstools+css-tokenizer@3.0.4": {
       "integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A==",
       "dependencies": [
@@ -3279,6 +3301,9 @@
         "fast-uri"
       ]
     },
+    "@fastify/busboy@2.1.1": {
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+    },
     "@fastify/cors@11.2.0": {
       "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
       "dependencies": [
@@ -3815,16 +3840,13 @@
         "@midnight-ntwrk/onchain-runtime-v1",
         "@types/object-inspect",
         "object-inspect"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/compact-runtime/0.11.0-rc.1/811dda48339e7be77aa8f88e4e99c0f022a1c3f3"
+      ]
     },
     "@midnight-ntwrk/ledger-v6@6.1.0-alpha.6": {
-      "integrity": "sha512-EwmapuQx2eREsunLHM8eyy5M9T6mAtgybyANsnZ89LjFKDOSFQcZG/MDNq45IK5gv1UMHBKI+HJo+CQ7gbYIkA==",
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/ledger-v6/6.1.0-alpha.6/f403540eca387202cd690dba171e97c682924ecd"
+      "integrity": "sha512-EwmapuQx2eREsunLHM8eyy5M9T6mAtgybyANsnZ89LjFKDOSFQcZG/MDNq45IK5gv1UMHBKI+HJo+CQ7gbYIkA=="
     },
     "@midnight-ntwrk/ledger@4.0.0": {
-      "integrity": "sha512-cnJisY8uQ4NO54miDnjs/ov6n102ZPfKEPxtiDKVEdlKijcc70jz/CI2yBCc0itlwwaqma7FM2Ou5N4pWpbwbg==",
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/ledger/4.0.0/2cf7370ff6e27482cce60724f114935512b5e473"
+      "integrity": "sha512-cnJisY8uQ4NO54miDnjs/ov6n102ZPfKEPxtiDKVEdlKijcc70jz/CI2yBCc0itlwwaqma7FM2Ou5N4pWpbwbg=="
     },
     "@midnight-ntwrk/midnight-js-contracts@3.0.0-alpha.11": {
       "integrity": "sha512-zk/Nfs24yFggbv6WpnGW5UCUABwce+YksX83qWyrX3oG2OSXlyurW3/hM8w1yEgzlNipgcbt6Lo5jY3DYLjTMQ==",
@@ -3832,16 +3854,14 @@
         "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.11",
         "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.11",
         "@midnight-ntwrk/midnight-js-utils@3.0.0-alpha.11"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-contracts/3.0.0-alpha.11/74a6f94d8b2de0c8f8ba1706b99c03e696853ef4"
+      ]
     },
     "@midnight-ntwrk/midnight-js-fetch-zk-config-provider@2.1.0": {
       "integrity": "sha512-oWztVa4A+/trjSFjEFID6pCYYip/r3JoMfjtoboby17Um/wncUTxu35dZybgmhQzM0BiGKuyq7zVVodI5bbl/Q==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-types@2.1.0",
         "cross-fetch@4.1.0"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-fetch-zk-config-provider/2.1.0/d5f394117dd68f8abe4cb989324bcde331db4ba5"
+      ]
     },
     "@midnight-ntwrk/midnight-js-http-client-proof-provider@3.0.0-alpha.11": {
       "integrity": "sha512-k4BMjor03gw0iaPiZWRiGWwjxCAZm1kdSJ2/KD2JAGY6weGbj+Vxv9SaHu5DQf7goWgdFUoVWlpf3FhQ9QEm2Q==",
@@ -3853,8 +3873,7 @@
         "cross-fetch@4.1.0",
         "fetch-retry",
         "lodash"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-http-client-proof-provider/3.0.0-alpha.11/bdd2d12ab846ad974f552a009d94d2e0fc0676b6"
+      ]
     },
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider@3.0.0-alpha.11_graphql@16.12.0_graphql-ws@6.0.6__graphql@16.12.0__ws@8.19.0___bufferutil@4.1.0___utf-8-validate@5.0.10_react@18.3.1_react-dom@18.3.1__react@18.3.1_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10_@types+react@18.3.1": {
       "integrity": "sha512-5LgjP9uNcJ5ynq2pTG9Y2IVEpU0abcmkOtExd9afPQyv+admGdnwJ1PHXP20SIlwNjb2+Ss1KIkuFTieU45r5Q==",
@@ -3871,8 +3890,7 @@
         "rxjs",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10",
         "zen-observable-ts"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-indexer-public-data-provider/3.0.0-alpha.11/c1cc295e76bf6c2f60767828a349f312523da431"
+      ]
     },
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider@3.0.0-alpha.12_graphql@16.12.0_graphql-ws@6.0.6__graphql@16.12.0__ws@8.19.0___bufferutil@4.1.0___utf-8-validate@5.0.10_react@18.3.1_react-dom@18.3.1__react@18.3.1_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10_@types+react@18.3.1": {
       "integrity": "sha512-he4ZogEWVDeVnsOljP0XO/DPAVeLW4zIpMjkW40SOB/Bb+JDNmx/i+sNogZIbylDwdNOj8lYMWaanzQNRr+cTw==",
@@ -3889,8 +3907,7 @@
         "rxjs",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10",
         "zen-observable-ts"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-indexer-public-data-provider/3.0.0-alpha.12/d66074c8f5452fca011819d898fcfffa2cde98ec"
+      ]
     },
     "@midnight-ntwrk/midnight-js-level-private-state-provider@3.0.0-alpha.11_fp-ts@2.16.11": {
       "integrity": "sha512-hrB5oSCNV027/ANDF19D4zxhhF/BSkDKy5zW1wEzyhI+tAghkVPULofnNcTUD4GTI/8SSzqgwj8YUv+24tNdIA==",
@@ -3903,87 +3920,74 @@
         "level",
         "lodash",
         "superjson"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-level-private-state-provider/3.0.0-alpha.11/ab032ce2cfc1c626a837214e425a66a695b89ae1"
+      ]
     },
     "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.11": {
-      "integrity": "sha512-E4I69HpRRai34Upbb4rk3inUdWPlUvnsrRm4GwjKe6Oe/Gt+GizBVI8BZl0R5XLxvx0/4oklPapYOXpkhT9tqQ==",
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-network-id/3.0.0-alpha.11/7193828eb6477d872b89ab31be40ddc31558b6e6"
+      "integrity": "sha512-E4I69HpRRai34Upbb4rk3inUdWPlUvnsrRm4GwjKe6Oe/Gt+GizBVI8BZl0R5XLxvx0/4oklPapYOXpkhT9tqQ=="
     },
     "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.12": {
-      "integrity": "sha512-C2tFkUMo38CxH+/jLLQ5ykl/AV38PnHZIfnyM8gkq7Noj0KYTmktkCYRZhkipeaoYVRwDHQS0K1SiGlwdRKi7A==",
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-network-id/3.0.0-alpha.12/0aa85ec4828c981699730088eaac260219eddbd7"
+      "integrity": "sha512-C2tFkUMo38CxH+/jLLQ5ykl/AV38PnHZIfnyM8gkq7Noj0KYTmktkCYRZhkipeaoYVRwDHQS0K1SiGlwdRKi7A=="
     },
     "@midnight-ntwrk/midnight-js-node-zk-config-provider@3.0.0-alpha.11": {
       "integrity": "sha512-LglvcwSQSLSE6HJF96QnBe+k+gbJAQftyV1PdcyvOuDkbHCFYkYZUsiYT3Ma8m/yN8UgC9nPltTlOw8tX30HJw==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.11"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-node-zk-config-provider/3.0.0-alpha.11/2fcbb352f8486524b52ba89d3d185c5a44dc1b07"
+      ]
     },
     "@midnight-ntwrk/midnight-js-types@2.1.0": {
       "integrity": "sha512-bU7f2gdXt1/BR2XatKNPx9o6FDq1exYcWLQg4kn78d1SX39OVD33PVOavg2mFMoeC00YpcG2T1xH0eD/CMwXgA==",
       "dependencies": [
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-types/2.1.0/7879d71a3d31f74a7021bb2b698eb6782b7d62c4"
+      ]
     },
     "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.11": {
       "integrity": "sha512-gdNVrAmN6mo1jNWUsQERneZ38ie1idmqJSOK7qj4/yG6mjTjFjWNvyeC1WxFXmDotqRpW5LiAR9hT/VIWzh2Xw==",
       "dependencies": [
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-types/3.0.0-alpha.11/061d9f8558fba96cbb0938a7073d5878d0f5f213"
+      ]
     },
     "@midnight-ntwrk/midnight-js-types@3.0.0-alpha.12": {
       "integrity": "sha512-ClyjWjWAJ2BJJtxAHoa4gLiIakfoFnLh0mW1QSTUaHzuwtXW673UlixS2XVb2f8HUs6/YqGW0nBOvGFtaRsDfg==",
       "dependencies": [
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-types/3.0.0-alpha.12/53a58ac880a7fe1d1f179e1ec053cd6566e55979"
+      ]
     },
     "@midnight-ntwrk/midnight-js-utils@3.0.0-alpha.11": {
       "integrity": "sha512-gdETtSPdEsc58oBtM+5aev0tFKoEulyoX6PnNt2vSsJVan825yPoF0cEgGUVMxkTIkWgDFmhSKeJ0pAhuO8TZA==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.11",
         "@scure/base@2.0.0"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-utils/3.0.0-alpha.11/b9d7023a14ad31b046588fc94ab4c39aab101f8a"
+      ]
     },
     "@midnight-ntwrk/midnight-js-utils@3.0.0-alpha.12": {
       "integrity": "sha512-I+WBbhJvK7k6mPHAixRWA3tfgYhiGc0WS3yNUu1nD31MpdlBzl+XrJe+yPhY2KYecxIohPHkxWSKW2fFvxB6Og==",
       "dependencies": [
         "@midnight-ntwrk/midnight-js-network-id@3.0.0-alpha.12",
         "@scure/base@2.0.0"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/midnight-js-utils/3.0.0-alpha.12/de290661a133e8aba9f9406cce84356aae67aa00"
+      ]
     },
     "@midnight-ntwrk/onchain-runtime-v1@1.0.0-alpha.5": {
-      "integrity": "sha512-f2l6PaWFycNukB8kk8w/E5TuR2P8DX1TJ1papbIoEFPYJadHozzMwg0OW9IEYWNIDw3S/adL0B9Qx7F8VODlPQ==",
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/onchain-runtime-v1/1.0.0-alpha.5/c7f885988b50886d1d78a0d25141c77302cef984"
+      "integrity": "sha512-f2l6PaWFycNukB8kk8w/E5TuR2P8DX1TJ1papbIoEFPYJadHozzMwg0OW9IEYWNIDw3S/adL0B9Qx7F8VODlPQ=="
     },
     "@midnight-ntwrk/wallet-api@5.0.0_rxjs@7.8.2": {
       "integrity": "sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==",
       "dependencies": [
         "@midnight-ntwrk/zswap",
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-api/5.0.0/3fdac91d3019d1e0e8f440a6444d9fd840f72741"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-abstractions@1.0.0-beta.9": {
       "integrity": "sha512-p1KPyDTa8yGrGEkzS+YFQ1WwRLSxEd4Q9AjxAkAT6Vi0ATKhD8v+i9tlnAawSvwlqwBJOQTByrt4WpfrZcdmrg==",
       "dependencies": [
         "effect"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-abstractions/1.0.0-beta.9/512269a27eb670465450bfce200c4b720b9f89d8"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-address-format@2.0.0_@midnight-ntwrk+zswap@4.0.0": {
       "integrity": "sha512-S/3uIfXXUcklYocO0UPey+15uI095CFuCyJRYgxnTmkIXrgjOn8IfSHnReHDtE6JKkvdN2EXlYVt4ufRdCMuPA==",
       "dependencies": [
         "@midnight-ntwrk/zswap",
         "@scure/base@1.2.6"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-address-format/2.0.0/655a703be8e7281b08cfe84c0478026f5212d240"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-address-format@3.0.0-beta.9": {
       "integrity": "sha512-HU60iB1uLTJj++wnOpJgrBGMbOk3nmzjCL2kkVDuvo8Q9xr9SHAuuUx8IiWRGJeoYIuU1ZIROJvxeKTkQF9rdA==",
@@ -3991,15 +3995,13 @@
         "@midnight-ntwrk/ledger-v6",
         "@scure/base@1.2.6",
         "@subsquid/scale-codec"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-address-format/3.0.0-beta.9/cf3025932bb42818a6e5184c88b19e7ddf48032d"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-capabilities@2.0.0_@midnight-ntwrk+zswap@4.0.0": {
       "integrity": "sha512-zl1uZwy8bMlpNfze6rRTEMZiOCKr4dYBYoIVKLPkck1vKcz3nhsjFAkNfsYtFyND/K7/7mLZBtuHxGWX4gYxXQ==",
       "dependencies": [
         "@midnight-ntwrk/zswap"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-capabilities/2.0.0/2be32fb38122603c262184c024bf8b99e8ce3573"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-capabilities@3.0.0-beta.9": {
       "integrity": "sha512-tpgjk9c1KpNMwoEw7t3ZXeKPAXdfR9FazzVELV2TcnXW7D4daFE5jcrcIKNTZQ2OCZUPyxo4WzGtzKOORKuDXw==",
@@ -4007,8 +4009,7 @@
         "@midnight-ntwrk/wallet-sdk-address-format@3.0.0-beta.9",
         "@midnight-ntwrk/wallet-sdk-hd",
         "effect"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-capabilities/3.0.0-beta.9/346cf9cb1148418b073ade60b98c38e922f4fd0d"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-dust-wallet@1.0.0-beta.11_ws@8.18.1": {
       "integrity": "sha512-HFC7cuyjOREMHtbGi6L873pv3QUHjC6bDf/xWnkwJ7H753lgf3fz1xwYi8S9PuR6FjEwruLwflRhv+p2vwjyjw==",
@@ -4025,8 +4026,7 @@
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect",
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-dust-wallet/1.0.0-beta.11/a2f73c964f9a59cab2966b062363fed78bcee0a1"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-facade@1.0.0-beta.12_ws@8.18.1": {
       "integrity": "sha512-+ARnm4nnQ/sG+wO0BVcl5yygJhALk1MIhD/+4/C4xmbWaSte6gStLD3p1M4yb3DehgxGhn7pxgo00D4yvw2Veg==",
@@ -4039,8 +4039,7 @@
         "@midnight-ntwrk/wallet-sdk-shielded@1.0.0-beta.12_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10",
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet",
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-facade/1.0.0-beta.12/56afbecb5f464ae8a43fb1d0ce70af2d7fe30f5a"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-hd@3.0.0-beta.7": {
       "integrity": "sha512-9WGZsAILQ8IMEhCaDesbpXobyAmvLbUAws/zL/YzOCzITUVxH4VIi51FnIu/wiZXHcjXdqfRAZZBYhFcVOsI4Q==",
@@ -4048,8 +4047,7 @@
         "@scure/base@1.2.6",
         "@scure/bip32@1.7.0",
         "@scure/bip39@1.6.0"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-hd/3.0.0-beta.7/40f050d92d726cd87f45ff701476e341d83403f7"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-indexer-client@1.0.0-beta.12_effect@3.19.14_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-n1B0vX3i60xs/rdFk+2QQIk6V5QODI/0Z4jzroiOLP3PRsKRptimr+WoBuz+o4NBMwyEve25sgh7f34frEuOGg==",
@@ -4062,8 +4060,7 @@
         "graphql",
         "graphql-http",
         "graphql-ws@6.0.6_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-indexer-client/1.0.0-beta.12/e6bc51605d7e2a8e9e42d71b691eedfca2191791"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-indexer-client@1.0.0-beta.13_effect@3.19.14_graphql@16.12.0_ws@8.18.1": {
       "integrity": "sha512-f0S94gDk9VMD4WC+bTntqNndv2tRQeeg38hPcuhGwdI0wDmQAbhEeu7kVDk5T3cW39J7KJx6w0a1ppxqlISEXg==",
@@ -4076,8 +4073,7 @@
         "graphql",
         "graphql-http",
         "graphql-ws@6.0.6_graphql@16.12.0_ws@8.18.1"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-indexer-client/1.0.0-beta.13/da11a811beb42ef7c9c1c87b1175834c4848731c"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-indexer-client@1.0.0-beta.13_effect@3.19.14_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-f0S94gDk9VMD4WC+bTntqNndv2tRQeeg38hPcuhGwdI0wDmQAbhEeu7kVDk5T3cW39J7KJx6w0a1ppxqlISEXg==",
@@ -4090,8 +4086,7 @@
         "graphql",
         "graphql-http",
         "graphql-ws@6.0.6_graphql@16.12.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-indexer-client/1.0.0-beta.13/da11a811beb42ef7c9c1c87b1175834c4848731c"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-node-client@1.0.0-beta.10": {
       "integrity": "sha512-UMESShY4QXv7J9MfaAHjCEFTN7/oaP5gt01JjZ+uJ2LbivN4gQv+6B3OpNzTR7GImVQYvdntz3xZ850dH2hotA==",
@@ -4111,8 +4106,7 @@
         "effect",
         "rxjs",
         "testcontainers"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-node-client/1.0.0-beta.10/c6fb0a9dcf203d147bb11399e26d89e893073ea0"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-prover-client@1.0.0-beta.10_effect@3.19.14": {
       "integrity": "sha512-ctAYUOwNr5bZnf77uykVrVhbqaCcpzeLApLs+EBCyliUXzLPQoj3r3Cl6rauKncJshw8HvdTPHBUSFpRPJYLMQ==",
@@ -4122,8 +4116,7 @@
         "@midnight-ntwrk/wallet-sdk-abstractions",
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-prover-client/1.0.0-beta.10/700f3dee04a8daa67dfe43797aebcd79a686d734"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-runtime@1.0.0-beta.8": {
       "integrity": "sha512-tKdohxKLGEsSR9JMBTIf6kzIgIurXMdmIQznMWqmZ0nT2E6FxbrcjCRPoXuNkfmSsWAYwdvx+AZdvq8NljerQw==",
@@ -4132,8 +4125,7 @@
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect",
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-runtime/1.0.0-beta.8/8da13169a64f4ed32b6da687e89419ed6dd2a922"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-shielded@1.0.0-beta.11_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-6iMYv1lM2wW8a6/532Oj3X+N29m3T8lXRNzZatUWlSOJ43Eb3JklqVsEXLiaX+acSf0n6gpOMWgWgIkTSFrVsg==",
@@ -4154,8 +4146,7 @@
         "rxjs",
         "scale-ts",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-shielded/1.0.0-beta.11/dd45fc4d556171ccce500176b8ee3bee73be08de"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-shielded@1.0.0-beta.12_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-XVNHIPoytYIdnPUCyO0JrchGTQb0KN17NeCGPJPMmK/oreh9gOI2NiqgnHmXPJn+a73Z+FGEfVPDaTb9AfAcXg==",
@@ -4176,15 +4167,13 @@
         "rxjs",
         "scale-ts",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-shielded/1.0.0-beta.12/ad87dc989c2a4b4b7d49edaf249a37b2f613a1d8"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-unshielded-state@1.0.0-beta.11": {
       "integrity": "sha512-IwaqiKRRJ9d9DSbGnB6gLlcrtJaukTX02MbAuThH5U4aEJAd8qPxEaxbF6KIqfAjHF/B2jlnuBEaR6+G/iaizA==",
       "dependencies": [
         "effect"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-unshielded-state/1.0.0-beta.11/a0f509d8388642aa28ad00e075f81f9dcf46697d"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-unshielded-wallet@1.0.0-beta.14_ws@8.18.1": {
       "integrity": "sha512-rPZOVOm55JRYi9Be+3kPUUjVFg4TOjRJ6wUXyoEMwq9YOdRowLCZdOK/svvrqd/FqHrLRz7Z6brXmJJ09zhXWA==",
@@ -4199,8 +4188,7 @@
         "@midnight-ntwrk/wallet-sdk-utilities",
         "effect",
         "rxjs"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-unshielded-wallet/1.0.0-beta.14/e2b616c71cb5c5a881f709dc50821011cc549d49"
+      ]
     },
     "@midnight-ntwrk/wallet-sdk-utilities@1.0.0-beta.7": {
       "integrity": "sha512-f7gVrsmcXKl/peAFiWxbftt+mFIBqoCtOOy9+ZdqBmzjpvegIYDURg/q9NiWUTviBb0w99MxoIa732Cpdtm/AQ==",
@@ -4209,8 +4197,7 @@
         "portfinder",
         "rxjs",
         "testcontainers"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet-sdk-utilities/1.0.0-beta.7/9f2215eff2b5542e7299ee29f6e6d1f588dd0cb0"
+      ]
     },
     "@midnight-ntwrk/wallet@5.0.0_rxjs@7.8.2_@midnight-ntwrk+zswap@4.0.0_ws@8.19.0__bufferutil@4.1.0__utf-8-validate@5.0.10": {
       "integrity": "sha512-30NjR0w4lOtFrJmwrV0MiFg6QtoKLmCd3e0vy5RxKOvdE8Au6N7O9jiEyZc13c2pk4Pj9ShKL8qukybQhhCuTQ==",
@@ -4224,12 +4211,10 @@
         "rxjs",
         "scale-ts",
         "ws@8.19.0_bufferutil@4.1.0_utf-8-validate@5.0.10"
-      ],
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/wallet/5.0.0/0019bbe327e49af96b27b9dc99bbe2015397a4e2"
+      ]
     },
     "@midnight-ntwrk/zswap@4.0.0": {
-      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw==",
-      "tarball": "https://npm.pkg.github.com/download/@midnight-ntwrk/zswap/4.0.0/cf83884fe94a4f03aadfc82e5161c05d54822053"
+      "integrity": "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw=="
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3": {
       "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
@@ -8349,6 +8334,16 @@
     },
     "@ungap/structured-clone@1.3.0": {
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+    },
+    "@utxorpc/sdk@0.8.0_@connectrpc+connect@1.4.0__@bufbuild+protobuf@1.10.1": {
+      "integrity": "sha512-bOm9bHmPEVOCTZD+kziCVgzQmttNoPy8okX3M84hYgrmuNL+rTwskELQDM2gx2VSliDGkjqjHx/Nzzfr72bi+g==",
+      "dependencies": [
+        "@connectrpc/connect",
+        "@connectrpc/connect-node",
+        "@connectrpc/connect-web",
+        "@utxorpc/spec",
+        "buffer@6.0.3"
+      ]
     },
     "@utxorpc/spec@0.18.1": {
       "integrity": "sha512-XNUhgYImEQlmYxWzHhtRSHcKU/VhJ2fbZPzjBgtEyU/3iZgAev9JdjZc5GWEBXO8iWifqaqK1TarANwMbOftVQ==",
@@ -19154,6 +19149,12 @@
     "undici-types@7.18.2": {
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
     },
+    "undici@5.29.0": {
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dependencies": [
+        "@fastify/busboy"
+      ]
+    },
     "undici@6.23.0": {
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="
     },
@@ -20531,14 +20532,7 @@
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   },
-  "remote": {
-    "https://raw.githubusercontent.com/utxorpc/node-sdk/626068a7a2737d81e399c546ce79f9ad3836b5f8/package.json": "f3ad0f06c32f5577edc70a6dfac8d7f0ac16fa33d422e30cb6a9b2c0a077c4ad"
-  },
   "workspace": {
-    "dependencies": [
-      "npm:@utxorpc/spec@~0.18.1",
-      "npm:buffer@^6.0.3"
-    ],
     "members": {
       "docs/site": {
         "packageJson": {
@@ -21176,6 +21170,7 @@
           "npm:@midnight-ntwrk/midnight-js-indexer-public-data-provider@3.0.0-alpha.12",
           "npm:@midnight-ntwrk/onchain-runtime-v1@1.0.0-alpha.5",
           "npm:@sinclair/typebox@0.34.41",
+          "npm:@utxorpc/sdk@0.8",
           "npm:@utxorpc/spec@~0.18.1",
           "npm:avail-js-sdk@~0.4.2",
           "npm:buffer@^6.0.3",

--- a/e2e/shared/data-types/src/grammar.ts
+++ b/e2e/shared/data-types/src/grammar.ts
@@ -39,4 +39,5 @@ export const grammar = {
   "transfer-erc20": builtinGrammars.evmErc20,
   "transfer-erc1155": builtinGrammars.evmErc1155,
   "bitcoin-transaction": builtinGrammars.bitcoinAddress,
+  "utxorpc": builtinGrammars.utxorpcGeneric,
 } as const satisfies GrammarDefinition;

--- a/packages/effectstream-sdk/config/deno.json
+++ b/packages/effectstream-sdk/config/deno.json
@@ -12,6 +12,7 @@
     "@dcspark/cip34-js": "npm:@dcspark/cip34-js@3.0.1",
     "assert-never": "npm:assert-never@^1.4.0",
     "@dcspark/carp-client": "npm:@dcspark/carp-client@^3.3.0",
+    "@utxorpc/spec": "npm:@utxorpc/spec@^0.18.1",
     "@midnight-ntwrk/onchain-runtime": "npm:@midnight-ntwrk/onchain-runtime-v1@1.0.0-alpha.5"
   }
 }

--- a/packages/effectstream-sdk/config/src/schema/primitive/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/primitive/types.ts
@@ -3,6 +3,7 @@ import type {
   ProtocolPrimitiveMap,
 } from "../sync-protocols/types.ts";
 import type { EncodedStateValue } from "@midnight-ntwrk/onchain-runtime";
+import type { cardano } from '@utxorpc/spec';
 
 export type { EncodedStateValue };
 
@@ -35,7 +36,7 @@ type CardanoCarpPrimitivePayload = {
 };
 
 type CardanoUtxoRpcPrimitivePayload = {
-  TODO_MISSING_FIELDS: string;
+  tx: cardano.Tx;
 };
 
 type MinaPrimitivePayload = {

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/mod.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/mod.ts
@@ -1,1 +1,2 @@
 export * from './carp.ts';
+export * from './utxorpc.ts';

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/utxorpc.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/utxorpc.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
 import { ConfigSyncProtocolType } from "../types.ts";
-import { NameField, PollingSyncProtocol, StartStopSlot } from "../../common.ts";
+import { NameField, StartStopSlot } from "../../common.ts";
 import {
   CommonResponseParallelSyncProtocol,
   type ConfigSyncProtocolCommonResponse,
@@ -19,6 +19,42 @@ import {
 // =====
 // Utils
 // =====
+
+export const UtxorpcAddressPattern = Type.Object({
+  exactAddress: Type.Optional(Type.String()),
+  paymentPart: Type.Optional(Type.String()),
+  delegationPart: Type.Optional(Type.String()),
+});
+export type UtxorpcAddressPattern = Static<typeof UtxorpcAddressPattern>;
+
+export const UtxorpcAssetPattern = Type.Object({
+  policyId: Type.Optional(Type.String()),
+  assetName: Type.Optional(Type.String()),
+});
+export type UtxorpcAssetPattern = Static<typeof UtxorpcAssetPattern>;
+
+export const UtxorpcTxOutputPattern = Type.Object({
+  address: Type.Optional(UtxorpcAddressPattern),
+  asset: Type.Optional(UtxorpcAssetPattern),
+});
+export type UtxorpcTxOutputPattern = Static<typeof UtxorpcTxOutputPattern>;
+
+export const UtxorpcTxPattern = Type.Object({
+  consumes: Type.Optional(UtxorpcTxOutputPattern),
+  produces: Type.Optional(UtxorpcTxOutputPattern),
+  hasAddress: Type.Optional(UtxorpcAddressPattern),
+  movesAsset: Type.Optional(UtxorpcAssetPattern),
+  mintsAsset: Type.Optional(UtxorpcAssetPattern),
+});
+export type UtxorpcTxPattern = Static<typeof UtxorpcTxPattern>;
+
+export const UtxorpcTxPredicate = Type.Recursive(This => Type.Object({
+  match: Type.Optional(UtxorpcTxPattern),
+  not: Type.Optional(Type.Array(This)),
+  allOf: Type.Optional(Type.Array(This)),
+  anyOf: Type.Optional(Type.Array(This)),
+}));
+export type UtxorpcTxPredicate = Static<typeof UtxorpcTxPredicate>;
 
 // ===========
 // Base schema
@@ -75,7 +111,7 @@ export const ConfigSyncProtocolSchemaCardanoUtxoRpcParallel =
         }),
       }),
     });
-export type ConfigSyncProtocolCardanoParallel = MergeIntersects<
+export type ConfigSyncProtocolCardanoUtxoRpcParallel = MergeIntersects<
   Static<
     ReturnType<
       typeof ConfigSyncProtocolSchemaCardanoUtxoRpcParallel.allProperties<true>

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/utxorpc.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/utxorpc.ts
@@ -68,7 +68,9 @@ export const ConfigSyncProtocolSchemaCardanoUtxoRpcBase = NameField
       name: Type.String(),
       rpcUrl: Type.String(),
     }),
-    optional: Type.Object({}),
+    optional: Type.Object({
+      headers: Type.Record(Type.String(), Type.String()),
+    }),
   });
 
 export const CommonResponseCardanoUtxoRpcBase = {

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
@@ -3,7 +3,7 @@ import { ConfigNetworkType } from "../network/mod.ts";
 import type { ConfigSyncProtocolDecoratorType } from "./decorators/types.ts";
 import type { NetworkConfig } from "../../config/parts/network.ts";
 import type { ConfigSyncProtocolMapping } from "./all.ts";
-import type { EncodedStateValue, getEvmEvent } from "@effectstream/config";
+import type { EncodedStateValue, UtxorpcTxPredicate, getEvmEvent } from "@effectstream/config";
 
 export enum ConfigSyncProtocolType {
   NTP_MAIN = "ntp-main",
@@ -58,7 +58,7 @@ type MidnightPrimitive = BasePrimitive & {
 };
 
 type CardanoUtxoRpcPrimitive = BasePrimitive & {
-  TODO_ADD_MISSING_FIELDS: string;
+  predicate: UtxorpcTxPredicate;
 };
 
 type CardanoCarpPrimitive = BasePrimitive & {

--- a/packages/node-sdk/sm/primitives/src/builtin.ts
+++ b/packages/node-sdk/sm/primitives/src/builtin.ts
@@ -2,6 +2,8 @@
 // this list is exposed to the effectstream-sdk modules via the @effectstream/sm/builtin module
 export const PrimitiveTypeMidnightGeneric = "Midnight:Generic" as const;
 
+export const PrimitiveTypeUtxorpcGeneric = "Utxorpc:Generic" as const;
+
 export const PrimitiveTypeEVMPaimaL2 = "EVM:PaimaL2" as const;
 export const PrimitiveTypeEVMERC721 = "EVM:ERC721" as const;
 export const PrimitiveTypeEVMERC20 = "EVM:ERC20" as const;
@@ -20,6 +22,7 @@ type BuiltInPrimitives =
     typeof PrimitiveTypeEVMERC20 |
     typeof PrimitiveTypeAvailGeneric |
     typeof PrimitiveTypeEVMERC1155 |
+    typeof PrimitiveTypeUtxorpcGeneric |
     typeof PrimitiveTypeBitcoinAddress // |
     // typeof PrimitiveTypeEVMGeneric
 ;

--- a/packages/node-sdk/sm/primitives/src/grammar.ts
+++ b/packages/node-sdk/sm/primitives/src/grammar.ts
@@ -7,6 +7,7 @@ import { erc20Grammar } from "./evm-erc20/erc20-grammar.ts";
 import { availGenericGrammar } from "./avail-generic/avail-generic-grammar.ts";
 import { erc1155Grammar } from "./evm-erc1155/erc1155-grammar.ts";
 import { bitcoinAddressGrammar } from "./bitcoin-address/bitcoin-grammar.ts";
+import { utxorpcGenericGrammar } from "./utxorpc-generic/utxorpc-generic-grammar.ts";
 
 export const builtinGrammars = {
   midnightGeneric: midnightGenericGrammar,
@@ -15,4 +16,5 @@ export const builtinGrammars = {
   availGeneric: availGenericGrammar,
   evmErc1155: erc1155Grammar,
   bitcoinAddress: bitcoinAddressGrammar,
+  utxorpcGeneric: utxorpcGenericGrammar,
 } as const;

--- a/packages/node-sdk/sm/primitives/src/utxorpc-generic/utxorpc-generic-grammar.ts
+++ b/packages/node-sdk/sm/primitives/src/utxorpc-generic/utxorpc-generic-grammar.ts
@@ -1,0 +1,6 @@
+import { Type } from '@sinclair/typebox';
+
+export const utxorpcGenericGrammar = [
+  ["hash", Type.String()],
+  ["bytes", Type.String()],
+] as const;

--- a/packages/node-sdk/sm/primitives/src/utxorpc-generic/utxorpc-generic.ts
+++ b/packages/node-sdk/sm/primitives/src/utxorpc-generic/utxorpc-generic.ts
@@ -1,0 +1,88 @@
+import type { Static, StaticDecode, TSchema } from '@sinclair/typebox';
+import {
+  type CommandTuple,
+  generateRawStmInput,
+  type ParamToData,
+} from "@effectstream/concise";
+import type { ConfigSyncProtocolType, FlattenSyncProtocolIOFor, ProtocolPrimitiveMap, UtxorpcTxPredicate } from '@effectstream/config';
+import type { StateUpdateStream } from "@effectstream/coroutine";
+import { type JsonObject, PaimaPrimitive } from "@effectstream/sm";
+import { type AddressAndType, AddressType, type PaimaBlockNumber, uint8ArrayToHexString } from '@effectstream/utils';
+import { utxorpcGenericGrammar } from './utxorpc-generic-grammar.ts';
+import { PrimitiveTypeUtxorpcGeneric } from '../builtin.ts';
+
+export class UtxorpcGenericPrimitive extends PaimaPrimitive<
+  ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL,
+  typeof utxorpcGenericGrammar
+> {
+  readonly internalTypeName = PrimitiveTypeUtxorpcGeneric;
+  readonly predicate: UtxorpcTxPredicate;
+  override grammar = utxorpcGenericGrammar;
+
+  constructor(config: {
+    instanceName: string;
+    startBlockHeight: number;
+    stateMachinePrefix: string | undefined;
+    predicate: UtxorpcTxPredicate;
+  }) {
+    super(config);
+    this.predicate = config.predicate;
+  }
+
+  override getConfig(): ProtocolPrimitiveMap[
+    ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL
+  ] {
+    return {
+      name: this.instanceName,
+      type: this.internalTypeName,
+      startBlockHeight: this.startBlockHeight,
+      scheduledPrefix: this.stateMachinePrefix,
+      predicate: this.predicate,
+    } as const;
+  }
+
+  override *getPayload(
+    _: PaimaBlockNumber,
+    primitiveTransactionData: FlattenSyncProtocolIOFor<
+      ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL
+    >,
+  ): StateUpdateStream<{
+    isBatched: boolean;
+    data: {
+      fromAddressAndType: AddressAndType;
+      stateMachinePayload:
+        | StaticDecode<
+          CommandTuple<string, typeof utxorpcGenericGrammar>
+        >
+        | null;
+      accountingPayload: JsonObject;
+    }[];
+  }> {
+    const payload = primitiveTransactionData.output.payload;
+    const accountingPayload = {
+      hash: uint8ArrayToHexString(payload.tx.hash),
+      bytes: uint8ArrayToHexString(payload.tx.toBinary()),
+    };
+    const stateMachinePayload: any = this.stateMachinePrefix
+        ? generateRawStmInput(
+          this.grammar,
+          this.stateMachinePrefix,
+          accountingPayload,
+        )
+        : null;
+
+    return {
+      isBatched: false,
+      data: [
+        {
+          fromAddressAndType: {
+            type: AddressType.NONE,
+            address: "0x0",
+          },
+          accountingPayload,
+          stateMachinePayload,
+        },
+      ],
+    };
+  }
+}

--- a/packages/node-sdk/sync/deno.json
+++ b/packages/node-sdk/sync/deno.json
@@ -13,9 +13,12 @@
     "denque": "npm:denque@^2.1.0",
     "pg": "npm:pg@^8.14.0",
     "json-stable-stringify": "npm:json-stable-stringify@^1.2.1",
-    "@utxorpc/sdk": "npm:@utxorpc/sdk@^0.6.8",
-    "@utxorpc/spec": "npm:@utxorpc/spec@^0.16.0",
+    "@cardano-sdk/core": "npm:@cardano-sdk/core@^0.46.11",
+    "@cardano-sdk/util": "npm:@cardano-sdk/util@^0.17.1",
+    "@utxorpc/sdk": "file:/home/simon/cardano/node-sdk/lib/browser/index.mjs",
+    "@utxorpc/spec": "npm:@utxorpc/spec@^0.18.1",
     "@sinclair/typebox": "npm:@sinclair/typebox@0.34.41",
-    "avail-js-sdk": "npm:avail-js-sdk@^0.4.2"
+    "avail-js-sdk": "npm:avail-js-sdk@^0.4.2",
+    "buffer": "npm:buffer@^6.0.3"
   }
 }

--- a/packages/node-sdk/sync/deno.json
+++ b/packages/node-sdk/sync/deno.json
@@ -15,7 +15,7 @@
     "json-stable-stringify": "npm:json-stable-stringify@^1.2.1",
     "@cardano-sdk/core": "npm:@cardano-sdk/core@^0.46.11",
     "@cardano-sdk/util": "npm:@cardano-sdk/util@^0.17.1",
-    "@utxorpc/sdk": "file:/home/simon/cardano/node-sdk/lib/browser/index.mjs",
+    "@utxorpc/sdk": "npm:@utxorpc/sdk@^0.8.0",
     "@utxorpc/spec": "npm:@utxorpc/spec@^0.18.1",
     "@sinclair/typebox": "npm:@sinclair/typebox@0.34.41",
     "avail-js-sdk": "npm:avail-js-sdk@^0.4.2",

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/BufferedRpc.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/BufferedRpc.ts
@@ -1,4 +1,4 @@
-import type { CardanoSyncClient, CardanoWatchClient } from "@utxorpc/sdk";
+import type { CardanoSyncClient } from "@utxorpc/sdk";
 import type { cardano } from "@utxorpc/spec";
 import type { OutputAndCleanup } from "../base/state.ts";
 import Deque from "denque";

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/BufferedRpc.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/BufferedRpc.ts
@@ -1,27 +1,22 @@
-import type { CardanoSyncClient } from "@utxorpc/sdk";
+import type { CardanoSyncClient, CardanoWatchClient } from "@utxorpc/sdk";
 import type { cardano } from "@utxorpc/spec";
 import type { OutputAndCleanup } from "../base/state.ts";
 import Deque from "denque";
 import type { BlockNumber } from "@effectstream/utils";
 import type { Operation } from "effection";
 import { conditionVariable } from "@effectstream/utils";
-import type { BlockAndTimestamp, Page } from "./types.ts";
+import type { BlockAndTxs, ChainPoint, Page, PrimitiveEntryType } from "./types.ts";
+import { hashEqual } from "./utils.ts";
 import { Buffer } from "node:buffer";
 
-// TODO: https://github.com/utxorpc/node-sdk/pull/38
-type ChainPoint = {
-  slot: number | string;
-  hash: string;
-};
-
 export class BufferedRpc {
-  private readonly buffer: Deque<OutputAndCleanup<BlockAndTimestamp>> =
+  private readonly buffer: Deque<OutputAndCleanup<BlockAndTxs>> =
     new Deque();
   private readonly newDataCondVar = conditionVariable<void>();
-  private bestBlock: undefined | Page = undefined;
 
   constructor(
-    public readonly client: CardanoSyncClient,
+    public readonly syncClient: CardanoSyncClient,
+    public readonly watchClient: CardanoWatchClient,
     /**
      * Finality should ensure that we never expose data that could be affected by `undo`
      * recall: finality is in terms of blocks created (not in terms of slots)
@@ -29,93 +24,63 @@ export class BufferedRpc {
     private readonly finality: BlockNumber,
   ) {}
 
-  public async start(point: undefined | ChainPoint): Promise<void> {
-    // TODO: these parameters can change
-    //       see: https://github.com/utxorpc/spec/issues/149
-    const byronGenesis = await fetch(
-      "http://localhost:10000/local-cluster/api/admin/devnet/genesis/byron",
-    );
-    const byronGenesisJson = await byronGenesis.json();
-    const shelleyGenesis = await fetch(
-      "http://localhost:10000/local-cluster/api/admin/devnet/genesis/shelley",
-    );
-    const shelleyGenesisJson = await shelleyGenesis.json();
-    const toTimestamp = (block: cardano.Block) => {
-      // TODO: hardcoded to yaci-devkit magic number until https://github.com/utxorpc/spec/pull/147
-      if (block.header!.slot < 600) {
-        return new Date(
-          1000 * byronGenesisJson.startTime +
-            (Number(block.header!.slot) *
-              byronGenesisJson.blockVersionData.slotDuration),
-        ).getTime();
-      }
-      // TODO: in yaci-devkit, systemStart starts at the time Shelley starts
-      //       but on mainnet, it starts at Byron start
-      //       so we hardcode the yaci-devkit behavior until https://github.com/utxorpc/spec/issues/149
-      return new Date(
-        shelleyGenesisJson.systemStart,
-      ).getTime() +
-        (1000 * (Number(block.header!.slot) - 600) *
-          shelleyGenesisJson.slotLength);
+  public async start(point: undefined | ChainPoint, primitives: PrimitiveEntryType[]): Promise<void> {
+    const predicate = {
+      anyOf: primitives.map(p => p.primitive.predicate),
     };
+    const intersect = point ? [point] : [];
+    const txEvents = this.watchClient.watchTxByPredicate(predicate, intersect);
 
-    if (point != null) {
-      const startBlock = await this.client.fetchBlock(point);
-      this.bestBlock = {
-        slot: Number(point.slot),
-        hash: point.hash,
-        height: Number(startBlock.header!.height),
-      };
-    } else {
-      const firstBlock = await this.client.fetchHistory(undefined);
-      point = {
-        slot: Number(firstBlock.header!.slot),
-        hash: Buffer.from(firstBlock.header!.hash).toString("hex"),
-      };
+    const cleanupBlock = (hash: Uint8Array) => {
+      for (let i = this.buffer.length; i >= 0; --i) {
+        const entry = this.buffer.peekAt(i)!;
+        if (hashEqual(entry.output.block.header!.hash, hash)) {
+          this.buffer.removeOne(i);
+          return;
+        }
+      }
     }
 
-    let seenReset = false; // chainsync always returns "reset" as the first event
-    // TODO: replace with watchTxByMatch once we have https://github.com/utxorpc/spec/issues/135
-    const tip = this.client.followTip([point]);
-    for await (
-      const event of tip
-    ) {
-      if (event.action === "apply") {
-        this.bestBlock = toPage(event.block);
+    for await (const txEvent of txEvents) {
+      if (txEvent.action === "idle") {
+        const block = await this.syncClient.fetchBlock(txEvent.BlockRef);
         this.buffer.push({
           output: {
-            block: event.block,
-            timestamp: toTimestamp(event.block),
+            block: block.parsedBlock,
+            txs: [],
           },
-          cleanup: () => {
-            // we have to look up the position in the buffer again
-            // since the position may have changed by the time we run the cleanup
-            // note: cleanup is typically called in an ordered way, so we search from the start of the buffer
-            const index = this.findFromStart(
-              Number(event.block.header!.height),
-            );
-            if (index == null) {
-              throw new Error(
-                `Block not found for slot ${event.block.header!.height}`,
-              );
-            }
-            this.buffer.remove(index, 1);
-          },
+          cleanup: () => cleanupBlock(block.parsedBlock.header!.hash),
         });
         this.newDataCondVar.wake();
-      } else if (event.action === "undo") {
-        this.buffer.pop();
-      } else if (event.action === "reset") {
-        if (!seenReset) {
-          seenReset = true;
-          continue;
+      } else if (txEvent.action === "apply") {
+        const lastBlock = this.buffer.peekBack();
+        if (lastBlock && hashEqual(lastBlock.output.block.header!.hash, txEvent.Block.header!.hash)) {
+          lastBlock.output.txs.push(txEvent.Tx);
+        } else {
+          this.buffer.push({
+            output: {
+              block: txEvent.Block,
+              txs: [txEvent.Tx],
+            },
+            cleanup: () => cleanupBlock(txEvent.Block.header!.hash),
+          });
+          this.newDataCondVar.wake();
         }
-
-        throw new Error(
-          `Paima node stuck on fork. Currently at point ${
-            JSON.stringify(point)
-          }`,
-        );
+      } else if (txEvent.action === "undo") {
+        for (let lastBlock = this.buffer.peekBack(); lastBlock; lastBlock = this.buffer.peekBack()) {
+          if (lastBlock.output.block.header!.height > txEvent.Block.header!.height) {
+            // rolled back past this apparently-empty block
+            this.buffer.pop();
+            continue;
+          }
+          if (lastBlock.output.block.header!.height === txEvent.Block.header!.height) {
+            lastBlock.output.txs = lastBlock.output.txs.filter(tx => !hashEqual(tx.hash, txEvent.Tx.hash));
+            if (!lastBlock.output.txs.length) {
+              this.buffer.pop();
+            }
+          }
+          break;
+        }
       }
     }
   }
@@ -181,8 +146,8 @@ export class BufferedRpc {
   public fetchBlocks(
     from: BlockNumber, // (inclusive)
     to: BlockNumber, // (inclusive)
-  ): OutputAndCleanup<BlockAndTimestamp>[] {
-    const blocks: OutputAndCleanup<BlockAndTimestamp>[] = [];
+  ): OutputAndCleanup<BlockAndTxs>[] {
+    const blocks: OutputAndCleanup<BlockAndTxs>[] = [];
     for (let i = 0; i < this.buffer.length; i++) {
       const block = this.buffer.peekAt(i)!;
       if (Number(block.output.block.header!.height) >= from) {
@@ -194,17 +159,6 @@ export class BufferedRpc {
     }
     return blocks;
   }
-
-  findFromStart = (height: BlockNumber): undefined | number => {
-    for (let i = 0; i < this.buffer.length; i++) {
-      if (
-        Number(this.buffer.peekAt(i)!.output.block.header!.height) === height
-      ) {
-        return i;
-      }
-    }
-    return undefined;
-  };
 }
 
 function toPage(block: cardano.Block): Page {

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/BufferedRpc.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/BufferedRpc.ts
@@ -5,18 +5,16 @@ import Deque from "denque";
 import type { BlockNumber } from "@effectstream/utils";
 import type { Operation } from "effection";
 import { conditionVariable } from "@effectstream/utils";
-import type { BlockAndTxs, ChainPoint, Page, PrimitiveEntryType } from "./types.ts";
-import { hashEqual } from "./utils.ts";
+import type { ChainPoint, Page } from "./types.ts";
 import { Buffer } from "node:buffer";
 
 export class BufferedRpc {
-  private readonly buffer: Deque<OutputAndCleanup<BlockAndTxs>> =
+  private readonly buffer: Deque<OutputAndCleanup<cardano.Block>> =
     new Deque();
   private readonly newDataCondVar = conditionVariable<void>();
 
   constructor(
     public readonly syncClient: CardanoSyncClient,
-    public readonly watchClient: CardanoWatchClient,
     /**
      * Finality should ensure that we never expose data that could be affected by `undo`
      * recall: finality is in terms of blocks created (not in terms of slots)
@@ -24,63 +22,35 @@ export class BufferedRpc {
     private readonly finality: BlockNumber,
   ) {}
 
-  public async start(point: undefined | ChainPoint, primitives: PrimitiveEntryType[]): Promise<void> {
-    const predicate = {
-      anyOf: primitives.map(p => p.primitive.predicate),
-    };
+  public async start(point: undefined | ChainPoint): Promise<void> {
     const intersect = point ? [point] : [];
-    const txEvents = this.watchClient.watchTxByPredicate(predicate, intersect);
+    const blockEvents = this.syncClient.followTip(intersect);
 
-    const cleanupBlock = (hash: Uint8Array) => {
-      for (let i = this.buffer.length; i >= 0; --i) {
-        const entry = this.buffer.peekAt(i)!;
-        if (hashEqual(entry.output.block.header!.hash, hash)) {
-          this.buffer.removeOne(i);
-          return;
-        }
-      }
-    }
+    let seenReset = false;
 
-    for await (const txEvent of txEvents) {
-      if (txEvent.action === "idle") {
-        const block = await this.syncClient.fetchBlock(txEvent.BlockRef);
+    for await (const blockEvent of blockEvents) {
+      if (blockEvent.action === "apply") {
         this.buffer.push({
-          output: {
-            block: block.parsedBlock,
-            txs: [],
-          },
-          cleanup: () => cleanupBlock(block.parsedBlock.header!.hash),
+          output: blockEvent.block,
+          cleanup: () => {},
         });
         this.newDataCondVar.wake();
-      } else if (txEvent.action === "apply") {
+      } else if (blockEvent.action === "undo") {
+        this.buffer.pop();
+      } else if (blockEvent.action === "reset") {
+        if (!seenReset) {
+          seenReset = true;
+          continue;
+        }
+
         const lastBlock = this.buffer.peekBack();
-        if (lastBlock && hashEqual(lastBlock.output.block.header!.hash, txEvent.Block.header!.hash)) {
-          lastBlock.output.txs.push(txEvent.Tx);
-        } else {
-          this.buffer.push({
-            output: {
-              block: txEvent.Block,
-              txs: [txEvent.Tx],
-            },
-            cleanup: () => cleanupBlock(txEvent.Block.header!.hash),
-          });
-          this.newDataCondVar.wake();
-        }
-      } else if (txEvent.action === "undo") {
-        for (let lastBlock = this.buffer.peekBack(); lastBlock; lastBlock = this.buffer.peekBack()) {
-          if (lastBlock.output.block.header!.height > txEvent.Block.header!.height) {
-            // rolled back past this apparently-empty block
-            this.buffer.pop();
-            continue;
-          }
-          if (lastBlock.output.block.header!.height === txEvent.Block.header!.height) {
-            lastBlock.output.txs = lastBlock.output.txs.filter(tx => !hashEqual(tx.hash, txEvent.Tx.hash));
-            if (!lastBlock.output.txs.length) {
-              this.buffer.pop();
-            }
-          }
-          break;
-        }
+        const lastPoint = lastBlock ? JSON.stringify({
+          slot: Number(lastBlock.output.header!.slot),
+          hash: Buffer.from(lastBlock.output.header!.hash).toString("hex"),
+        }) : "<none>";
+        throw new Error(
+          `Paima node stuck on fork. Currently at point ${lastPoint}`,
+        );
       }
     }
   }
@@ -98,7 +68,7 @@ export class BufferedRpc {
     while (
       this.buffer.length == 0 ||
       lastElement == null ||
-      height >= Number(lastElement.output.block.header!.height) - this.finality
+      height >= Number(lastElement.output.header!.height) - this.finality
     ) {
       yield* this.newDataCondVar.wait();
       lastElement = this.buffer.peekBack();
@@ -107,11 +77,11 @@ export class BufferedRpc {
     const endIndex = (() => {
       let endIndex = this.buffer.length - 1;
       const highestValid =
-        Number(this.buffer.peekBack()!.output.block.header!.height) -
+        Number(this.buffer.peekBack()!.output.header!.height) -
         this.finality;
       while (
         endIndex > 0 &&
-        Number(this.buffer.peekAt(endIndex)!.output.block.header!.height) >
+        Number(this.buffer.peekAt(endIndex)!.output.header!.height) >
           highestValid
       ) {
         endIndex--;
@@ -124,7 +94,7 @@ export class BufferedRpc {
       while (
         startIndex > 0 &&
         Number(
-            this.buffer.peekAt(startIndex - 1)!.output.block.header!.height,
+            this.buffer.peekAt(startIndex - 1)!.output.header!.height,
           ) >
           height
       ) {
@@ -133,8 +103,8 @@ export class BufferedRpc {
       return startIndex;
     })();
     return {
-      from: toPage(this.buffer.peekAt(startIndex)!.output.block),
-      to: toPage(this.buffer.peekAt(endIndex)!.output.block),
+      from: toPage(this.buffer.peekAt(startIndex)!.output),
+      to: toPage(this.buffer.peekAt(endIndex)!.output),
     };
   }
 
@@ -146,14 +116,14 @@ export class BufferedRpc {
   public fetchBlocks(
     from: BlockNumber, // (inclusive)
     to: BlockNumber, // (inclusive)
-  ): OutputAndCleanup<BlockAndTxs>[] {
-    const blocks: OutputAndCleanup<BlockAndTxs>[] = [];
+  ): OutputAndCleanup<cardano.Block>[] {
+    const blocks: OutputAndCleanup<cardano.Block>[] = [];
     for (let i = 0; i < this.buffer.length; i++) {
       const block = this.buffer.peekAt(i)!;
-      if (Number(block.output.block.header!.height) >= from) {
+      if (Number(block.output.header!.height) >= from) {
         blocks.push(block);
       }
-      if (Number(block.output.block.header!.height) >= to) {
+      if (Number(block.output.header!.height) >= to) {
         break;
       }
     }

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/fetcher.ts
@@ -1,24 +1,27 @@
 import { BaseDataFetcher, type DataFetched } from "../base/fetcher.ts";
 import type { RootOutput, RootPage } from "../types.ts";
 import type { Operation } from "effection";
-import { bound } from "@effectstream/utils";
-import type { Input, Output, Page } from "./types.ts";
+import { bound, uint8ArrayToHexString } from "@effectstream/utils";
+import type { ChainPoint, ConfigType, Input, Output, Page, PrimitiveType } from "./types.ts";
 import type { OutputAndCleanup, RootConversion } from "../base/state.ts";
-import type { ConfigNetworkType, SyncProtocolWithNetwork } from "@effectstream/config";
 import type { BufferedRpc } from "./BufferedRpc.ts";
 import { Buffer } from "node:buffer";
+import type { cardano } from "@utxorpc/spec";
+import { hashEqual, matchesPredicate } from "./utils.ts";
 
 export class UtxoRpcFetcher
   extends BaseDataFetcher<Input, Output, RootOutput, Page, RootPage> // PrimitiveFetcher<Input, Page, cardano.Block, PrimitiveType>,
 {
   constructor(
-    readonly config: Extract<
-      SyncProtocolWithNetwork,
-      { networkType: ConfigNetworkType.CARDANO }
-    >,
+    readonly config: ConfigType,
     readonly client: BufferedRpc,
   ) {
     super(config.syncProtocol.name);
+  }
+
+  @bound
+  async startAsync(point: ChainPoint | undefined) {
+    await this.client.start(point, this.config.primitives);
   }
 
   @bound
@@ -39,14 +42,8 @@ export class UtxoRpcFetcher
         output: {
           // TODO: What is the correct block hash?
           blockHashes: [String(block.output.block.header?.hash)],
-          raw: block.output,
-          // TODO: https://github.com/utxorpc/spec/issues/135
-          //       mock data for now
-          primitives: [{
-            value: Math.round(Math.random() * 1000000),
-            block: block.output.block,
-            timestamp: block.output.timestamp,
-          } as any],
+          raw: block.output.block,
+          primitives: this.findPrimitives(block.output.block, new Uint8Array(), block.output.txs),
         },
         cleanup: block.cleanup,
       });
@@ -57,13 +54,13 @@ export class UtxoRpcFetcher
         ownBlockNumber: Number(data.to),
         own: {
           slot: Number(
-            outputs[outputs.length - 1].output.raw.block.header!.slot,
+            outputs[outputs.length - 1].output.raw.header!.slot,
           ),
           height: Number(
-            outputs[outputs.length - 1].output.raw.block.header!.height,
+            outputs[outputs.length - 1].output.raw.header!.height,
           ),
           hash: Buffer.from(
-            outputs[outputs.length - 1].output.raw.block.header!.hash,
+            outputs[outputs.length - 1].output.raw.header!.hash,
           )
             .toString("hex"),
         },
@@ -74,5 +71,36 @@ export class UtxoRpcFetcher
         }),
       },
     };
+  }
+
+  @bound
+  findPrimitives(block: cardano.Block, blockBytes: Uint8Array, txs: cardano.Tx[]): PrimitiveType[] {
+    const primitiveResponses: PrimitiveType[] = [];
+    for (const tx of txs) {
+      let logIndex = 0;
+      for (const primitveEntry of this.config.primitives) {
+        if (!matchesPredicate(tx, primitveEntry.primitive.predicate)) {
+          continue;
+        }
+        const transactionIndex = block.body?.tx.findIndex(t => hashEqual(t.hash, tx.hash));
+        primitiveResponses.push({
+          syncProtocol: {
+            name: primitveEntry.syncProtocol,
+            blockNumber: Number(block.header!.height),
+            transactionHash: uint8ArrayToHexString(tx.hash),
+            transactionIndex,
+            contractAddress: '',
+            logIndex,
+          },
+          primitive: primitveEntry.primitive.name,
+          output: {
+            payloadType: 'utxorpc-response',
+            payload: { tx }
+          }
+        });
+        ++logIndex;
+      }
+    }
+    return primitiveResponses;
   }
 }

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/fetcher.ts
@@ -21,7 +21,7 @@ export class UtxoRpcFetcher
 
   @bound
   async startAsync(point: ChainPoint | undefined) {
-    await this.client.start(point, this.config.primitives);
+    await this.client.start(point);
   }
 
   @bound
@@ -41,9 +41,9 @@ export class UtxoRpcFetcher
       outputs.push({
         output: {
           // TODO: What is the correct block hash?
-          blockHashes: [String(block.output.block.header?.hash)],
-          raw: block.output.block,
-          primitives: this.findPrimitives(block.output.block, new Uint8Array(), block.output.txs),
+          blockHashes: [String(block.output.header?.hash)],
+          raw: block.output,
+          primitives: this.findPrimitives(block.output),
         },
         cleanup: block.cleanup,
       });
@@ -74,9 +74,9 @@ export class UtxoRpcFetcher
   }
 
   @bound
-  findPrimitives(block: cardano.Block, blockBytes: Uint8Array, txs: cardano.Tx[]): PrimitiveType[] {
+  findPrimitives(block: cardano.Block): PrimitiveType[] {
     const primitiveResponses: PrimitiveType[] = [];
-    for (const tx of txs) {
+    for (const tx of block.body?.tx ?? []) {
       let logIndex = 0;
       for (const primitveEntry of this.config.primitives) {
         if (!matchesPredicate(tx, primitveEntry.primitive.predicate)) {

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/state.ts
@@ -7,10 +7,8 @@ import { bound, type TimestampMs } from "@effectstream/utils";
 import { type LastPage, SyncState } from "../base/state.ts";
 import type { RootOutput, RootPage } from "../types.ts";
 import type { UtxoRpcFetcher } from "./fetcher.ts";
-import type { Input, Output, Page } from "./types.ts";
+import type { ConfigType, Input, Output, Page } from "./types.ts";
 import { chainPointRelation } from "./types.ts";
-import type { ConfigNetworkType, SyncProtocolWithNetwork } from "@effectstream/config";
-import { ConfigSyncProtocolType } from "@effectstream/config";
 import { Buffer } from "node:buffer";
 
 export class UtxoRpcSyncState extends SyncState<
@@ -23,10 +21,7 @@ export class UtxoRpcSyncState extends SyncState<
 > {
   constructor(
     lastPage: undefined | LastPage<Page, RootPage>,
-    readonly config: Extract<
-      SyncProtocolWithNetwork,
-      { networkType: ConfigNetworkType.CARDANO }
-    >,
+    readonly config: ConfigType,
     fetcher: UtxoRpcFetcher,
     dbConn: PoolClient,
   ) {
@@ -45,10 +40,10 @@ export class UtxoRpcSyncState extends SyncState<
       // TODO: get startSlot if lastPage doesn't exist
       // problem: utxorpc "fetchBlock" requires a ChainPoint
       // see: https://github.com/utxorpc/spec/issues/148
-      yield* call(() => this.fetcher.client.start(undefined));
+      yield* call(() => this.fetcher.startAsync(undefined));
     }
     yield* call(() =>
-      this.fetcher.client.start({
+      this.fetcher.startAsync({
         slot: this.lastPage!.own.slot,
         hash: this.lastPage!.own.hash,
       })
@@ -63,7 +58,7 @@ export class UtxoRpcSyncState extends SyncState<
   @bound
   override toRootPage(data: Output): RootPage {
     return applyDelay(
-      data.raw.timestamp,
+      Number(data.raw.timestamp),
       this.config.syncProtocol.delayMs,
     );
   }
@@ -100,9 +95,9 @@ export class UtxoRpcSyncState extends SyncState<
     data: Output[],
   ): Page {
     return {
-      slot: Number(data[data.length - 1].raw.block.header!.slot),
-      height: Number(data[data.length - 1].raw.block.header!.height),
-      hash: Buffer.from(data[data.length - 1].raw.block.header!.hash).toString(
+      slot: Number(data[data.length - 1].raw.header!.slot),
+      height: Number(data[data.length - 1].raw.header!.height),
+      hash: Buffer.from(data[data.length - 1].raw.header!.hash).toString(
         "hex",
       ),
     };
@@ -119,7 +114,7 @@ export class UtxoRpcSyncState extends SyncState<
     }));
     const blockInfo = ourOutput.blockHashes.map((h) => ({
       protocol_name: this.config.syncProtocol.name,
-      block_number: Number(ourOutput.raw.block.header!.height),
+      block_number: Number(ourOutput.raw.header!.height),
       blockHash: h,
     }));
     rootOutput.primitives.push(...primitives);
@@ -133,10 +128,7 @@ export class UtxoRpcSyncState extends SyncState<
 
   static *restoreState(
     dbConn: PoolClient,
-    config: Extract<
-      SyncProtocolWithNetwork,
-      { networkType: ConfigNetworkType.CARDANO }
-    >,
+    config: ConfigType,
     fetcher: UtxoRpcFetcher,
   ): Operation<UtxoRpcSyncState> {
     // TODO: move this DB query into page-helpers?

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/types.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/types.ts
@@ -11,17 +11,19 @@ import type { PageSyncRange } from "../common/page-helpers.ts";
 import type {
   ConfigSyncProtocolType,
   FlattenSyncProtocolIOFor,
+  PrimitiveEntry,
+  SyncProtocolWithNetwork,
 } from "@effectstream/config";
 
-/**
- * Cardano blocks don't contain an explicit timestamp
- * So we have to manage the mapping
- *
- * Note: this is no longer required if this is merged: https://github.com/utxorpc/spec/issues/150
- */
-export type BlockAndTimestamp = {
+// TODO: https://github.com/utxorpc/node-sdk/pull/38
+export type ChainPoint = {
+  slot: number | string;
+  hash: string;
+};
+
+export type BlockAndTxs = {
   block: cardano.Block;
-  timestamp: TimestampMs;
+  txs: cardano.Tx[];
 };
 
 export type Page = {
@@ -30,13 +32,18 @@ export type Page = {
   hash: CardanoBlockHash;
 };
 
+export type PrimitiveEntryType = Extract<
+  PrimitiveEntry,
+  { syncProtocol: ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL }
+>;
+
 // TODO: blocked on https://github.com/utxorpc/spec/issues/135
 export type PrimitiveType = FlattenSyncProtocolIOFor<
   ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL
 >;
 export type Input = PageSyncRange<BlockNumber>;
 export type Output = {
-  raw: BlockAndTimestamp;
+  raw: cardano.Block;
   primitives: PrimitiveType[];
   blockHashes: CardanoBlockHash[];
 };
@@ -47,3 +54,8 @@ export const chainPointRelation: PageRelation<Page> = {
   min: (p1, p2) => (p1.slot < p2.slot ? p1 : p2),
   max: (p1, p2) => (p1.slot > p2.slot ? p1 : p2),
 };
+
+export type ConfigType = Extract<
+  SyncProtocolWithNetwork,
+  { syncProtocolType: ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL }
+>;

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/types.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/types.ts
@@ -21,11 +21,6 @@ export type ChainPoint = {
   hash: string;
 };
 
-export type BlockAndTxs = {
-  block: cardano.Block;
-  txs: cardano.Tx[];
-};
-
 export type Page = {
   slot: AbsoluteSlotNumber;
   height: CardanoBlockNumber;

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/utils.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/utils.ts
@@ -1,0 +1,80 @@
+import type { cardano } from '@utxorpc/spec';
+import type { UtxorpcAddressPattern, UtxorpcAssetPattern, UtxorpcTxOutputPattern, UtxorpcTxPattern, UtxorpcTxPredicate } from "@effectstream/config";
+import { hexStringToUint8Array } from "@effectstream/utils";
+import { Cardano } from '@cardano-sdk/core';
+import { HexBlob } from '@cardano-sdk/util';
+
+export function hashEqual(lhs: Uint8Array, rhs: Uint8Array): boolean {
+  if (lhs.length !== rhs.length) {
+    return false;
+  }
+  for (let i = 0; i < lhs.length; ++i) {
+    if (lhs[i] !== rhs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function matchesPredicate(tx: cardano.Tx, predicate: UtxorpcTxPredicate): boolean {
+  if (predicate.match && !matchesPattern(tx, predicate.match)) {
+    return false;
+  }
+  if (predicate.not && predicate.not.some(p => matchesPredicate(tx, p))) {
+    return false;
+  }
+  if (predicate.allOf && !predicate.allOf.every(p => matchesPredicate(tx, p))) {
+    return false;
+  }
+  if (predicate.anyOf && !predicate.anyOf.some(p => matchesPredicate(tx, p))) {
+    return false;
+  }
+  return true;
+}
+
+function matchesPattern(tx: cardano.Tx, pattern: UtxorpcTxPattern): boolean {
+  const outputs = tx.outputs;
+  const inputs = tx.inputs.map(input => input.asOutput!).filter(x => x);
+  const matchConsumes = !pattern.consumes || matchesOutputPattern(outputs, pattern.consumes);
+  const matchProduces = !pattern.produces || matchesOutputPattern(inputs, pattern.produces);
+  const matchHasAddress = !pattern.hasAddress || matchesAddress(outputs, pattern.hasAddress) || matchesAddress(inputs, pattern.hasAddress);
+  const matchMovesAsset = !pattern.movesAsset || matchesAsset(inputs, pattern.movesAsset);
+  const matchMintsAsset = !pattern.mintsAsset || matchesAsset(outputs, pattern.mintsAsset);
+  return matchConsumes && matchProduces && matchHasAddress && matchMovesAsset && matchMintsAsset;
+}
+
+function matchesOutputPattern(outputs: cardano.TxOutput[], pattern: UtxorpcTxOutputPattern): boolean {
+  const matchAddress = !pattern.address || matchesAddress(outputs, pattern.address);
+  const matchAsset = !pattern.asset || matchesAsset(outputs, pattern.asset);
+  return matchAddress && matchAsset;
+}
+
+function matchesAddress(outputs: cardano.TxOutput[], pattern: UtxorpcAddressPattern): boolean {
+  if (pattern.exactAddress) {
+    const address = hexStringToUint8Array(pattern.exactAddress);
+    if (!outputs.some(o => hashEqual(o.address, address))) {
+      return false;
+    }
+  }
+  if (pattern.paymentPart || pattern.delegationPart) {
+    const addresses = outputs.map(o => Cardano.Address.fromBytes(HexBlob.fromBytes(o.address)));
+    if (pattern.paymentPart && !addresses.some(a => a.getProps()?.paymentPart?.hash === pattern.paymentPart)) {
+      return false;
+    }
+    if (pattern.delegationPart && !addresses.some(a => a.getProps()?.delegationPart?.hash === pattern.delegationPart)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function matchesAsset(outputs: cardano.TxOutput[], pattern: UtxorpcAssetPattern): boolean {
+  const policyId = pattern.policyId ? hexStringToUint8Array(pattern.policyId) : null;
+  const assetName = pattern.assetName ? hexStringToUint8Array(pattern.assetName) : null;
+  return outputs.some(o => o.assets.some(ma => {
+    if (policyId && !hashEqual(policyId, ma.policyId)) {
+      return false;
+    }
+    return ma.assets.some(a => !assetName || hashEqual(a.name, assetName));
+  }));
+}

--- a/packages/node-sdk/sync/src/syncProtocolFactory.ts
+++ b/packages/node-sdk/sync/src/syncProtocolFactory.ts
@@ -10,7 +10,7 @@ import {
   ConfigSyncProtocolType,
   getViemNetwork,
 } from "@effectstream/config";
-import { CardanoSyncClient } from "@utxorpc/sdk";
+import { CardanoSyncClient, CardanoWatchClient } from "@utxorpc/sdk";
 import { BufferedRpc } from "./sync-protocols/utxorpc/BufferedRpc.ts";
 import { UtxoRpcFetcher } from "./sync-protocols/utxorpc/fetcher.ts";
 import { UtxoRpcSyncState } from "./sync-protocols/utxorpc/state.ts";
@@ -59,15 +59,19 @@ export function* genSyncProtocols(
       entry.networkType === ConfigNetworkType.CARDANO
     ) {
       if (
-        entry.syncProtocol.type === ConfigSyncProtocolType.CARDANO_CARP_PARALLEL
+        entry.syncProtocolType === ConfigSyncProtocolType.CARDANO_CARP_PARALLEL
       ) {
         throw new Error("CARP not supported yet");
       }
-      const client = new CardanoSyncClient({
+      const syncClient = new CardanoSyncClient({
+        uri: entry.syncProtocol.rpcUrl,
+      });
+      const watchClient = new CardanoWatchClient({
         uri: entry.syncProtocol.rpcUrl,
       });
       const bufferedRpc = new BufferedRpc(
-        client,
+        syncClient,
+        watchClient,
         entry.syncProtocol.confirmationDepth,
       );
       const fetcher = new UtxoRpcFetcher(

--- a/packages/node-sdk/sync/src/syncProtocolFactory.ts
+++ b/packages/node-sdk/sync/src/syncProtocolFactory.ts
@@ -65,6 +65,7 @@ export function* genSyncProtocols(
       }
       const syncClient = new CardanoSyncClient({
         uri: entry.syncProtocol.rpcUrl,
+        headers: entry.syncProtocol.headers,
       });
       const bufferedRpc = new BufferedRpc(
         syncClient,

--- a/packages/node-sdk/sync/src/syncProtocolFactory.ts
+++ b/packages/node-sdk/sync/src/syncProtocolFactory.ts
@@ -10,7 +10,7 @@ import {
   ConfigSyncProtocolType,
   getViemNetwork,
 } from "@effectstream/config";
-import { CardanoSyncClient, CardanoWatchClient } from "@utxorpc/sdk";
+import { CardanoSyncClient } from "@utxorpc/sdk";
 import { BufferedRpc } from "./sync-protocols/utxorpc/BufferedRpc.ts";
 import { UtxoRpcFetcher } from "./sync-protocols/utxorpc/fetcher.ts";
 import { UtxoRpcSyncState } from "./sync-protocols/utxorpc/state.ts";
@@ -66,12 +66,8 @@ export function* genSyncProtocols(
       const syncClient = new CardanoSyncClient({
         uri: entry.syncProtocol.rpcUrl,
       });
-      const watchClient = new CardanoWatchClient({
-        uri: entry.syncProtocol.rpcUrl,
-      });
       const bufferedRpc = new BufferedRpc(
         syncClient,
-        watchClient,
         entry.syncProtocol.confirmationDepth,
       );
       const fetcher = new UtxoRpcFetcher(


### PR DESCRIPTION
Add a utxorpc primitive. It is configured with patterns used by the utxorpc "watch" endpoints, and will return any TXs which match those patterns. Its payloads are (the bytes of) transactions returned by utxorpc.

Note: in this PR, we still use the utxorpc "sync" endpoints rather than "watch" endpoints. This is for simplicity and performance:
 - Primitives apparently need the contents of every block on the chain (whether the block has events or not), but the watch endpoint only returns references to blocks without any matching TXs. By using the watch endpoint, we'd need to make extra RPC requests to fetch missing blocks.
 - If there's more than one primitive, we need to request TXs which match any of our own primitives and then filter on a per-primitive level client-side. This means we already need to implement utxorpc filter logic in the client, even if we use the watch endpoint.
 - The watch endpoint returns one event per matching transaction, and that event includes the entire block which contained that transaction. If two transactions in the same block both match our conditions, we'll receive that entire block twice. It's more performant to just receive the entire block once, and pull matching transactions out of it.