### PR TITLE
Fix tsLog severity && read severity from an env var

### DIFF
--- a/packages/effectstream-sdk/log/src/const.ts
+++ b/packages/effectstream-sdk/log/src/const.ts
@@ -1,4 +1,5 @@
 import { SeverityNumber } from "@opentelemetry/api-logs";
+import { getEnv } from "@effectstream/utils/runtime";
 
 /**
  * Main components
@@ -75,8 +76,15 @@ export const ComponentNames = {
   ...SecondaryComponents,
 };
 
-// TODO: this try some ENV var before defaulting to INFO
-export const defaultSeverity = SeverityNumber.INFO;
+const parseSeverity = (): SeverityNumber => {
+  const level = getEnv("EFFECTSTREAM_LOG_LEVEL")?.toUpperCase();
+  if (level && level in SeverityNumber) {
+    return SeverityNumber[level as keyof typeof SeverityNumber];
+  }
+  return SeverityNumber.INFO;
+};
+
+export const defaultSeverity = parseSeverity();
 
 /**
  * extra step in the logger to avoid performance degradation.

--- a/packages/effectstream-sdk/log/src/tslog.ts
+++ b/packages/effectstream-sdk/log/src/tslog.ts
@@ -166,6 +166,7 @@ export const tsLogOrchestrator: TslogLogFunc = (
   level,
   doLog,
 ): void => {
+  if (level < defaultSeverity) return;
   doLog((...data: unknown[]) =>
       console.log(JSON.stringify({
         "__ORCHESTRATOR__": true,


### PR DESCRIPTION
This PR fixes one issue and addresses a TODO, adding a new env var. Theoretically, these should be two different PRs, but I figured the improvement + bug fix here were small enough to suggest them together.

Fix:
`tsLog` didn't respect the `defaultSeverity`, meaning all the orchestrator logs were spamming the stdout, making it impossible to see what is happening

Feature:
there was TODO to read the `defaultSeverity` from an env var. I've added that via the `EFFECSTREAM_LOG_LEVEL` env varibale, so the user can configure this.