### PR TITLE
Support File Persistence with PGLite

### DIFF
--- a/packages/effectstream-sdk/utils/src/config.ts
+++ b/packages/effectstream-sdk/utils/src/config.ts
@@ -202,6 +202,13 @@ const definitions: Record<string, ConfigDefinition> = {
     description:
       "Enable single connection mode and other specific PGLite features. IMPORTANT enable only for development. ('true' or 'false')",
   },
+  PGLITE_DATA_DIR: {
+    key: "PGLITE_DATA_DIR",
+    type: "string",
+    defaultValue: "memory://",
+    description:
+      "PGLite data directory. Use 'memory://' for in-memory (default) or a file path for persistent storage. Example: './pglite-data'",
+  },
   DEBUG_PGLITE: {
     key: "DEBUG_PGLITE",
     type: "number",
@@ -306,6 +313,9 @@ export class ENV {
   }
   static get PGLITE(): boolean {
     return ENV.getConfig(definitions.PGLITE);
+  }
+  static get PGLITE_DATA_DIR(): string {
+    return ENV.getConfig(definitions.PGLITE_DATA_DIR);
   }
   static get DEBUG_PGLITE(): number {
     return ENV.getConfig(definitions.DEBUG_PGLITE);

--- a/packages/node-sdk/db/scripts/start-pglite.ts
+++ b/packages/node-sdk/db/scripts/start-pglite.ts
@@ -34,7 +34,7 @@ while (true) {
 }
 
 const db = new PGlite(
-  "memory://", // TODO: use different values for in-browser & production builds
+  ENV.PGLITE_DATA_DIR,
   {
     username: ENV.DB_USER,
     database: ENV.DB_NAME,


### PR DESCRIPTION
This change will allow users to use an on-disk file to persist PGLite state, configured via an environment variable. The default value is `memory://`, which means this change is backwards compatible.