### PR TITLE
Midnight type fixes

### DIFF
--- a/packages/effectstream-sdk/config/src/schema/primitive/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/primitive/types.ts
@@ -2,10 +2,10 @@ import type {
   ConfigSyncProtocolType,
   ProtocolPrimitiveMap,
 } from "../sync-protocols/types.ts";
-import type { EncodedStateValue } from "@midnight-ntwrk/onchain-runtime";
+import type { StateValue } from "@midnight-ntwrk/onchain-runtime";
 import type { cardano } from '@utxorpc/spec';
 
-export type { EncodedStateValue };
+export type { StateValue };
 
 export type FlattenSyncProtocolIOFor<
   SyncProtocol extends keyof ProtocolPrimitiveMap,

--- a/packages/effectstream-sdk/config/src/schema/primitive/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/primitive/types.ts
@@ -27,7 +27,7 @@ export type FlattenSyncProtocolIOFor<
 
 type EVMPrimitivePayload = Record<string, any>;
 
-type MidnightTPrimitivePayload = EncodedStateValue;
+type MidnightTPrimitivePayload = Record<string, any>;
 
 type NtpPrimitivePayload = never;
 

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
@@ -3,7 +3,8 @@ import { ConfigNetworkType } from "../network/mod.ts";
 import type { ConfigSyncProtocolDecoratorType } from "./decorators/types.ts";
 import type { NetworkConfig } from "../../config/parts/network.ts";
 import type { ConfigSyncProtocolMapping } from "./all.ts";
-import type { EncodedStateValue, UtxorpcTxPredicate, getEvmEvent } from "@effectstream/config";
+import type { UtxorpcTxPredicate, getEvmEvent } from "@effectstream/config";
+import type { StateValue } from "@midnight-ntwrk/onchain-runtime"
 
 export enum ConfigSyncProtocolType {
   NTP_MAIN = "ntp-main",
@@ -51,7 +52,7 @@ type MidnightPrimitive = BasePrimitive & {
   name: string;
   contractAddress: string;
   contract: {
-    ledger: (data: EncodedStateValue) => any;
+    ledger: (data: StateValue) => Record<string, any>;
   };
   networkId?: string;
   genesisHash?: string;

--- a/packages/node-sdk/sm/primitives/src/midnight-generic/midnight-genetic.ts
+++ b/packages/node-sdk/sm/primitives/src/midnight-generic/midnight-genetic.ts
@@ -14,11 +14,10 @@ import {
 } from "@effectstream/concise";
 import type {
   ConfigSyncProtocolType,
-  EncodedStateValue,
   FlattenSyncProtocolIOFor,
   ProtocolPrimitiveMap,
+  StateValue,
 } from "@effectstream/config";
-import { StateValue } from '@midnight-ntwrk/onchain-runtime';
 import type { SyncStateUpdateStream } from "@effectstream/coroutine";
 import { PrimitiveTypeMidnightGeneric } from "../builtin.ts";
 import { midnightGenericGrammar } from "./midnight-genetic-grammar.ts"

--- a/packages/node-sdk/sm/primitives/src/midnight-generic/midnight-genetic.ts
+++ b/packages/node-sdk/sm/primitives/src/midnight-generic/midnight-genetic.ts
@@ -4,6 +4,7 @@ import {
   AddressType,
   type MidnightAddress,
   type PaimaBlockNumber,
+  uint8ArrayToHexString,
 } from "@effectstream/utils";
 import type { StaticDecode } from "@sinclair/typebox";
 import {
@@ -17,6 +18,7 @@ import type {
   FlattenSyncProtocolIOFor,
   ProtocolPrimitiveMap,
 } from "@effectstream/config";
+import { StateValue } from '@midnight-ntwrk/onchain-runtime';
 import type { SyncStateUpdateStream } from "@effectstream/coroutine";
 import { PrimitiveTypeMidnightGeneric } from "../builtin.ts";
 import { midnightGenericGrammar } from "./midnight-genetic-grammar.ts"
@@ -31,7 +33,7 @@ export class MidnightGenericPrimitive extends PaimaPrimitive<
   override readonly grammar = midnightGenericGrammar;
   readonly contractAddress: string;
   readonly contract: {
-    ledger: (data: EncodedStateValue) => any;
+    ledger: (data: StateValue) => any;
   };
   readonly networkId: string;
   readonly genesisHash: string;
@@ -50,7 +52,7 @@ export class MidnightGenericPrimitive extends PaimaPrimitive<
     contractAddress: MidnightAddress;
     stateMachinePrefix: string;
     contract: {
-      ledger: (data: EncodedStateValue) => any;
+      ledger: (data: StateValue) => any;
     }
     networkId?: string;
     genesisHash?: string;
@@ -82,8 +84,8 @@ export class MidnightGenericPrimitive extends PaimaPrimitive<
       const isBatched = false;
      
       const accountingPayload: ParamToData<typeof this.grammar> = {
-        payload,
-      } as unknown as ParamToData<typeof this.grammar>;
+        payload: makeJsonSafe(payload),
+      };
      
       const stateMachinePayload:
         | StaticDecode<
@@ -137,6 +139,28 @@ export class MidnightGenericPrimitive extends PaimaPrimitive<
       genesisHash: this.genesisHash || "", 
     } as const;
   }
+}
+
+function makeJsonSafe(data: unknown): any {
+  if (typeof data === 'boolean' || typeof data === 'number' || typeof data === 'string') {
+    return data;
+  }
+  if (typeof data === 'bigint') {
+    return data.toString();
+  }
+  if (data === null || data === undefined) {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return data.map(makeJsonSafe);
+  }
+  if (data instanceof Uint8Array) {
+    return uint8ArrayToHexString(data);
+  }
+  if (typeof data === 'object') {
+    return Object.fromEntries(Object.entries(data).map(([k, v]) => [k, makeJsonSafe(v)]));
+  }
+  return data;
 }
 
 // declare module "@effectstream/sm" {

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
@@ -17,7 +17,6 @@ import type {
 import type { RootOutput, RootPage } from "../types.ts";
 import { bound } from "@effectstream/utils";
 import { MidnightClient, type MidnightGqlBlockState } from "./MidnightClient.ts";
-import type { EncodedStateValue } from "@effectstream/config";
 import { ContractState } from "@midnight-ntwrk/onchain-runtime";
 
 export class MidnightFetcher extends BaseDataFetcher<

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
@@ -154,11 +154,7 @@ export class MidnightFetcher extends BaseDataFetcher<
       const byteState = new Uint8Array(rawState.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)));
       const contractState = ContractState.deserialize(byteState);
       const contract = primitiveEntry.primitive.contract;
-      const state = contract.ledger(contractState.data as any);
-      const pojoState = JSON.parse(JSON.stringify(
-        state,
-        (_key, value) => typeof value === "bigint" ? value.toString() : value
-      ));
+      const state = contract.ledger(contractState.data.state);
       return {
         syncProtocol: {
           name: primitiveEntry.syncProtocol,
@@ -169,7 +165,7 @@ export class MidnightFetcher extends BaseDataFetcher<
         primitive: primitiveEntry.primitive.name,
         output: {
           payloadType: "midnight-contract-state",
-          payload: pojoState as unknown as EncodedStateValue,
+          payload: state,
         },
       }
     });


### PR DESCRIPTION
Fix some issues with the midnight fetcher and primitives:
 - The `ledger` function for midnight primitives takes a `StateValue`, not an `EncodedStateValue`
 - The `MidnightFetcher` returns payloads with arbitrary user-facing data, not an `EncodedStateValue`
 - The `MidnightPrimitive` makes sure its data is JSON-safe (often contains `Uint8Array` or `bigint` fields which don't serialize well)