### PR TITLE
Yield for wait time before initial snapshot to avoid backup at 0s

### DIFF
--- a/packages/node-sdk/db/src/snapshot-handler.ts
+++ b/packages/node-sdk/db/src/snapshot-handler.ts
@@ -74,16 +74,16 @@ export function* runSnapshotLoop(
   snapshotConfig: SnapshotConfig,
 ): Operation<void> {
   const intervalMs = (snapshotConfig.intervalSeconds ?? 3600) * 1000;
-  console.log(`[Snapshot] Loop started (interval ${intervalMs / 1000}s, path ${snapshotConfig.path ?? "./snapshots"}, cwd ${Deno.cwd()})`);
+  console.log(`[Snapshot] Loop started (interval ${intervalMs / 1000}s, path ${snapshotConfig.path ?? "./snapshots"}, cwd ${Deno.cwd()}); first snapshot in ${intervalMs / 1000}s`);
   while (true) {
+    yield* sleep(intervalMs);
     console.log(`[Snapshot] Firing`);
     try {
       yield* until(createSnapshot(snapshotConfig));
-      console.log(`[Snapshot] Done; sleeping ${intervalMs / 1000}s`);
+      console.log(`[Snapshot] Done`);
     } catch (e) {
       console.error("[Snapshot] Failed:", e);
     }
-    yield* sleep(intervalMs);
   }
 }
 


### PR DESCRIPTION

<img width="1198" height="200" alt="image" src="https://github.com/user-attachments/assets/e5fdde7b-3fc7-4617-8664-2463d2fcc039" />


```
🔍 [Running test] 82: Snapshot .dump file created
[snapshotTest] Found: snapshot-2026-05-07T18-46-56Z.dump
✅ Test passed
[snapshotRetentionTest] Waiting up to 375s for 2+ snapshots...
🔍 [Running test] 83: Retention: ≤ 3 snapshot(s) in ./snapshots
[snapshotRetentionTest] OK: 1 file(s) — snapshot-2026-05-07T18-46-56Z.dump
✅ Test passed


🔍 [Summary]
  83 tests passed
  0 tests failed
  0 tests skipped
```