### PR TITLE
Fix config snapshot

### DIFF
--- a/packages/node-sdk/runtime/src/config-snapshot.ts
+++ b/packages/node-sdk/runtime/src/config-snapshot.ts
@@ -110,11 +110,16 @@ export function* validateAndSnapshotConfig(
     const saved = rows[0].immutable_config as Record<string, unknown>;
     const mismatches: string[] = [];
     console.log("saved", saved);
-    for (const [key, savedValue] of Object.entries(saved)) {
-      console.log("key", key, savedValue, currentImmutable[key]);
-      if (currentImmutable[key] !== savedValue) {
-        mismatches.push(`  ${key}: saved=${JSON.stringify(savedValue)}, current=${JSON.stringify(currentImmutable[key])}`);
+    if (typeof savedValue === "object" && savedValue !== null) {
+      for (const [k, v] of Object.entries(savedValue)) {
+        if (currentImmutable[key][k] !== v) {
+          mismatches.push(`  ${key}.${k}: saved=${JSON.stringify(v)},
+    current=${JSON.stringify(currentImmutable[key][k])}`);
+        }
       }
+    } else if (currentImmutable[key] !== savedValue) {
+      mismatches.push(`  ${key}: saved=${JSON.stringify(savedValue)},
+    current=${JSON.stringify(currentImmutable[key])}`);
     }
 
     if (mismatches.length === 0) {


### PR DESCRIPTION
Currently, the config snapshot checks use strict equality, which always fail when comparing objects, since it compares by reference.

I also noticed that the key ordering is different for the `startChainPoint` in the saved config and the current config, which could also cause surprises with equality, even if the above issue was fixed. So this checks the value of each key in the object for equality.