### PR TITLE
Add DISABLE_CARDANO environment variable for E2E tests

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -88,6 +88,7 @@ RUN deno task -r contract:compile
 # START E2E TESTS
 # Launching processes en parallel generates issues on linux
 ENV EFFECTSTREAM_ORCHESTRATOR_SERIAL=true
+ENV DISABLE_CARDANO=true
 # Show Effectstream logs
 ENV EFFECTSTREAM_STDOUT=true
 CMD ["deno", "task", "-f", "@e2e/node", "e2e"]


### PR DESCRIPTION
Launching YACI causes OS Error (26) on linux when starting processes. This is to enable CICD testing 