### PR TITLE
fix: SyncChains events for skipped blocks & 0x0 empty block hashes

### DIFF
--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -612,7 +612,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
               },
               (event) => {
                 latestBlock = Math.max(event.block, latestBlock);
-                if (latestBlock > Number(receipt.blockNumber)) {
+                if (latestBlock >= Number(receipt.blockNumber)) {
                   resolve({ latestBlock, rollup: event.rollup });
                 }
               },

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
@@ -43,6 +43,8 @@ type BasePrimitive = {
   type: `${string}:${string}`;
   startBlockHeight: number;
   scheduledPrefix?: string;
+  /** When true, fetcher returns block info for ALL blocks in range, not just those with primitives. Default: false */
+  getAllBlockHeaders?: boolean;
 };
 
 type EVMPrimitive = BasePrimitive & {

--- a/packages/node-sdk/db/src/mod.ts
+++ b/packages/node-sdk/db/src/mod.ts
@@ -16,21 +16,27 @@ export type {
 // https://github.com/adelsz/pgtyped/issues/565
 export {
   blockHeightDone,
+  deleteEmptyBlocks,
   getBlockByHash,
   getBlockHeights,
   getBlockSeeds,
+  getLastNonEmptyBlockHash,
   getLatestProcessedBlockHeight,
   saveLastBlock,
 } from "./sql/block-heights.queries.ts";
 export type {
   IBlockHeightDoneParams,
   IBlockHeightDoneResult,
+  IDeleteEmptyBlocksParams,
+  IDeleteEmptyBlocksResult,
   IGetBlockByHashParams,
   IGetBlockByHashResult,
   IGetBlockHeightsParams,
   IGetBlockHeightsResult,
   IGetBlockSeedsParams,
   IGetBlockSeedsResult,
+  IGetLastNonEmptyBlockHashParams,
+  IGetLastNonEmptyBlockHashResult,
   IGetLatestProcessedBlockHeightParams,
   IGetLatestProcessedBlockHeightResult,
   ISaveLastBlockParams,

--- a/packages/node-sdk/db/src/sql/block-heights.queries.ts
+++ b/packages/node-sdk/db/src/sql/block-heights.queries.ts
@@ -174,6 +174,34 @@ const saveLastBlockIR: any = {"usedParamSet":{"block_height":true,"ver":true,"ma
 export const saveLastBlock = new PreparedQuery<ISaveLastBlockParams,ISaveLastBlockResult>(saveLastBlockIR);
 
 
+/** 'GetLastNonEmptyBlockHash' parameters type */
+export type IGetLastNonEmptyBlockHashParams = void;
+
+/** 'GetLastNonEmptyBlockHash' return type */
+export interface IGetLastNonEmptyBlockHashResult {
+  effectstream_block_hash: Buffer | null;
+}
+
+/** 'GetLastNonEmptyBlockHash' query type */
+export interface IGetLastNonEmptyBlockHashQuery {
+  params: IGetLastNonEmptyBlockHashParams;
+  result: IGetLastNonEmptyBlockHashResult;
+}
+
+const getLastNonEmptyBlockHashIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT effectstream_block_hash FROM effectstream.effectstream_blocks\nWHERE effectstream_block_hash IS NOT NULL\n  AND effectstream_block_hash != '\\x307830'::bytea\nORDER BY block_height DESC\nLIMIT 1"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT effectstream_block_hash FROM effectstream.effectstream_blocks
+ * WHERE effectstream_block_hash IS NOT NULL
+ *   AND effectstream_block_hash != '\x307830'::bytea
+ * ORDER BY block_height DESC
+ * LIMIT 1
+ * ```
+ */
+export const getLastNonEmptyBlockHash = new PreparedQuery<IGetLastNonEmptyBlockHashParams,IGetLastNonEmptyBlockHashResult>(getLastNonEmptyBlockHashIR);
+
 /** 'BlockHeightDone' parameters type */
 export interface IBlockHeightDoneParams {
   block_hash: Buffer;
@@ -188,6 +216,29 @@ export interface IBlockHeightDoneQuery {
   params: IBlockHeightDoneParams;
   result: IBlockHeightDoneResult;
 }
+
+/** 'DeleteEmptyBlocks' parameters type */
+export type IDeleteEmptyBlocksParams = void;
+
+/** 'DeleteEmptyBlocks' return type */
+export type IDeleteEmptyBlocksResult = void;
+
+/** 'DeleteEmptyBlocks' query type */
+export interface IDeleteEmptyBlocksQuery {
+  params: IDeleteEmptyBlocksParams;
+  result: IDeleteEmptyBlocksResult;
+}
+
+const deleteEmptyBlocksIR: any = {"usedParamSet":{},"params":[],"statement":"DELETE FROM effectstream.effectstream_blocks\nWHERE effectstream_block_hash = '\\x307830'::bytea"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM effectstream.effectstream_blocks
+ * WHERE effectstream_block_hash = '\x307830'::bytea
+ * ```
+ */
+export const deleteEmptyBlocks = new PreparedQuery<IDeleteEmptyBlocksParams,IDeleteEmptyBlocksResult>(deleteEmptyBlocksIR);
 
 const blockHeightDoneIR: any = {"usedParamSet":{"block_hash":true,"block_height":true},"params":[{"name":"block_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":70,"b":81}]},{"name":"block_height","required":true,"transform":{"type":"scalar"},"locs":[{"a":104,"b":117}]}],"statement":"UPDATE effectstream.effectstream_blocks\nSET\neffectstream_block_hash = :block_hash!\nWHERE block_height = :block_height!"};
 

--- a/packages/node-sdk/db/src/sql/block-heights.sql
+++ b/packages/node-sdk/db/src/sql/block-heights.sql
@@ -38,6 +38,17 @@ seed = EXCLUDED.seed,
 ms_timestamp = EXCLUDED.ms_timestamp,
 effectstream_block_hash = EXCLUDED.effectstream_block_hash;
 
+/* @name getLastNonEmptyBlockHash */
+SELECT effectstream_block_hash FROM effectstream.effectstream_blocks
+WHERE effectstream_block_hash IS NOT NULL
+  AND effectstream_block_hash != '\x307830'::bytea
+ORDER BY block_height DESC
+LIMIT 1;
+
+/* @name deleteEmptyBlocks */
+DELETE FROM effectstream.effectstream_blocks
+WHERE effectstream_block_hash = '\x307830'::bytea;
+
 /* @name blockHeightDone */
 UPDATE effectstream.effectstream_blocks
 SET

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -7,6 +7,7 @@ import {
   acquireDBMutex,
   createDynamicTables,
   getConnection,
+  getLastNonEmptyBlockHash,
   releaseDBMutex,
   resetPublicTables,
   runSnapshotLoop,
@@ -134,7 +135,10 @@ export function* start(config: StartConfig): Operation<void> {
     }
   });
 
-  let blockHash: PaimaBlockHash | null = null;
+  const [lastHashRow] = yield* until(getLastNonEmptyBlockHash.run(undefined, dbConn));
+  let blockHash: PaimaBlockHash | null = lastHashRow
+    ? lastHashRow.effectstream_block_hash!.toString() as PaimaBlockHash
+    : null;
   if (config.snapshotConfig) {
     yield* spawn(() => runSnapshotLoop(config.snapshotConfig!));
   }
@@ -148,12 +152,15 @@ export function* start(config: StartConfig): Operation<void> {
       yield* acquireDBMutex(`processing-blocks:${value.blockNumber}`);
       dbClient = yield* until((dbConn as any).connect()); // Client,
 
-      blockHash = yield* processFinalizedBlock(
+      const resultHash = yield* processFinalizedBlock(
         value,
         config,
         dbClient as any, // Client,
         blockHash,
       );
+      if (resultHash !== "0x0") {
+        blockHash = resultHash;
+      }
     } finally {
       releaseDBMutex(`processing-blocks:${value.blockNumber}`);
       if (dbClient) {

--- a/packages/node-sdk/runtime/src/process-blocks.ts
+++ b/packages/node-sdk/runtime/src/process-blocks.ts
@@ -10,6 +10,7 @@ import type {
 } from "@effectstream/coroutine";
 import {
   blockHeightDone,
+  deleteEmptyBlocks,
   deleteScheduled,
   getFutureGameInputByBlockHeight,
   getFutureGameInputByMaxTimestamp,
@@ -133,6 +134,7 @@ export function* processFinalizedBlock(
     value,
     previousBlockHash,
   );
+  let hasOperations = false;
   try {
     /* STEP 0: Start the transaction. */
     yield* until(dbConn.query("BEGIN"));
@@ -151,8 +153,9 @@ export function* processFinalizedBlock(
     );
 
     /* STEP 2: Process the migrations. */
+    let hasMigrations = false;
     if (migrations) {
-      yield* applyUserMigrations(
+      hasMigrations = yield* applyUserMigrations(
         value.blockNumber,
         dbConn as any, // Client,
         migrations,
@@ -251,9 +254,15 @@ export function* processFinalizedBlock(
     }
 
     /* STEP 6: Mark the block as done. */
+    hasOperations = hasMigrations ||
+      value.primitives.length > 0 ||
+      scheduledData.length > 0;
+    if (!hasOperations) {
+      yield* call(() => deleteEmptyBlocks.run(undefined, dbConn));
+    }
     yield* call(() =>
       blockHeightDone.run({
-        block_hash: Buffer.from(blockHash),
+        block_hash: Buffer.from(hasOperations ? blockHash : "0x0"),
         block_height: value.blockNumber,
       }, dbConn)
     );
@@ -298,5 +307,5 @@ export function* processFinalizedBlock(
     // We cannot recover from this error.
     throw err;
   }
-  return blockHash;
+  return hasOperations ? blockHash : "0x0" as PaimaBlockHash;
 }

--- a/packages/node-sdk/runtime/src/version-migrations.ts
+++ b/packages/node-sdk/runtime/src/version-migrations.ts
@@ -95,7 +95,7 @@ export function* applyUserMigrations(
   currentBlockHeight: number,
   dbConn: Client,
   migrationOrder: DBMigrations[] | undefined,
-): Operation<void> {
+): Operation<boolean> {
   const migrations = yield* getAllUserMigrations(
     EFFECTSTREAM_ENGINE_VERSION,
     migrationOrder,
@@ -114,6 +114,7 @@ export function* applyUserMigrations(
       ),
     );
   }
+  return migrations.length > 0;
 }
 
 function* getAllUserMigrations(

--- a/packages/node-sdk/sync/src/sync-protocols/avail/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/fetcher.ts
@@ -48,11 +48,16 @@ export class AvailFetcher extends BaseDataFetcher<
     lastPage: LastPage<Page, RootPage> | undefined,
   ): Operation<DataFetched<Output, Page, RootPage>> {
     const outputs: OutputAndCleanup<Output>[] = [];
+    const fetchAllBlocks = this.config.primitives.some(
+      (p) => p.primitive.getAllBlockHeaders,
+    );
     console.log(
       `[Avail] Fetching blocks from ${data.from} to ${data.to}. ${
         data.isPresync ? "[presync]" : ""
       }`,
     );
+
+    let lastHeader: Output["raw"] | undefined;
     for (let height = data.from; height <= data.to; height++) {
       let header;
       try {
@@ -60,26 +65,28 @@ export class AvailFetcher extends BaseDataFetcher<
           this.client.getBlockHeaderFromHeight(height)
         );
       } catch (_e) {
-        // Likely reached the tip; stop here
         break;
       }
 
+      lastHeader = header;
       const primitives = yield* this.readPrimitives(
         height,
         header,
         this.config.primitives,
       );
 
-      outputs.push({
-        output: {
-          raw: header,
-          primitives,
-        },
-        cleanup: () => {},
-      });
+      if (fetchAllBlocks || primitives.length > 0 || height === data.to) {
+        outputs.push({
+          output: {
+            raw: header,
+            primitives,
+          },
+          cleanup: () => {},
+        });
+      }
     }
 
-    if (outputs.length === 0) {
+    if (!lastHeader) {
       if (!lastPage) {
         throw new Error(
           `Could not fetch any blocks from ${data.from} to ${data.to} and no previous page was found.`,
@@ -91,16 +98,18 @@ export class AvailFetcher extends BaseDataFetcher<
       };
     }
 
-    const lastOutput = outputs[outputs.length - 1].output;
     return {
       output: outputs,
       lastPage: {
-        ownBlockNumber: lastOutput.raw.number,
+        ownBlockNumber: lastHeader.number,
         own: {
-          height: lastOutput.raw.number,
-          hash: lastOutput.raw.hash,
+          height: lastHeader.number,
+          hash: lastHeader.hash,
         },
-        root: rootConversion.toRootPage(lastOutput),
+        root: rootConversion.toRootPage({
+          raw: lastHeader,
+          primitives: [],
+        }),
       },
     };
   }

--- a/packages/node-sdk/sync/src/sync-protocols/bitcoin/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/bitcoin/fetcher.ts
@@ -111,24 +111,31 @@ export class BitcoinFetcher
     );
     const groupedByPage = this.groupByPage(primitives);
 
+    const fetchAllBlocks = this.config.primitives.some(
+      (p) => p.primitive.getAllBlockHeaders,
+    );
+
     const outputs: OutputAndCleanup<Output>[] = [];
+    let lastBlock: BitcoinBlock | undefined;
     for (let height = Number(data.from); height <= Number(data.to); height++) {
       const blockHeight = height as Page;
       const block = yield* call(() => pageFetcher(blockHeight));
-      outputs.push({
-        output: {
-          raw: block,
-          primitives: groupedByPage[String(height)] ?? [],
-          blockHashes: [block.hash],
-        },
-        cleanup: () => {},
-      });
+      lastBlock = block;
+      const blockPrimitives = groupedByPage[String(height)] ?? [];
+      if (fetchAllBlocks || blockPrimitives.length > 0 || height === Number(data.to)) {
+        outputs.push({
+          output: {
+            raw: block,
+            primitives: blockPrimitives,
+            blockHashes: [block.hash],
+          },
+          cleanup: () => {},
+        });
+      }
     }
-    const lastOutput = outputs[outputs.length - 1];
-    if (!lastOutput) {
+    if (!lastBlock) {
       throw new Error("BitcoinFetcher: no block data fetched for interval");
     }
-    const lastBlock = lastOutput.output.raw;
     const lastPageRef = this.asPage(Number(data.to));
     return {
       output: outputs,

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/fetcher.ts
@@ -47,6 +47,9 @@ export class CelestiaFetcher extends BaseDataFetcher<
     lastPage: LastPage<Page, RootPage> | undefined,
   ): Operation<DataFetched<Output, Page, RootPage>> {
     const outputs: OutputAndCleanup<Output>[] = [];
+    const fetchAllBlocks = this.config.primitives.some(
+      (p) => p.primitive.getAllBlockHeaders,
+    );
 
     console.log(
       `[Celestia] Fetching blocks from ${data.from} to ${data.to}.${
@@ -54,6 +57,7 @@ export class CelestiaFetcher extends BaseDataFetcher<
       }`,
     );
 
+    let lastFetchedOutput: Output | undefined;
     for (let height = data.from; height <= data.to; height++) {
       let extHeader;
       try {
@@ -61,7 +65,6 @@ export class CelestiaFetcher extends BaseDataFetcher<
           this.client.getHeaderAtHeight(height)
         );
       } catch (_e) {
-        // Likely reached the chain tip; stop here
         break;
       }
 
@@ -73,18 +76,23 @@ export class CelestiaFetcher extends BaseDataFetcher<
         this.config.primitives,
       );
 
-      outputs.push({
-        output: {
-          timestamp: extHeader.header.time,
-          height,
-          hash: blockHash,
-          primitives,
-        },
-        cleanup: () => {},
-      });
+      const output: Output = {
+        timestamp: extHeader.header.time,
+        height,
+        hash: blockHash,
+        primitives,
+      };
+      lastFetchedOutput = output;
+
+      if (fetchAllBlocks || primitives.length > 0 || height === data.to) {
+        outputs.push({
+          output,
+          cleanup: () => {},
+        });
+      }
     }
 
-    if (outputs.length === 0) {
+    if (!lastFetchedOutput) {
       if (!lastPage) {
         throw new Error(
           `[Celestia] Could not fetch any blocks from ${data.from} to ${data.to} and no previous page was found.`,
@@ -96,16 +104,15 @@ export class CelestiaFetcher extends BaseDataFetcher<
       };
     }
 
-    const lastOutput = outputs[outputs.length - 1].output;
     return {
       output: outputs,
       lastPage: {
-        ownBlockNumber: lastOutput.height,
+        ownBlockNumber: lastFetchedOutput.height,
         own: {
-          height: lastOutput.height,
-          hash: lastOutput.hash,
+          height: lastFetchedOutput.height,
+          hash: lastFetchedOutput.hash,
         },
-        root: rootConversion.toRootPage(lastOutput),
+        root: rootConversion.toRootPage(lastFetchedOutput),
       },
     };
   }

--- a/packages/node-sdk/sync/src/sync-protocols/evm/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/evm/fetcher.ts
@@ -25,7 +25,7 @@ import type {
 import { PageSchema } from "./types.ts";
 import {
   fetchNewestPage,
-  genImmediatePageRequests,
+  genOnDemandPageRequests,
   type PageRange,
   type PageRequest,
 } from "../base/page.ts";
@@ -62,15 +62,17 @@ export class EvmFetcher
     data: Input,
     rootConversion: RootConversion<Output, RootOutput, RootPage>,
   ): Operation<DataFetched<Output, Page, RootPage>> {
-    const allPages: Page[] = [];
-    for (let p = data.from; p <= data.to; p++) allPages.push(p);
-    const pageFetcher = genImmediatePageRequests(
-      allPages,
-      (page) => this.client.getBlock({ blockNumber: BigInt(page) }),
+    const fetchAllBlocks = this.config.primitives.some(
+      (p) => p.primitive.getAllBlockHeaders,
     );
 
-    // TODO: if we expect multiple primitives per block
-    //       it can, depending on the chain, be faster to just download the full block and parse it locally
+    const pageFetcher = genOnDemandPageRequests(
+      data.from,
+      data.to,
+      (page) => this.client.getBlock({ blockNumber: BigInt(page) }),
+      blockNumberRelation,
+    );
+
     const primitives = yield* this.readPrimitives(
       data,
       pageFetcher,
@@ -92,25 +94,28 @@ export class EvmFetcher
             };
           }),
         ),
-        // we always need to get the last page in the parallel case
-        // so we can use it for pagination
+        // we always need the last page for pagination
         call(() => pageFetcher(Number(data.to))),
       ],
     );
 
-    // Build an output with all page info, as we need all the hashes to build the effectstream-block-hash
-    // All blocks are already pre-fetched in parallel by genImmediatePageRequests above
     const allOutputs: Output[] = [];
     for (let page = data.from; page <= data.to; page++) {
       const _output = output.find((o) => o.raw.number === BigInt(page));
       if (_output) {
         allOutputs.push(_output);
-      } else {
+      } else if (fetchAllBlocks) {
         const raw = yield* call(() => pageFetcher(page));
         allOutputs.push({
           raw,
           primitives: [],
           blockHashes: [raw.hash] as EvmBlockHash[],
+        });
+      } else if (page === data.to) {
+        allOutputs.push({
+          raw: lastPage,
+          primitives: [],
+          blockHashes: [lastPage.hash] as EvmBlockHash[],
         });
       }
     }
@@ -118,14 +123,14 @@ export class EvmFetcher
     return {
       output: allOutputs.map((o) => ({
         output: o,
-        cleanup: () => {}, // no cleanup required
+        cleanup: () => {},
       })),
       lastPage: {
         own: Number(data.to),
         ownBlockNumber: Number(data.to),
         root: rootConversion.toRootPage({
           blockHashes: [lastPage.hash] as EvmBlockHash[],
-          primitives: [], // unused in toRootPage
+          primitives: [],
           raw: lastPage,
         }),
       },

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
@@ -93,11 +93,11 @@ export class MidnightFetcher extends BaseDataFetcher<
       { length: data.to - data.from + 1 },
       (_, i) => i + data.from,
     );
+    const fetchAllBlocks = this.config.primitives.some(
+      (p) => p.primitive.getAllBlockHeaders,
+    );
+
     const fetched = yield* all(
-      // The endpoint does not support range requests,
-      // so we fetch each block individually in parallel.
-      // useAbortSignal() ties each fetch's lifetime to its Effection scope,
-      // so cancellation by all() cleanly aborts the underlying HTTP request.
       heights.map(function* (height) {
         const signal = yield* useAbortSignal();
         const result: MidnightGqlBlockState = yield* call(() =>
@@ -117,9 +117,22 @@ export class MidnightFetcher extends BaseDataFetcher<
         };
       }),
     );
-    outputs.push(...fetched);
 
-    const lastOutput = outputs[outputs.length - 1].output;
+    const lastFetched = fetched[fetched.length - 1];
+    if (fetchAllBlocks) {
+      outputs.push(...fetched);
+    } else {
+      for (const item of fetched) {
+        if (item.output.primitives.length > 0) {
+          outputs.push(item);
+        }
+      }
+      if (outputs.length === 0 || outputs[outputs.length - 1] !== lastFetched) {
+        outputs.push(lastFetched);
+      }
+    }
+
+    const lastOutput = lastFetched.output;
     return {
       output: outputs,
       lastPage: {

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/fetcher.ts
@@ -39,39 +39,51 @@ export class UtxoRpcFetcher
         data.isPresync ? "[presync]" : ""
       }`,
     );
+    const fetchAllBlocks = this.config.primitives.some(
+      (p) => p.primitive.getAllBlockHeaders,
+    );
+
     const outputs: OutputAndCleanup<Output>[] = [];
     const blocks = this.client.fetchBlocks(data.from, data.to);
+    let lastBlock: typeof blocks[number] | undefined;
     for (const block of blocks) {
+      lastBlock = block;
+      const primitives = this.findPrimitives(block.output);
+      if (fetchAllBlocks || primitives.length > 0) {
+        outputs.push({
+          output: {
+            blockHashes: [String(block.output.header?.hash)],
+            raw: block.output,
+            primitives,
+          },
+          cleanup: block.cleanup,
+        });
+      }
+    }
+    if (lastBlock && (outputs.length === 0 || outputs[outputs.length - 1].output.raw !== lastBlock.output)) {
       outputs.push({
         output: {
-          // TODO: What is the correct block hash?
-          blockHashes: [String(block.output.header?.hash)],
-          raw: block.output,
-          primitives: this.findPrimitives(block.output),
+          blockHashes: [String(lastBlock.output.header?.hash)],
+          raw: lastBlock.output,
+          primitives: [],
         },
-        cleanup: block.cleanup,
+        cleanup: lastBlock.cleanup,
       });
     }
+    const lastRaw = lastBlock!.output;
     return {
       output: outputs,
       lastPage: {
         ownBlockNumber: Number(data.to),
         own: {
-          slot: Number(
-            outputs[outputs.length - 1].output.raw.header!.slot,
-          ),
-          height: Number(
-            outputs[outputs.length - 1].output.raw.header!.height,
-          ),
-          hash: Buffer.from(
-            outputs[outputs.length - 1].output.raw.header!.hash,
-          )
-            .toString("hex"),
+          slot: Number(lastRaw.header!.slot),
+          height: Number(lastRaw.header!.height),
+          hash: Buffer.from(lastRaw.header!.hash).toString("hex"),
         },
         root: rootConversion.toRootPage({
           blockHashes: [],
-          primitives: [], // TODO: I think this can be left empty here
-          raw: outputs[outputs.length - 1].output.raw,
+          primitives: [],
+          raw: lastRaw,
         }),
       },
     };


### PR DESCRIPTION
## Summary
- **Fetcher optimization fix**: All fetchers (EVM, UTXORPC, Avail, Bitcoin, Celestia, Midnight) now always include the last block in their output even when it has no primitives. This ensures `SyncChains` events fire for every chain on every effectstream block, fixing the batcher timeout and e2e test hangs caused by the `fetchAllBlocks` optimization.
- **Batcher confirmation**: Changed `>` to `>=` in the batcher's `wait-effectstream-processed` logic — seeing the transaction's own block is sufficient since events are emitted after DB commit.
- **Empty block hashing**: Blocks with no operations (no migrations, no primitives, no scheduled data) store `0x0` as their hash. Previous `0x0` rows are deleted so only the latest empty block is kept. The in-memory hash chain only advances on real hashes, making restarts deterministic.

## Test plan
- [ ] Run e2e tests (previously stuck at batcher timeout and "schedule" game input)
- [ ] Verify `SyncChains` events fire for parallel chains even when blocks have no primitives
- [ ] Verify empty blocks store `0x0` hash and previous `0x0` rows are cleaned up
- [ ] Verify restart produces identical block hashes (deterministic hash chain)