### PR TITLE
docs: add Cardano primitives documentation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,10 +34,13 @@
         "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
         "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
         "@midnight-ntwrk/wallet-sdk-facade": "3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^2.0.0",
         "@sinclair/typebox": "^0.34.30",
         "@zswap-da/contract-offer-files": "workspace:*",
         "effection": "^3.5.0",
-        "mip-zswap-offer": "link:mip-zswap-offer",
+        "mip-zswap-offer": "github:effectstream/mip-zswap-offer#main",
         "pg": "^8.14.0",
         "rxjs": "^7.8.2",
       },
@@ -84,13 +87,17 @@
         "@midnight-ntwrk/midnight-js-types": "4.0.2",
         "@midnight-ntwrk/midnight-js-utils": "4.0.2",
         "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^2.0.0",
         "@zswap-da/contract-offer-files": "workspace:*",
-        "mip-zswap-offer": "link:mip-zswap-offer",
+        "mip-zswap-offer": "github:effectstream/mip-zswap-offer#main",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "three": "^0.183.2",
       },
       "devDependencies": {
+        "@types/node": "^22.19.3",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.183.1",
@@ -140,11 +147,14 @@
         "@midnight-ntwrk/midnight-js-network-id": "4.0.4",
         "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
         "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^2.0.0",
         "@sinclair/typebox": "^0.34.30",
         "@zswap-da/contract-offer-files": "workspace:*",
         "@zswap-da/database": "workspace:*",
         "effection": "^3.5.0",
-        "mip-zswap-offer": "link:mip-zswap-offer",
+        "mip-zswap-offer": "github:effectstream/mip-zswap-offer#main",
         "rxjs": "^7.8.2",
       },
     },
@@ -590,7 +600,7 @@
     },
     "packages/batcher": {
       "name": "@effectstream/batcher-sdk",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/event-client": "workspace:*",
@@ -633,7 +643,7 @@
     },
     "packages/binaries/avail-light-client": {
       "name": "@effectstream/npm-avail-light-client",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "npm-avail-light-client": "index.js",
       },
@@ -644,7 +654,7 @@
     },
     "packages/binaries/avail-node": {
       "name": "@effectstream/npm-avail-node",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "npm-avail-node": "index.js",
       },
@@ -655,7 +665,7 @@
     },
     "packages/binaries/bitcoin-core": {
       "name": "@effectstream/bitcoin-core",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "bitcoin-core": "./index.js",
       },
@@ -665,7 +675,7 @@
     },
     "packages/binaries/celestia": {
       "name": "@effectstream/celestia",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "celestia": "./index.js",
       },
@@ -675,7 +685,7 @@
     },
     "packages/binaries/grafana-alloy": {
       "name": "@effectstream/grafana-alloy",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "grafana-alloy": "index.js",
       },
@@ -685,7 +695,7 @@
     },
     "packages/binaries/grafana-loki": {
       "name": "@effectstream/grafana-loki",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "grafana-loki": "index.js",
       },
@@ -695,7 +705,7 @@
     },
     "packages/binaries/midnight-indexer": {
       "name": "@effectstream/npm-midnight-indexer",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "npm-midnight-indexer": "index.js",
       },
@@ -708,7 +718,7 @@
     },
     "packages/binaries/midnight-node": {
       "name": "@effectstream/npm-midnight-node",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "npm-midnight-node": "index.js",
       },
@@ -720,7 +730,7 @@
     },
     "packages/binaries/midnight-proof-server": {
       "name": "@effectstream/npm-midnight-proof-server",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "npm-midnight-proof-server": "index.js",
       },
@@ -731,7 +741,7 @@
     },
     "packages/binaries/near-sandbox": {
       "name": "@effectstream/near-sandbox",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "near-sandbox": "./index.js",
       },
@@ -741,7 +751,7 @@
     },
     "packages/binaries/ord": {
       "name": "@effectstream/ord",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "ord": "./index.js",
       },
@@ -776,7 +786,7 @@
     },
     "packages/build-tools/orchestrator": {
       "name": "@effectstream/orchestrator",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "bin": {
         "orchestrator": "src/cli.ts",
       },
@@ -786,11 +796,11 @@
     },
     "packages/chains/avail-contracts": {
       "name": "@effectstream/avail-contracts",
-      "version": "0.100.12",
+      "version": "0.100.13",
     },
     "packages/chains/bitcoin-contracts": {
       "name": "@effectstream/bitcoin-contracts",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "bitcoinjs-lib": "^7.0.0",
         "ecpair": "^3.0.0",
@@ -799,11 +809,11 @@
     },
     "packages/chains/cardano-contracts": {
       "name": "@effectstream/cardano-contracts",
-      "version": "0.100.12",
+      "version": "0.100.13",
     },
     "packages/chains/evm-contracts": {
       "name": "@effectstream/evm-contracts",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@nomicfoundation/hardhat-ignition": "3.0.2",
         "@nomicfoundation/hardhat-ignition-viem": "3.0.2",
@@ -818,7 +828,7 @@
     },
     "packages/chains/evm-hardhat": {
       "name": "@effectstream/evm-hardhat",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -835,7 +845,7 @@
     },
     "packages/chains/midnight-contracts": {
       "name": "@effectstream/midnight-contracts",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@midnight-ntwrk/compact-js": "2.5.0",
@@ -868,14 +878,14 @@
     },
     "packages/effectstream-sdk/chain-types": {
       "name": "@effectstream/chain-types",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/concise": {
       "name": "@effectstream/concise",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -886,7 +896,7 @@
     },
     "packages/effectstream-sdk/config": {
       "name": "@effectstream/config",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@dcspark/carp-client": "^3.3.0",
         "@dcspark/cip34-js": "3.0.1",
@@ -903,7 +913,7 @@
     },
     "packages/effectstream-sdk/coroutine": {
       "name": "@effectstream/coroutine",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@pgtyped/parser": "2.4.2",
@@ -915,7 +925,7 @@
     },
     "packages/effectstream-sdk/crypto": {
       "name": "@effectstream/crypto",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
         "@effectstream/utils": "workspace:*",
@@ -930,7 +940,7 @@
     },
     "packages/effectstream-sdk/events": {
       "name": "@effectstream/event-client",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@sinclair/typebox": "0.34.41",
@@ -943,7 +953,7 @@
     },
     "packages/effectstream-sdk/log": {
       "name": "@effectstream/log",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
@@ -965,14 +975,14 @@
     },
     "packages/effectstream-sdk/precompile": {
       "name": "@effectstream/precompile",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/utils": {
       "name": "@effectstream/utils",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@foxglove/crc": "^1.0.1",
@@ -993,7 +1003,7 @@
     },
     "packages/effectstream-sdk/wallets": {
       "name": "@effectstream/wallets",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@aurowallet/mina-provider": "^1.0.12",
         "@effectstream/concise": "workspace:*",
@@ -1019,61 +1029,16 @@
         "web3-utils": "^4.3.3",
       },
     },
-    "packages/effectstream-sdk/wallets/npm": {
-      "name": "@effectstream/wallets-dnt-output",
-      "version": "0.3.0",
-      "dependencies": {
-        "@aurowallet/mina-provider": "^1.0.12",
-        "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
-        "@coderspirit/nominal": "^4.1.1",
-        "@foxglove/crc": "^1.0.1",
-        "@metamask/providers": "^22.1.0",
-        "@midnight-ntwrk/dapp-connector-api": "4.0.1",
-        "@perawallet/connect": "^1.4.2",
-        "@polkadot/extension-dapp": "^0.58.10",
-        "@polkadot/extension-inject": "^0.58.10",
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/util-crypto": "^13.4.3",
-        "@sinclair/typebox": "0.34.41",
-        "@subsquid/ss58-codec": "^1.2.3",
-        "abitype": "1.1.0",
-        "algosdk": "^3.4.0",
-        "assert-never": "^1.4.0",
-        "avail-js-sdk": "^0.4.2",
-        "bech32": "^2.0.0",
-        "bs58": "^6.0.0",
-        "bs58check": "^4.0.0",
-        "effection": "^3.5.0",
-        "ethers": "^6.15.0",
-        "hi-base32": "^0.5.1",
-        "js-base64": "^3.7.7",
-        "js-sha3": "^0.9.3",
-        "js-sha512": "^0.9.0",
-        "mina-signer": "^3.0.7",
-        "mqtt": "^5.14.0",
-        "mqtt-pattern": "^2.1.0",
-        "semver": "^7.7.3",
-        "viem": "2.37.3",
-        "web3": "^4.16.0",
-        "web3-utils": "^4.3.3",
-      },
-    },
-    "packages/effectstream-sdk/wallets/npm/esm": {
-      "name": "@effectstream/wallets-npm-esm-stub",
-    },
-    "packages/effectstream-sdk/wallets/npm/script": {
-      "name": "@effectstream/wallets-npm-script-stub",
-    },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/wallets": "workspace:*",
       },
     },
     "packages/node-sdk/db": {
       "name": "@effectstream/db",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/coroutine": "workspace:*",
         "@effectstream/log": "workspace:*",
@@ -1096,7 +1061,7 @@
     },
     "packages/node-sdk/db-emulator": {
       "name": "@effectstream/db-emulator",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@pgtyped/runtime": "2.4.2",
         "effection": "^3.5.0",
@@ -1105,7 +1070,7 @@
     },
     "packages/node-sdk/events": {
       "name": "@effectstream/event-server",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "aedes": "^0.51.3",
@@ -1115,7 +1080,7 @@
     },
     "packages/node-sdk/node": {
       "name": "@effectstream/node-sdk",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/chain-types": "workspace:*",
         "@effectstream/concise": "workspace:*",
@@ -1133,7 +1098,7 @@
     },
     "packages/node-sdk/runtime": {
       "name": "@effectstream/runtime",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1165,7 +1130,7 @@
     },
     "packages/node-sdk/sm": {
       "name": "@effectstream/sm",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1186,7 +1151,7 @@
     },
     "packages/node-sdk/sync": {
       "name": "@effectstream/sync",
-      "version": "0.100.12",
+      "version": "0.100.13",
       "dependencies": {
         "@cardano-sdk/core": "^0.46.11",
         "@cardano-sdk/util": "^0.17.1",
@@ -1462,12 +1427,6 @@
     "@effectstream/utils": ["@effectstream/utils@workspace:packages/effectstream-sdk/utils"],
 
     "@effectstream/wallets": ["@effectstream/wallets@workspace:packages/effectstream-sdk/wallets"],
-
-    "@effectstream/wallets-dnt-output": ["@effectstream/wallets-dnt-output@workspace:packages/effectstream-sdk/wallets/npm"],
-
-    "@effectstream/wallets-npm-esm-stub": ["@effectstream/wallets-npm-esm-stub@workspace:packages/effectstream-sdk/wallets/npm/esm"],
-
-    "@effectstream/wallets-npm-script-stub": ["@effectstream/wallets-npm-script-stub@workspace:packages/effectstream-sdk/wallets/npm/script"],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 
@@ -1835,7 +1794,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
@@ -2239,7 +2198,7 @@
 
     "@scarf/scarf": ["@scarf/scarf@1.4.0", "", {}, "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="],
 
-    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+    "@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
@@ -2463,7 +2422,7 @@
 
     "@types/mysql": ["@types/mysql@2.15.26", "", { "dependencies": { "@types/node": "*" } }, "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ=="],
 
-    "@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+    "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "@types/object-inspect": ["@types/object-inspect@1.13.0", "", {}, "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w=="],
 
@@ -3527,7 +3486,7 @@
 
     "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
 
-    "mip-zswap-offer": ["mip-zswap-offer@link:mip-zswap-offer", {}],
+    "mip-zswap-offer": ["mip-zswap-offer@github:effectstream/mip-zswap-offer#32377f4", { "peerDependencies": { "@midnight-ntwrk/ledger-v8": "*", "@noble/curves": "^1.0.0 || ^2.0.0", "@noble/hashes": "^1.0.0 || ^2.0.0", "@scure/base": "^1.1.0 || ^2.0.0" }, "optionalPeers": ["@midnight-ntwrk/ledger-v8"] }, "effectstream-mip-zswap-offer-32377f4", "sha512-pmokkKfv9IMm/Gp4NeBvoq3FleFt60NOgfk54zvSNJi76BgRUIUqfsulypICPGDpt0hVT04hruU+85jQR1ZOkw=="],
 
     "mipd": ["mipd@0.0.7", "", { "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg=="],
 
@@ -4107,7 +4066,7 @@
 
     "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
-    "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "union": ["union@0.5.0", "", { "dependencies": { "qs": "^6.4.0" } }, "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA=="],
 
@@ -4299,6 +4258,8 @@
 
     "@cardano-sdk/core/@foxglove/crc": ["@foxglove/crc@0.0.3", "", {}, "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA=="],
 
+    "@cardano-sdk/core/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@coinbase/cdp-sdk/abitype": ["abitype@1.0.6", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A=="],
 
     "@coinbase/cdp-sdk/axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
@@ -4381,10 +4342,6 @@
 
     "@effectstream/wallets/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
 
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
-
-    "@effectstream/wallets-dnt-output/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
-
     "@ethersproject/abi/@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
 
     "@ethersproject/hash/@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
@@ -4443,13 +4400,13 @@
 
     "@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@midnight-ntwrk/compact-js/@effect/platform": ["@effect/platform@0.95.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.20.0" } }, "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA=="],
 
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
-
-    "@midnight-ntwrk/midnight-js-utils/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
     "@midnight-ntwrk/platform-js/@effect/platform": ["@effect/platform@0.95.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.20.0" } }, "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA=="],
 
@@ -4458,8 +4415,6 @@
     "@midnight-ntwrk/wallet/@midnight-ntwrk/wallet-sdk-capabilities": ["@midnight-ntwrk/wallet-sdk-capabilities@2.0.0", "", { "peerDependencies": { "@midnight-ntwrk/zswap": "4.0.0" } }, "sha512-zl1uZwy8bMlpNfze6rRTEMZiOCKr4dYBYoIVKLPkck1vKcz3nhsjFAkNfsYtFyND/K7/7mLZBtuHxGWX4gYxXQ=="],
 
     "@midnight-ntwrk/wallet/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
-
-    "@midnight-ntwrk/wallet-sdk-address-format/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
     "@midnight-ntwrk/wallet-sdk-dust-wallet/@midnight-ntwrk/wallet-sdk-indexer-client": ["@midnight-ntwrk/wallet-sdk-indexer-client@1.2.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@midnight-ntwrk/wallet-sdk-utilities": "1.1.0", "effect": "^3.19.19", "graphql": "^16.13.0", "graphql-http": "^1.22.4", "graphql-ws": "^6.0.7" } }, "sha512-VzwJ0LTBcUWqr5H4a56DhT6zpLYLjg/H6vRrwKYEz3EhQTKLGnQ7d2PKS0Z0QcKGEXOHzeeSmI41FsvG4FbTAQ=="],
 
@@ -4509,6 +4464,8 @@
 
     "@polkadot-api/substrate-bindings/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@polkadot-api/substrate-bindings/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@polkadot/api/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
 
     "@polkadot/api-derive/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
@@ -4531,9 +4488,13 @@
 
     "@polkadot/util/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
 
+    "@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@polkadot/util-crypto/@polkadot/util": ["@polkadot/util@14.0.3", "", { "dependencies": { "@polkadot/x-bigint": "14.0.3", "@polkadot/x-global": "14.0.3", "@polkadot/x-textdecoder": "14.0.3", "@polkadot/x-textencoder": "14.0.3", "@types/bn.js": "^5.1.6", "bn.js": "^5.2.1", "tslib": "^2.8.0" } }, "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw=="],
+
+    "@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@polkadot/x-bigint/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
 
@@ -4559,11 +4520,11 @@
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@scure/bip39/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
-
-    "@scure/sr25519/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+    "@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@scure/sr25519/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -4579,7 +4540,33 @@
 
     "@stricahq/typhonjs/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
+    "@types/bn.js/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/bunyan/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/cacheable-request/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/connect/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/keyv/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/memcached/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/mysql/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/pg/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
     "@types/react-dom/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/readable-stream/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/responselike/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/tedious/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/yauzl/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
     "@vitest/runner/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -4683,6 +4670,10 @@
 
     "@zswap-da/e2e/@midnight-ntwrk/midnight-js-network-id": ["@midnight-ntwrk/midnight-js-network-id@4.0.4", "", {}, "sha512-bieKcN9ybIf+HoaHPjCJGxmYrcmUrdEOErxkxhiqgos2k7DKM9mZO7AgzN0WnBbPHYdT4z0c740QAcG95BaV8g=="],
 
+    "@zswap-da/e2e/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@zswap-da/frontend/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@zswap-da/frontend/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@zswap-da/frontend/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
@@ -4696,6 +4687,8 @@
     "@zswap-da/node/@midnight-ntwrk/midnight-js-contracts": ["@midnight-ntwrk/midnight-js-contracts@4.0.4", "", { "dependencies": { "@midnight-ntwrk/compact-js": "2.5.0", "@midnight-ntwrk/midnight-js-network-id": "4.0.4", "@midnight-ntwrk/midnight-js-types": "4.0.4", "@midnight-ntwrk/midnight-js-utils": "4.0.4" } }, "sha512-lu9A45upwvPSy/YohU0TMvaeL2ru1zJt6axbuGwGup2L16p+fN8ojjHji6YGEC6XkgyISH3L0GfsgxsQKmt56g=="],
 
     "@zswap-da/node/@midnight-ntwrk/midnight-js-network-id": ["@midnight-ntwrk/midnight-js-network-id@4.0.4", "", {}, "sha512-bieKcN9ybIf+HoaHPjCJGxmYrcmUrdEOErxkxhiqgos2k7DKM9mZO7AgzN0WnBbPHYdT4z0c740QAcG95BaV8g=="],
+
+    "@zswap-da/node/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "aedes-packet/mqtt-packet": ["mqtt-packet@7.1.2", "", { "dependencies": { "bl": "^4.0.2", "debug": "^4.1.1", "process-nextick-args": "^2.0.1" } }, "sha512-FFZbcZ2omsf4c5TxEQfcX9hI+JzDpDKPT46OmeIBpVA7+t32ey25UNqlqNXTmeZOr5BLsSIERpQQLsFWJS94SQ=="],
 
@@ -4726,6 +4719,8 @@
     "bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "bs58check/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "bun-types/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
     "cbw-sdk/preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
@@ -4761,8 +4756,6 @@
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
@@ -4784,6 +4777,8 @@
     "ethers/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
 
     "ethers/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
+    "ethers/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
     "ethers/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
@@ -4834,6 +4829,8 @@
     "micro-eth-signer/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
     "micro-eth-signer/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "micro-packed/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
@@ -5289,6 +5286,8 @@
 
     "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
+    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "ox/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
@@ -5308,6 +5307,8 @@
     "porto/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "porto/zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
+
+    "protobufjs/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
     "public-encrypt/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
@@ -5349,6 +5350,8 @@
 
     "valtio/use-sync-external-store": ["use-sync-external-store@1.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="],
 
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
@@ -5383,6 +5386,8 @@
 
     "@base-org/account/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
+    "@base-org/account/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@base-org/account/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@base-org/account/ox/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
@@ -5390,6 +5395,8 @@
     "@cardano-ogmios/client/cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "@coinbase/cdp-sdk/axios/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "@coinbase/cdp-sdk/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@coinbase/cdp-sdk/viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5403,6 +5410,8 @@
 
     "@coinbase/wallet-sdk/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
+    "@coinbase/wallet-sdk/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@coinbase/wallet-sdk/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@coinbase/wallet-sdk/ox/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
@@ -5410,6 +5419,8 @@
     "@e2e/bitcoin-contracts/bitcoinjs-lib/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@e2e/bitcoin-contracts/bitcoinjs-lib/bs58check": ["bs58check@3.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^5.0.0" } }, "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ=="],
+
+    "@e2e/evm-batcher/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@e2e/evm-batcher/viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5420,6 +5431,8 @@
     "@e2e/evm-batcher/viem/ox": ["ox@0.14.20", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw=="],
 
     "@e2e/evm-batcher/viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "@effectstream/batcher-sdk/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@effectstream/batcher-sdk/viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5443,6 +5456,8 @@
 
     "@effectstream/bitcoin-contracts/ecpair/wif": ["wif@5.0.0", "", { "dependencies": { "bs58check": "^4.0.0" } }, "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA=="],
 
+    "@effectstream/crypto/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@effectstream/crypto/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@effectstream/crypto/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
@@ -5451,17 +5466,13 @@
 
     "@effectstream/crypto/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
+    "@effectstream/crypto/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@effectstream/grafana-alloy/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@15.2.0", "", { "dependencies": { "@xhmikosr/archive-type": "^7.1.0", "@xhmikosr/decompress": "^10.2.0", "content-disposition": "^0.5.4", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^20.5.0", "filenamify": "^6.0.0", "get-stream": "^6.0.1", "got": "^13.0.0" } }, "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g=="],
 
     "@effectstream/grafana-loki/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@15.2.0", "", { "dependencies": { "@xhmikosr/archive-type": "^7.1.0", "@xhmikosr/decompress": "^10.2.0", "content-disposition": "^0.5.4", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^20.5.0", "filenamify": "^6.0.0", "get-stream": "^6.0.1", "got": "^13.0.0" } }, "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g=="],
 
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
+    "@effectstream/wallets/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@effectstream/wallets/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5470,6 +5481,8 @@
     "@effectstream/wallets/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
 
     "@effectstream/wallets/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
+
+    "@effectstream/wallets/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@fastify/swagger-ui/@fastify/static/content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -5480,6 +5493,8 @@
     "@lucid-evolution/utils/@cardano-sdk/core/@cardano-sdk/util": ["@cardano-sdk/util@0.16.0", "", { "dependencies": { "bech32": "^2.0.0", "lodash": "^4.17.21", "serialize-error": "^8", "ts-custom-error": "^3.2.0", "ts-log": "^2.2.4", "type-fest": "^2.19.0" } }, "sha512-f0tfX8oiauqAFCyyc/o2Ouezyk83QD4zqLl4DUjZNyCtITL8gBHh25Bkw7RUCGEZ+hf6Qms1n0ui0j3wVY7zRg=="],
 
     "@lucid-evolution/utils/@cardano-sdk/core/@foxglove/crc": ["@foxglove/crc@0.0.3", "", {}, "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA=="],
+
+    "@lucid-evolution/utils/@cardano-sdk/core/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors": ["@metamask/rpc-errors@6.4.0", "", { "dependencies": { "@metamask/utils": "^9.0.0", "fast-safe-stringify": "^2.0.6" } }, "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg=="],
 
@@ -5500,8 +5515,6 @@
     "@metamask/sdk/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "@midnight-ntwrk/wallet-sdk-hd/@scure/bip32/@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
-
-    "@midnight-ntwrk/wallet-sdk-hd/@scure/bip32/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
     "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/api-augment": ["@polkadot/api-augment@16.5.6", "", { "dependencies": { "@polkadot/api-base": "16.5.6", "@polkadot/rpc-augment": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/types-augment": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw=="],
 
@@ -5539,6 +5552,8 @@
 
     "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/util/@polkadot/x-textencoder": ["@polkadot/x-textencoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ=="],
 
+    "@midnight-ntwrk/wallet/@midnight-ntwrk/wallet-sdk-address-format/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@paima/pgtyped-cli/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "@pgtyped/parser/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -5546,6 +5561,8 @@
     "@pgtyped/query/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "@pgtyped/runtime/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "@polkadot/api-derive/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@polkadot/api-derive/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5555,6 +5572,10 @@
 
     "@polkadot/api-derive/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
+    "@polkadot/api-derive/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/api/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@polkadot/api/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@polkadot/api/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
@@ -5562,6 +5583,10 @@
     "@polkadot/api/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
 
     "@polkadot/api/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
+
+    "@polkadot/api/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/extension-dapp/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@polkadot/extension-dapp/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5571,6 +5596,10 @@
 
     "@polkadot/extension-dapp/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
+    "@polkadot/extension-dapp/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/extension-inject/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@polkadot/extension-inject/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@polkadot/extension-inject/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
@@ -5578,6 +5607,10 @@
     "@polkadot/extension-inject/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
 
     "@polkadot/extension-inject/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
+
+    "@polkadot/extension-inject/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/keyring/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@polkadot/keyring/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5587,11 +5620,15 @@
 
     "@polkadot/keyring/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
+    "@polkadot/keyring/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@polkadot/networks/@polkadot/util/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
 
     "@polkadot/networks/@polkadot/util/@polkadot/x-textdecoder": ["@polkadot/x-textdecoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA=="],
 
     "@polkadot/networks/@polkadot/util/@polkadot/x-textencoder": ["@polkadot/x-textencoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ=="],
+
+    "@polkadot/rpc-provider/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@polkadot/rpc-provider/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5601,6 +5638,10 @@
 
     "@polkadot/rpc-provider/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
+    "@polkadot/rpc-provider/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@polkadot/types/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@polkadot/types/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
@@ -5608,6 +5649,8 @@
     "@polkadot/types/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
 
     "@polkadot/types/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@polkadot/util-crypto/@polkadot/util/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
 
@@ -5634,6 +5677,32 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/sign-client": ["@walletconnect/sign-client@2.21.0", "", { "dependencies": { "@walletconnect/core": "2.21.0", "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/logger": "2.1.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/utils": "2.21.0", "events": "3.3.0" } }, "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
+
+    "@types/bn.js/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/bunyan/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/cacheable-request/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/connect/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/keyv/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/memcached/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/mysql/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/readable-stream/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/responselike/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/tedious/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@types/yauzl/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "@walletconnect/browser-utils/@walletconnect/window-metadata/@walletconnect/window-getters": ["@walletconnect/window-getters@1.0.1", "", { "dependencies": { "tslib": "1.14.1" } }, "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q=="],
 
@@ -5735,11 +5804,15 @@
 
     "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "bun-types/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
     "concurrently/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "ethereum-cryptography/@scure/bip32/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 
     "ethereum-cryptography/@scure/bip39/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
+
+    "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "execa/cross-spawn/lru-cache": ["lru-cache@4.1.5", "", { "dependencies": { "pseudomap": "^1.0.2", "yallist": "^2.1.2" } }, "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g=="],
 
@@ -5811,13 +5884,19 @@
 
     "obj-multiplex/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "porto/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "porto/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "porto/ox/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
     "porto/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "protobufjs/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
@@ -5895,19 +5974,33 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "vite-plugin-static-copy/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "web3-providers-ws/@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
     "wif/bs58check/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
+    "@base-org/account/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@coinbase/cdp-sdk/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@coinbase/cdp-sdk/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@coinbase/cdp-sdk/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "@coinbase/wallet-sdk/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@e2e/bitcoin-contracts/bitcoinjs-lib/bs58check/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "@e2e/evm-batcher/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@e2e/evm-batcher/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@e2e/evm-batcher/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@effectstream/batcher-sdk/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@effectstream/batcher-sdk/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
@@ -5943,11 +6036,15 @@
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@metamask/sdk/@metamask/providers/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -6051,8 +6148,6 @@
 
     "@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "@zswap-da/e2e/@midnight-ntwrk/midnight-js-contracts/@midnight-ntwrk/midnight-js-utils/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
-
     "@zswap-da/frontend/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
     "@zswap-da/frontend/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
@@ -6105,8 +6200,6 @@
 
     "@zswap-da/frontend/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
-    "@zswap-da/node/@midnight-ntwrk/midnight-js-contracts/@midnight-ntwrk/midnight-js-utils/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
-
     "aedes-packet/mqtt-packet/bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "aedes-packet/mqtt-packet/bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -6149,6 +6242,8 @@
 
     "npm/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "porto/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
@@ -6162,6 +6257,8 @@
     "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "vite-plugin-static-copy/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "web3-providers-ws/@types/ws/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "wif/bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
@@ -6199,9 +6296,13 @@
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@metamask/sdk/@metamask/providers/@metamask/rpc-errors/@metamask/utils/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/rpc-errors/@metamask/utils/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -6257,6 +6358,10 @@
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
+    "@walletconnect/ethereum-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/ethereum-provider/@walletconnect/utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@walletconnect/ethereum-provider/@walletconnect/utils/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@walletconnect/ethereum-provider/@walletconnect/utils/viem/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
@@ -6271,6 +6376,10 @@
 
     "@walletconnect/ethereum-provider/@walletconnect/utils/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "@walletconnect/sign-client/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/sign-client/@walletconnect/utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@walletconnect/sign-client/@walletconnect/utils/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@walletconnect/sign-client/@walletconnect/utils/viem/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
@@ -6284,6 +6393,10 @@
     "@walletconnect/sign-client/@walletconnect/utils/viem/ox/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
     "@walletconnect/sign-client/@walletconnect/utils/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
@@ -6325,6 +6438,10 @@
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
@@ -6340,6 +6457,10 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
+
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
@@ -6357,6 +6478,10 @@
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
+    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
@@ -6371,10 +6496,34 @@
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "@walletconnect/ethereum-provider/@walletconnect/utils/viem/ox/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/ethereum-provider/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/sign-client/@walletconnect/utils/viem/ox/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/sign-client/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
     "npm/node-gyp/make-fetch-happen/cacache/glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "npm/node-gyp/make-fetch-happen/cacache/unique-filename/unique-slug": ["unique-slug@3.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w=="],
 
     "qrcode/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
   }
 }

--- a/docs/site/blog/2026-04-28-achievement-system.md
+++ b/docs/site/blog/2026-04-28-achievement-system.md
@@ -22,6 +22,29 @@ A game implementing PRC-1 exposes two endpoints:
 - `GET /achievements/public/list` returns all achievements defined by the game (name, description, display metadata)
 - `GET /achievements/wallet/:wallet` returns which achievements a specific player has earned, with timestamps and completion data
 
+The achievement list response is a flat TypeScript shape — no chain-specific fields, no platform-specific fields:
+
+```typescript
+interface AchievementPublicList {
+  achievements: {
+    name: string;              // Unique achievement ID, e.g. "speed_demon"
+    displayName: string;       // Player-facing title
+    description: string;       // How to unlock
+    isActive: boolean;         // Currently unlockable?
+    score?: number;            // Optional point value
+    category?: string;         // Optional grouping ("Gold", "Diamond", ...)
+    percentCompleted?: number; // Percentage of players who have it
+    iconURI?: string;          // Badge image URL
+    iconGreyURI?: string;      // Badge image URL when not yet earned
+    spoiler?: 'all' | 'description'; // Hide details until unlocked
+    startDate?: string;        // ISO8601, optional time-limited start
+    endDate?: string;          // ISO8601, optional time-limited end
+  }[];
+}
+```
+
+Per-player completion follows a matching shape, keyed by achievement `name` with completion timestamps and optional incremental progress (`progress` / `total`). The full schema is in [`prc-1.md`](https://github.com/effectstream/midnight-game-api-spec/blob/main/prc-1.md).
+
 Any game that implements these endpoints is automatically discoverable by achievement portals, leaderboard aggregators, and third-party tools. The standard is intentionally minimal: it defines the interface, not the implementation. Games track achievements however they want internally; they just expose results through these endpoints.
 
 ## PRC-6: Midnight dApp integration extension
@@ -35,7 +58,86 @@ For games running on the [midnight.fun](https://midnight.fun/games) portal, we e
 
 PRC-6 is what powers the rich game cards on midnight.fun. Each game tile shows live player counts, leaderboard positions, and achievement progress, all pulled from the standard API.
 
-The full PRC-6 spec lives in the same repository: [effectstream/midnight-game-api-spec](https://github.com/effectstream/midnight-game-api-spec).
+A PRC-6 application advertises its metadata, achievements, and channels at a single root endpoint:
+
+```bash
+GET {BASE_URL}/metrics
+```
+
+```json
+{
+  "name": "Cyber Drifter",
+  "description": "High-octane neon racing.",
+  "achievements": [
+    {
+      "name": "speed_demon",
+      "displayName": "Speed Demon",
+      "description": "Finish a lap under 60 seconds.",
+      "isActive": true,
+      "percentCompleted": 14.2
+    }
+  ],
+  "channels": [
+    { "id": "leaderboard", "name": "Lap Time",
+      "scoreUnit": "Lap Time (s)", "sortOrder": "ASC" },
+    { "id": "kos", "name": "Knock Outs",
+      "scoreUnit": "KOs", "sortOrder": "DESC" },
+    { "id": "volume", "name": "USD Volume",
+      "scoreUnit": "USD Volume", "sortOrder": "DESC", "auth": true }
+  ]
+}
+```
+
+The platform reads this once per game and uses it to render the game card, then queries each channel and per-user profile as needed.
+
+The interesting trick is identity resolution. A query on a session wallet returns the resolved main wallet's stats, with the delegation chain made explicit:
+
+```bash
+GET {BASE_URL}/metrics/users/mn_session_abc123?channel=leaderboard
+```
+
+```json
+{
+  "identity": {
+    "address": "mn_main_driftking",
+    "delegatedFrom": ["mn_session_abc123"],
+    "displayName": "DriftKing"
+  },
+  "achievements": ["speed_demon", "first_blood"],
+  "channels": {
+    "leaderboard": {
+      "stats": { "score": 45.2, "rank": 1 }
+    }
+  }
+}
+```
+
+A player using [auto-sign](/docs/blog/auto-sign) may hold dozens of session wallets across a game's lifetime; the platform collapses them all back to one main wallet for reputation and leaderboard purposes.
+
+The full PRC-6 spec, including all channel definitions, authentication rules, and snapshot vs. cumulative semantics, lives at [`prc-6.md`](https://github.com/effectstream/midnight-game-api-spec/blob/main/prc-6.md).
+
+## Implementing it in a game
+
+The spec repository ships with a runnable [reference server](https://github.com/effectstream/midnight-game-api-spec/tree/main/demo) that implements every endpoint against in-memory fixtures. The `/metrics` route is a few lines of Fastify:
+
+```typescript
+import Fastify from "fastify";
+import { APP_NAME, APP_DESCRIPTION, ACHIEVEMENTS, CHANNEL_DEFS }
+  from "./data/store.js";
+
+const app = Fastify();
+
+app.get("/metrics", async () => ({
+  name: APP_NAME,
+  description: APP_DESCRIPTION,
+  achievements: ACHIEVEMENTS,    // your achievement definitions
+  channels: CHANNEL_DEFS,        // your metric channels
+}));
+
+await app.listen({ port: 3000 });
+```
+
+There is no SDK to install. PRC-6 is just HTTP. A new game spending an afternoon on this gets discoverable on midnight.fun and queryable by every third-party tool that speaks the standard.
 
 ## Live implementation: three games on midnight.fun
 
@@ -50,6 +152,10 @@ PRC-1 and PRC-6 are implemented in three live games on the midnight.fun portal:
 The screenshot shows the midnight.fun portal pulling data from all three games. Each game card displays live achievement counts and leaderboard positions, sourced from the PRC-1 and PRC-6 APIs. There's no centralized database here; the data lives in each game's node, and the portal queries it on the fly.
 
 <iframe src="https://drive.google.com/file/d/1SSpY_nFAIm95b7v4LSEDhSywYgAkx0nK/preview" width="100%" height="480" allow="autoplay"></iframe>
+
+The walkthrough below shows the full earn-to-display loop: a player plays a game, unlocks an achievement, and the unlock surfaces immediately on the live leaderboard via the PRC-6 endpoints.
+
+<iframe src="https://drive.google.com/file/d/1j9KKy3Z2Jw5LAxK1a-PWNzUIhJj_-6H7/preview" width="100%" height="480" allow="autoplay"></iframe>
 
 ## How it works under the hood
 

--- a/docs/site/blog/2026-04-28-auto-sign.md
+++ b/docs/site/blog/2026-04-28-auto-sign.md
@@ -30,7 +30,54 @@ This preserves the security guarantees players expect: nobody can move their ass
 
 Auto-sign lives in the [`@effectstream/wallets`](https://www.npmjs.com/package/@effectstream/wallets) package, which provides multi-chain wallet support for EffectStream applications. The package handles the full delegation lifecycle: key generation, certificate signing, session management, and automatic signing of non-financial transactions.
 
-The wallet layer supports multiple chains (EVM via injected providers and Ethers, Cardano, Midnight, Polkadot, Algorand, and Mina), and auto-sign works across all of them through a unified API. Developers don't need chain-specific signing logic; the framework handles the differences.
+The wallet layer supports multiple chains (EVM via injected providers and Ethers, Cardano, Midnight, Polkadot, Algorand, and Mina), and auto-sign works across all of them through a unified API. Developers don't need chain-specific signing logic; the framework handles the differences. Full reference is in the [wallets documentation](/docs/home/components/wallets).
+
+The three-step flow in Safe Solver is representative of every game on midnight.fun:
+
+```typescript
+import {
+  WalletMode,
+  walletLogin,
+  allInjectedWallets,
+} from "@effectstream/wallets";
+
+// 1. Initialize a local session wallet, silent and persisted in
+//    encrypted browser storage. preferBatchedMode enables auto-sign.
+const localWalletResult = await walletLogin({
+  mode: WalletMode.EvmEthers,
+  preferBatchedMode: true,
+  connection: {
+    metadata: { name: "session", displayName: "Session Wallet" },
+    api: await getLocalSignerFromStorage(),
+  },
+});
+
+// 2. Let the user connect their real wallet (Midnight Lace in this
+//    example) — this is the only step that shows a pop-up.
+const injected = await allInjectedWallets({
+  signatureSupport: false,
+  transactionSupport: false,
+});
+const midnightWallet = injected[WalletMode.Midnight][0];
+const realWalletResult = await walletLogin({
+  mode: WalletMode.Midnight,
+  preference: { name: midnightWallet.metadata.name },
+});
+
+// 3. One-time delegation: the real wallet signs a message
+//    authorising the session wallet to submit non-financial inputs
+//    on its behalf. After this point, gameplay is silent.
+await effectStreamService.connectWallets(
+  localWalletResult.result,
+  realWalletResult.result,
+);
+
+// 4. Every subsequent game input is signed by the session wallet —
+//    no pop-ups for the rest of the session.
+await sendGameMove({ move: "x10y20" });
+```
+
+The signing model is uniform regardless of chain: `WalletMode.Midnight` could be swapped for `WalletMode.EvmInjected`, `WalletMode.Cardano`, or any other supported chain and the rest of the flow stays the same.
 
 ## Live on midnight.fun
 

--- a/docs/site/blog/2026-04-28-avail-data-availability.md
+++ b/docs/site/blog/2026-04-28-avail-data-availability.md
@@ -21,7 +21,7 @@ A DA layer like [Celestia](https://celestia.org/) provides an alternative: post 
 
 The Celestia integration adds a new data path to EffectStream's batcher system. The batcher aggregates individual user submissions into batches and posts them to Celestia for data availability, while settlement transactions go to the configured settlement chain.
 
-The integration is implemented in [PR #680](https://github.com/effectstream/effectstream/pull/680) ("Zswap DA Demo"), which includes:
+The integration lives in the [`bun-zswap-da` template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/bun-zswap-da), which includes:
 
 - **Batcher** that aggregates and posts batches to Celestia
 - **Database** tracking submitted batches, token states, and offer lifecycle
@@ -73,5 +73,5 @@ With Celestia support, developers can build hybrid applications:
 
 The developer configures which data goes where, and the framework handles routing, batching, and event delivery.
 
-- [Celestia integration PR #680](https://github.com/effectstream/effectstream/pull/680)
+- [Celestia integration code (`bun-zswap-da` template)](https://github.com/effectstream/effectstream/tree/v-next-bun-start/bun-zswap-da)
 - [Celestia documentation](https://celestia.org/developer-portal/)

--- a/docs/site/blog/2026-04-28-engine-integrations.md
+++ b/docs/site/blog/2026-04-28-engine-integrations.md
@@ -13,7 +13,7 @@ EffectStream is designed to integrate with any game engine or platform. This art
 
 One of the biggest friction points for multi-chain developers is setting up a local dev environment. Syncing a Cardano indexer like Carp can take days on testnet and even longer on mainnet, which makes rapid iteration pretty much impossible. We built a template that replaces this entire workflow with an instant localhost setup.
 
-The EVM-Cardano template, included in [PR #673](https://github.com/effectstream/effectstream/pull/673), combines:
+The EVM-Cardano template, [available in the monorepo](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/evm-cardano), combines:
 
 - [**Hardhat v3**](https://hardhat.org/) for EVM smart contract development and a local EVM chain
 - [**YACI DevKit**](https://github.com/bloxbean/yaci-devkit) for a local Cardano devnet
@@ -28,6 +28,61 @@ The template includes an explorer UI for interacting with the local environment.
 ![EVM-Cardano Explorer: mint NFTs, send ADA, cross-chain event feed](/img/blog/evm-cardano-2.png)
 
 This is a complete local dev environment for building cross-chain applications. Write smart contracts on both chains, test interactions between them, iterate fast. No testnet, no waiting for chain sync.
+
+### Controlling the stack: the orchestrator
+
+A multi-chain dev environment is not one process — it's six or seven, with dependencies between them: PGLite has to come up before the sync node, Dolos needs cardano-node, the contracts have to be deployed before the frontend can talk to them. We built `bunx orchestrator` as the master controller for this. It launches every process in dependency order, restarts individual ones, follows their logs, and silences the noisy ones, all from a single CLI.
+
+```text
+$ bunx orchestrator --help
+
+orchestrator — Bun-based process orchestration CLI
+
+Usage:
+  orchestrator <command> [options]
+
+Commands:
+  start   [config|name...]    Start all processes, or specific ones by name
+  status                      Show status of running processes
+  restart <name>              Restart a specific process by name
+  stop    [name]              Stop a specific process (or all if no name given)
+  list    [config]            List processes in config without starting them
+  silence [name...]           Suppress terminal output for processes
+  unsilence <name...>         Resume terminal output for processes
+  logs    [name...]           Follow background daemon log files (like tail -f)
+
+Global options:
+  -c, --config  <path>        Config file (default: auto-detected)
+  -h, --help                  Print help
+
+Options for `start`:
+  -b, --background            Run as a detached background daemon
+  -p, --port    <n>           Orchestrator API port (default: 4747)
+  -o, --only    <p1,p2,...>   Run only these processes (+ dependencies)
+  -e, --except  <p1,p2,...>   Skip these processes
+  -s, --serial                Launch one at a time instead of in parallel waves
+  --no-deps                   Launch only named processes, skip dependency resolution
+  --log-dir     <path>        Log directory when using -b (default: .orchestrator-logs)
+  --no-api                    Disable the HTTP API server
+  --silence     <p1,p2,...>   Suppress terminal output for these processes
+
+Options for `status`:
+  -f, --follow                Continuously refresh the status table (1s interval)
+```
+
+In practice, the developer workflow is just:
+
+```bash
+bunx orchestrator start              # bring up the whole stack
+bunx orchestrator status             # see what's running and what failed
+bunx orchestrator restart midnight-node   # bounce a single process
+bunx orchestrator logs sync-node     # tail the logs of one process
+bunx orchestrator stop               # tear everything down
+```
+
+The `--only` and `--except` flags let you run partial stacks — useful when you're iterating on the sync node and don't need the frontend rebuilding, or when you're testing the batcher in isolation. `--background` runs the whole orchestrator as a detached daemon with logs going to files, which is how the e2e test suite runs the same stack on CI.
+
+The point is that the same `bun run dev` command that boots the EVM-Cardano template also boots the cardano-delegation template, the zk-cardano template, and every other template in the monorepo — they all share the orchestrator and just declare a different process graph in their config.
 
 <iframe src="https://drive.google.com/file/d/1dmXshwpqeXi9sez5ekfqfrlXBdjVVABW/preview" width="100%" height="480" allow="autoplay"></iframe>
 
@@ -57,7 +112,7 @@ The most ambitious integration: a game template combining GPS location data for 
 
 The mobile app communicates with an EffectStream backend that manages on-chain state, while the mobile layer renders game objects at GPS-determined positions. It shows that EffectStream works well beyond the browser.
 
-- [Template code](https://github.com/PaimaStudios/paima-game-templates/pull/85)
+- [Template code (`paima-game-templates` repository)](https://github.com/PaimaStudios/paima-game-templates)
 
 <iframe src="https://drive.google.com/file/d/16IH6do2cyxigKaxL996TtGqMFwHZR3Xs/preview" width="100%" height="480" allow="autoplay"></iframe>
 
@@ -72,4 +127,5 @@ The mobile app communicates with an EffectStream backend that manages on-chain s
 
 All templates are open-source in the [game templates repository](https://github.com/PaimaStudios/paima-game-templates). The EVM-Cardano template with its Dolos-based local development stack is probably the most impactful: it removes the biggest barrier to Cardano development by getting rid of the sync time that's historically made local testing impractical.
 
-- [EffectStream PR #673](https://github.com/effectstream/effectstream/pull/673) - EVM-Cardano template with Dolos + YACI DevKit
+- [EVM-Cardano template code (Dolos + YACI DevKit)](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/evm-cardano)
+- [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)

--- a/docs/site/blog/2026-04-28-mina-zk-integration.md
+++ b/docs/site/blog/2026-04-28-mina-zk-integration.md
@@ -56,7 +56,7 @@ Here's the concept: a governance vote where voting power comes from your Cardano
 
 ![Private Delegation Voting: Cardano + Midnight cross-chain ZK voting with stake pool delegation](/img/blog/zk-cardano.png)
 
-This template is part of [PR #673](https://github.com/effectstream/effectstream/pull/673), which includes the full ZK-Cardano template alongside five new Cardano primitives.
+The full [ZK-Cardano template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/zk-cardano) is available in the monorepo alongside five new [Cardano primitives](/docs/home/chains/cardano#primitives).
 
 <iframe src="https://drive.google.com/file/d/1qeFPXN3cjsd66aFn-kgu2q8fqTr8SA-A/preview" width="100%" height="480" allow="autoplay"></iframe>
 
@@ -93,6 +93,7 @@ Beyond chain-integrated ZK, EffectStream also supports computing zero-knowledge 
 
 The trade-off is in verification: chain-verified proofs inherit the chain's security guarantees, while locally-verified proofs need the application to validate them. For many use cases (anti-cheat in games, client-side validation), local proofs are sufficient and quite a bit faster.
 
-- [EffectStream PR #673](https://github.com/effectstream/effectstream/pull/673) - ZK-Cardano template
+- [ZK-Cardano template code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/zk-cardano)
+- [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)
 - [Midnight Network](https://midnight.network/)
 - [UTxORPC Watch Module](https://utxorpc.org/watch/intro/) - streaming protocol for Cardano data

--- a/docs/site/blog/2026-04-28-nft-launchpad.md
+++ b/docs/site/blog/2026-04-28-nft-launchpad.md
@@ -32,7 +32,7 @@ EffectStream's NTP-based sync (instead of block-based) makes this practical. The
 The launchpad UI supports both EVM and Cardano wallets. Creators set up sales with configurable parameters (countdown timers, reward tiers, package bundles, item catalogs). Buyers browse campaigns, add items to a cart, and contribute funds from whichever chain they prefer.
 
 - [Launchpad portal components](https://github.com/PaimaStudios/paima-portal/tree/main/src/components/launchpad)
-- [Portal integration PR](https://github.com/PaimaStudios/paima-portal/pull/7)
+- [Portal repository](https://github.com/PaimaStudios/paima-portal)
 
 <iframe src="https://drive.google.com/file/d/1MiTyu_Et36zyE1qP7vWYG-2DEaUFyI-s/preview" width="100%" height="480" allow="autoplay"></iframe>
 

--- a/docs/site/blog/2026-04-28-projected-nfts.md
+++ b/docs/site/blog/2026-04-28-projected-nfts.md
@@ -36,7 +36,7 @@ We built a full dApp called Hololocker for projecting and managing NFTs. It supp
 
 To track NFT lock/unlock events in real-time, we originally built a [Carp](https://dcspark.github.io/carp/) indexer task. But Carp requires heavy synchronization (days on testnet, even longer on mainnet), which made rapid development impractical.
 
-We've since moved to [Dolos](https://github.com/txpipe/dolos) via the UTxORPC protocol. The new **ProjectedNFT primitive** in EffectStream reads projection events directly from Dolos's gRPC stream, parsing the datum to extract lock status, owner, policy ID, and asset name. This is part of [PR #673](https://github.com/effectstream/effectstream/pull/673), which introduces five new Cardano primitives backed by an IVM (Indexed View Materializer) with PostgreSQL materialized views.
+We've since moved to [Dolos](https://github.com/txpipe/dolos) via the UTxORPC protocol. The new **ProjectedNFT primitive** in EffectStream reads projection events directly from Dolos's gRPC stream, parsing the datum to extract lock status, owner, policy ID, and asset name. It is one of five new [Cardano primitives](/docs/home/chains/cardano#primitives) backed by an IVM (Indexed View Materializer) with PostgreSQL materialized views.
 
 The ProjectedNFT primitive tracks:
 - Lock events (NFT enters the projection contract)
@@ -54,7 +54,8 @@ A game could grant in-game powers when a player projects a specific NFT, remove 
 
 The integration is end-to-end tested with 21 E2E tests covering the full lifecycle: stake registration, delegation, lock, unlock, and claim, all verified against a local Dolos instance.
 
-- [EffectStream PR #673](https://github.com/effectstream/effectstream/pull/673)
+- [ProjectedNFT primitive source code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src)
+- [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)
 
 ## The full stack
 

--- a/docs/site/blog/2026-04-28-stakepool-delegation-batcher.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation-batcher.md
@@ -1,0 +1,317 @@
+---
+slug: stakepool-delegation-batcher
+title: "Stake Pool Delegation Part 3: Building a Pool-Aware Batcher"
+authors: [effectstream]
+tags: [cardano, stakepools, delegation, batcher, technical]
+---
+
+In [Part 1](/docs/blog/stakepool-delegation) we covered how EffectStream indexes delegation changes. In [Part 2](/docs/blog/stakepool-delegation-technical) we walked through the state machine that writes delegation events to PostgreSQL. Now we'll build on that foundation: a custom Batcher that reads delegation state from the database and decides whether to accept or reject user transactions based on which pool they're delegating to.
+
+This is the key use case for stake pool operators: **free transactions for your delegators**. The SPO runs a batcher that covers gas fees, but only for users delegating to their pool.
+
+<!-- truncate -->
+
+## What the Batcher does
+
+The EffectStream Batcher is a standalone service that:
+
+1. Receives user inputs via HTTP (`POST /send-input`)
+2. Validates each input using a chain-specific adapter
+3. Queues valid inputs in persistent storage
+4. Batches them into a single on-chain transaction when criteria are met
+5. Submits the batch and waits for confirmation
+
+The adapter is the extension point. By implementing a custom `BlockchainAdapter`, you control validation, serialization, and submission. For the delegation use case, we add a `validateInput()` method that queries the `delegations` table before accepting the input.
+
+See the full [Batcher documentation](/docs/home/components/batcher/overview) for the complete API.
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph User["User Request"]
+        direction LR
+        W["Wallet"] -->|"POST /send-input"| B["Batcher HTTP API"]
+    end
+
+    subgraph Validation["Pool-Aware Validation"]
+        direction LR
+        V["validateInput()"] -->|"SELECT"| DB["delegations table"]
+        DB -->|"pool match?"| D{"Delegating to\nallowed pool?"}
+    end
+
+    subgraph Batch["Batching & Submission"]
+        direction LR
+        Q["Queue"] --> CR["Criteria Check"] --> TX["Submit TX"]
+    end
+
+    User --> Validation
+    D -->|"Yes"| Batch
+    D -->|"No"| R["Reject: 'Not delegating to an enabled pool'"]
+```
+
+## 1. The delegation-aware adapter
+
+The core idea: extend the default EVM adapter with a `validateInput()` method that checks the user's delegation status before accepting their input. The batcher reads from the same `delegations` table that the sync node writes to (from [Part 2](/docs/blog/stakepool-delegation-technical)).
+
+```typescript
+import {
+  type BlockchainAdapter,
+  type DefaultBatcherInput,
+  type ValidationResult,
+  EffectStreamL2DefaultAdapter,
+} from "@effectstream/batcher";
+import { getDelegationsByAddress } from "@cardano-delegation/database";
+import type { Pool } from "pg";
+
+export class DelegationAwareBatcherAdapter
+  extends EffectStreamL2DefaultAdapter
+{
+  private readonly dbConn: Pool;
+  private readonly enabledPools: Set<string>;
+
+  constructor(
+    contractAddress: string,
+    privateKey: string,
+    fee: bigint,
+    syncProtocolName: string,
+    dbConn: Pool,
+    enabledPools: string[],
+  ) {
+    super(contractAddress, privateKey, fee, syncProtocolName);
+    this.dbConn = dbConn;
+    this.enabledPools = new Set(
+      enabledPools.map((p) => p.toLowerCase()),
+    );
+  }
+
+  async validateInput(
+    input: DefaultBatcherInput,
+  ): Promise<ValidationResult> {
+    // Look up the user's current delegation
+    const delegations = await getDelegationsByAddress.run(
+      { address: input.address },
+      this.dbConn,
+    );
+
+    if (delegations.length === 0) {
+      return {
+        valid: false,
+        error: "No delegation found for this address",
+      };
+    }
+
+    // Check if the most recent delegation is to an enabled pool
+    const latestDelegation = delegations[0];
+    if (!this.enabledPools.has(latestDelegation.pool.toLowerCase())) {
+      return {
+        valid: false,
+        error: `Not delegating to an enabled pool. ` +
+          `Current pool: ${latestDelegation.pool}`,
+      };
+    }
+
+    return { valid: true };
+  }
+}
+```
+
+The `getDelegationsByAddress` query is the same pgtyped query from Part 2 — it returns delegations ordered by `id DESC`, so `delegations[0]` is the most recent one.
+
+## 2. Configuring the batcher
+
+Wire the adapter into a batcher instance with the pool hashes you want to subsidize:
+
+```typescript
+import { main, suspend } from "effection";
+import {
+  createNewBatcher,
+  FileStorage,
+  type BatcherConfig,
+} from "@effectstream/batcher";
+import { getConnection } from "@effectstream/db";
+import { DelegationAwareBatcherAdapter } from "./delegation-adapter.ts";
+
+const ENABLED_POOLS = [
+  "7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57",
+  "82ec502f8c0a51e7c0db410e6722dd42df3b8e11f48e833f9fdf2941",
+];
+
+const dbConn = getConnection();
+
+const adapter = new DelegationAwareBatcherAdapter(
+  process.env.L2_CONTRACT_ADDRESS!,
+  process.env.BATCHER_PRIVATE_KEY!,
+  0n,                        // Free for delegators
+  "mainEvmRPC",
+  dbConn,
+  ENABLED_POOLS,
+);
+
+const config: BatcherConfig = {
+  pollingIntervalMs: 1000,
+  adapters: { evm: adapter },
+  defaultTarget: "evm",
+  batchingCriteria: {
+    evm: {
+      criteriaType: "hybrid",
+      timeWindowMs: 5000,      // Batch every 5 seconds
+      maxBatchSize: 50,        // Or when 50 inputs queue up
+    },
+  },
+  confirmationLevel: "wait-receipt",
+  enableHttpServer: true,
+  port: 3334,
+  enableEventSystem: true,
+};
+
+const batcher = createNewBatcher(config, new FileStorage("./batcher-data"));
+
+main(function* () {
+  batcher.addStateTransition("startup", ({ publicConfig }) => {
+    console.log(
+      `Pool-aware batcher started on port ${publicConfig.port}`,
+    );
+    console.log(
+      `Enabled pools: ${ENABLED_POOLS.length}`,
+    );
+  });
+
+  batcher.addStateTransition("batch:submit", ({ txHash }) => {
+    console.log(`Batch submitted: ${txHash}`);
+  });
+
+  yield* batcher.runBatcher();
+  yield* suspend();
+});
+```
+
+The `fee: 0n` means the SPO covers the cost. Users delegating to the enabled pools get free transactions. Users delegating elsewhere get rejected at the `validateInput()` step before their input even enters the queue.
+
+## 3. The validation flow
+
+When a user submits an input, the batcher pipeline processes it in order:
+
+1. **Targeting** — route to the correct adapter based on `input.target`
+2. **Signature verification** — verify the user's wallet signature (inherited from `EffectStreamL2DefaultAdapter`)
+3. **Input validation** — our custom `validateInput()` runs:
+   - Query `delegations` table by `input.address`
+   - Check if the latest delegation pool is in `enabledPools`
+   - Return `{ valid: true }` or `{ valid: false, error: "..." }`
+4. **Storage** — if valid, the input is persisted to disk
+5. **Batching** — when criteria are met, inputs are serialized and submitted
+
+A rejected input returns immediately with an error:
+
+```bash
+curl -X POST http://localhost:3334/send-input \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "address": "0x742d35Cc...",
+      "addressType": 0,
+      "input": "gameMove|x10y20",
+      "signature": "0x...",
+      "timestamp": "1234567890"
+    }
+  }'
+
+# If not delegating to an enabled pool:
+# { "success": false, "error": "Not delegating to an enabled pool. Current pool: abc123..." }
+
+# If delegating to an enabled pool:
+# { "success": true, "hash": "0x..." }
+```
+
+## 4. Batching criteria options
+
+The batcher supports multiple strategies for when to submit batches. Choose based on your game's requirements:
+
+```typescript
+// Time-based: submit every N milliseconds
+{ criteriaType: "time", timeWindowMs: 5000 }
+
+// Size-based: submit when N inputs are queued
+{ criteriaType: "size", maxBatchSize: 50 }
+
+// Hybrid: whichever comes first
+{ criteriaType: "hybrid", timeWindowMs: 5000, maxBatchSize: 50 }
+
+// Value-based: submit when accumulated value reaches threshold
+{
+  criteriaType: "value",
+  valueAccumulatorFn: (input) => parseFloat(input.input.split("|")[1]),
+  targetValue: 1000,
+}
+
+// Custom: any logic you want
+{
+  criteriaType: "custom",
+  isBatchReadyFn: (inputs, lastProcessTime) => {
+    // Process immediately if any high-priority input exists
+    return inputs.some((i) => i.input.startsWith("urgent|"));
+  },
+}
+```
+
+## 5. Adding event monitoring
+
+The batcher emits lifecycle events you can use for monitoring and observability:
+
+```typescript
+batcher.addStateTransition("startup", ({ publicConfig }) => {
+  console.log(`Batcher ready on port ${publicConfig.port}`);
+});
+
+batcher.addStateTransition("batch:submit", ({ txHash }) => {
+  console.log(`Batch submitted: ${txHash}`);
+});
+
+batcher.addStateTransition("batch:confirmed", ({ receipt }) => {
+  console.log(`Confirmed in block ${receipt.blockNumber}`);
+});
+
+batcher.addStateTransition("input:rejected", ({ error }) => {
+  console.warn(`Input rejected: ${error}`);
+});
+```
+
+## What SPOs can build with this
+
+With the delegation-aware batcher, stake pool operators can offer tangible benefits to their delegators:
+
+- **Free game transactions** — delegators play without paying gas fees, the SPO covers the cost
+- **Priority batching** — delegators of partner pools get their inputs processed first
+- **Tiered access** — different pools unlock different game features or areas
+- **Dynamic pricing** — charge non-delegators, subsidize delegators
+
+The configuration is straightforward: add your pool hash to `ENABLED_POOLS`, fund the batcher wallet, and point your game's frontend at the batcher endpoint. The delegation check happens automatically on every input.
+
+## Running the full stack
+
+The complete delegation + batcher stack requires both the sync node (indexing delegations) and the batcher (validating inputs) running together:
+
+```bash
+# Terminal 1: Start the delegation sync node (from Part 2)
+git clone https://github.com/effectstream/effectstream.git \
+  --branch v-next-bun-start
+cd effectstream/templates/cardano-delegation
+bun i
+bun run dev
+# Sync node indexes delegations → http://localhost:10599
+
+# Terminal 2: Start the pool-aware batcher
+cd packages/batcher
+bun run batcher.dev.ts
+# Batcher validates inputs → http://localhost:3334
+```
+
+Both services share the same PostgreSQL database (PGLite). The sync node writes delegation events; the batcher reads them during validation.
+
+---
+
+- [Batcher documentation](/docs/home/components/batcher/overview)
+- [Custom Adapters guide](/docs/home/components/batcher/adapter)
+- [Part 1: Connecting Cardano SPOs](/docs/blog/stakepool-delegation)
+- [Part 2: Building the State Machine](/docs/blog/stakepool-delegation-technical)
+- [Template source code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation)

--- a/docs/site/blog/2026-04-28-stakepool-delegation-midnight.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation-midnight.md
@@ -1,0 +1,221 @@
+---
+slug: stakepool-delegation-midnight
+title: "Stake Pool Delegation Part 4: Stake Pools as Chain Validators"
+authors: [effectstream]
+tags: [cardano, stakepools, delegation, midnight, partner-chains, technical]
+---
+
+In [Part 1](/docs/blog/stakepool-delegation) through [Part 3](/docs/blog/stakepool-delegation-batcher) we built a stack that **observes** Cardano delegation — index the certificates, persist them, gate user inputs on pool membership. The application reads delegation; delegation does not read the application. There is a more ambitious place to put stake pools, though: at the consensus layer of a chain itself. That is where Midnight lives. Once you go there, "react to delegation" stops being a feature flag inside a game and starts being block production for an entire ecosystem of games.
+
+<!-- truncate -->
+
+## From event consumer to consensus input
+
+The progression across this series goes like this:
+
+| Part | Role of delegation | Surface area |
+|------|--------------------|--------------|
+| 1 | Indexed event | A PostgreSQL row |
+| 2 | State machine input | An `addStateTransition` handler |
+| 3 | Batcher validation | An accept/reject decision per input |
+| 4 | **Consensus weight** | **Block production share on Midnight** |
+
+By Part 3 a stake pool delegation could already decide whether your transaction gets free batching. Part 4 raises the stakes: delegating to a registered SPO contributes to that pool's share of blocks produced on Midnight. The same delegation certificate now does two things at once — it routes ADA rewards on Cardano, and it weights consensus participation on a partner chain.
+
+## What a Partner Chain is
+
+Midnight is a [Partner Chain](https://github.com/input-output-hk/partner-chains). Partner Chains are blockchains that run in parallel to Cardano and inherit Cardano's security model by reusing its set of Stake Pool Operators as block producers. The Partner Chains Toolkit — built by IOG, the same engineering team behind Cardano itself — provides the off-chain CLI, on-chain Plutus scripts, and Substrate runtime pallets that turn a generic Substrate chain into a Cardano-anchored partner chain.
+
+The toolkit pulls three things from Cardano:
+
+1. **SPO registrations** — a Cardano transaction in which an SPO signs a message declaring they want to produce blocks on the partner chain.
+2. **Delegation stake** — read off Cardano's ledger via `db-sync`, used to weight how many blocks a registered SPO produces.
+3. **Governance parameters** — the *D-Parameter* and the permissioned validator whitelist, written to a Cardano script address and observed by the partner chain runtime.
+
+```mermaid
+flowchart TB
+    subgraph Cardano["Cardano Main Chain"]
+        direction LR
+        U["User"] -->|"Delegate ADA"| SP["Stake Pool"]
+        SP -->|"smart-contracts register"| CCV["CommitteeCandidateValidator"]
+        GOV["Governance Authority"] -->|"upsert-d-parameter"| DPV["DParameterValidator"]
+    end
+
+    subgraph Observability["Cardano Observability"]
+        direction LR
+        CN["cardano-node"] --> DB["db-sync"] --> PG[("PostgreSQL")]
+    end
+
+    subgraph Midnight["Midnight Partner Chain"]
+        direction LR
+        IDP["Inherent Data Providers"] --> ARI["Ariadne Selection"] --> COMM["Block Production Committee"] --> BP["Block Producer"]
+    end
+
+    subgraph Apps["Applications on Midnight"]
+        direction LR
+        G1["Game"] ~~~ G2["Game"] ~~~ G3["Game"]
+    end
+
+    Cardano --> Observability --> Midnight --> Apps
+```
+
+The arrows are not metaphorical. Every Midnight epoch, the runtime re-reads Cardano state — registrations from the `CommitteeCandidateValidator` address, the D-Parameter from `DParameterValidator`, the permissioned candidates list — and feeds them into [Ariadne](https://github.com/input-output-hk/partner-chains), the committee selection algorithm. Ariadne outputs the validator set for the next epoch. That set is what Aura (Substrate's slot-based consensus) uses to produce Midnight blocks.
+
+## How Cardano SPOs become Midnight validators
+
+The registration flow is intentionally permissionless. An SPO who wants to produce Midnight blocks runs three CLI commands from the Partner Chains Toolkit. The exact commands live in the toolkit documentation; the shape of the flow is:
+
+```bash
+# 1. Generate the registration signatures on an offline machine
+#    (cold keys never touch the internet)
+pc-node registration-signatures \
+  --genesis-utxo $GENESIS_UTXO \
+  --mainchain-signing-key cold.skey \
+  --sidechain-signing-key partner-chain.skey \
+  --registration-utxo $REGISTRATION_UTXO
+
+# 2. Submit the registration as a Cardano transaction
+pc-node smart-contracts register \
+  --genesis-utxo $GENESIS_UTXO \
+  --registration-utxo $REGISTRATION_UTXO \
+  --payment-key-file payment.skey \
+  --partner-chain-public-keys $PC_PUB:$AURA_PUB:$GRANDPA_PUB \
+  --partner-chain-signature $PC_SIG \
+  --spo-public-key $SPO_PUB \
+  --spo-signature $SPO_SIG
+
+# 3. Confirm activation — registrations made in epoch N
+#    become active in epoch N+2
+pc-node registration-status \
+  --stake-pool-pub-key $SPO_PUB \
+  --mc-epoch-number $EPOCH
+```
+
+What lands on Cardano after step 2 is a UTXO at the `CommitteeCandidateValidator` script address, with a datum that carries the SPO's main-chain public key, their partner-chain public key, their Aura and Grandpa session keys, and the cross-signature proving the same operator controls both sides. Midnight's runtime reads that datum every epoch and treats it as a vote: "I, this SPO, with my Cardano delegators behind me, want to produce blocks on this chain."
+
+The crucial property is that **the stake weight comes from Cardano's ledger, not from a token on Midnight**. There is no separate "Midnight validator stake" to bond. The delegators who already delegated their ADA to that SPO on Cardano are — without any extra action — backing the SPO's block production on Midnight.
+
+## The D-Parameter: governance over the registered/permissioned ratio
+
+Block producers on a partner chain come from two pools:
+
+- **Registered validators** — Cardano SPOs who completed the registration flow above.
+- **Permissioned validators** — a whitelist maintained by the chain's governance authority, intended to bootstrap the network when SPO registrations are still rolling in.
+
+The split between them is governed by a single on-chain value, the **D-Parameter**, written to Cardano via:
+
+```bash
+pc-node smart-contracts upsert-d-parameter \
+  --permissioned-candidates-count 3 \
+  --registered-candidates-count 7 \
+  --payment-key-file governance.skey \
+  --genesis-utxo $GENESIS_UTXO
+```
+
+This particular setting reserves 3 of the 10 committee seats per epoch for permissioned validators and lets the remaining 7 be filled by registered SPOs proportional to delegation stake. The two-epoch delay before changes take effect gives the network a stable window to observe new parameters before they apply.
+
+A chain typically launches near `permissioned=N, registered=0` and ramps toward `permissioned=0, registered=N` as SPO registrations stabilise. This is the same decentralisation curve Cardano itself walked from Byron through Shelley, but governed transparently on-chain instead of by a hard fork.
+
+## Querying partner chain state from EffectStream
+
+Everything above is observable, which means application code can read it. The Partner Chains Toolkit exposes the relevant state via CLI commands and JSON-RPC. For an EffectStream app running on top of (or alongside) a partner chain, the two queries that matter for delegation-aware logic are:
+
+- **`ariadne-parameters --mc-epoch-number N`** — returns the registered candidates, the permissioned candidates, the D-Parameter, and the delegation stakes effective at epoch *N*. Use this to find out which SPOs are actually producing blocks right now.
+- **`registration-status --stake-pool-pub-key K --mc-epoch-number N`** — returns whether SPO `K` is registered and active at epoch *N*. Use this to gate features on whether a specific pool has joined the partner chain.
+
+Wired into a state machine transition, these become first-class inputs alongside the `delegations` table from Part 2:
+
+```typescript
+import { World } from "@effectstream/runtime";
+import {
+  getDelegationsByAddress,
+  getActivePartnerChainSPOs,
+} from "@cardano-delegation/database";
+import {
+  fetchAriadneParameters,
+  type AriadneParameters,
+} from "@effectstream/partner-chains";
+
+stm.addStateTransition("delegation-bonus", function* (data) {
+  const { address } = data.parsedInput as { address: string };
+
+  // 1. Cardano side: where is this address currently delegating?
+  const delegations = yield* World.resolve(
+    getDelegationsByAddress, { address },
+  );
+  if (delegations.length === 0) return;
+  const userPool = delegations[0].pool.toLowerCase();
+
+  // 2. Partner-chain side: which SPOs are in the active committee
+  //    for the current Cardano epoch?
+  const epoch = slotToEpoch(data.blockHeight);
+  const params: AriadneParameters = yield* fetchAriadneParameters({
+    mcEpochNumber: epoch,
+  });
+  const activeProducers = new Set(
+    params.registeredCandidates.map((c) =>
+      c.stakePoolPubKey.toLowerCase()
+    ),
+  );
+
+  // 3. Game-side: if the user's delegated SPO is actively producing
+  //    blocks on the partner chain this epoch, grant a bonus.
+  if (activeProducers.has(userPool)) {
+    yield* World.resolve(grantBonus, {
+      address,
+      pool: userPool,
+      epoch,
+      multiplier: 2.0,
+      reason: "active-validator-delegator",
+    });
+  }
+});
+```
+
+What this handler captures is the full loop:
+
+1. The user delegated ADA to an SPO on Cardano (Part 1 indexed it).
+2. The state machine wrote that delegation to PostgreSQL (Part 2).
+3. The SPO registered on the partner chain and is now in the block-production committee.
+4. The application reads both sides and rewards the user proportional to consensus participation, not just delegation existence.
+
+A user who switches to a non-registered pool keeps earning Cardano staking rewards but loses the application-side bonus. A user who switches to a pool that just got into the committee for next epoch picks it up automatically two epochs later — the same cadence Cardano itself uses for stake-distribution snapshots.
+
+## Cross-chain identity: associating Cardano and partner-chain addresses
+
+One more piece of the Partner Chains Toolkit is worth pointing at because it makes everything above clean to use: address association. A user with a Cardano stake address and a partner-chain address can sign a message linking the two, then submit the signature to the partner-chain ledger:
+
+```bash
+pc-node sign-address-association \
+  --genesis-utxo $GENESIS_UTXO \
+  --partnerchain-address $PC_ADDRESS \
+  --signing-key cardano-stake.skey
+```
+
+Once associated, application code on the partner chain can resolve `partner-chain address → Cardano stake address → current delegation` without the user re-signing anything per session. For games this matters more than it sounds: it removes a per-transaction wallet prompt from the loop, and combined with the auto-sign work from [the wallets release](/docs/blog/auto-sign), it gives delegators a friction-free path from "I stake to this pool on Cardano" to "I have the right state inside this game on Midnight."
+
+## What runs on this today
+
+The applications already deployed on Midnight are the proof that this is not a thought experiment. Four games — Safe Solver, Kachina Kolosseum, Block Kart Legends, and Dust-2-Dust — run on a chain whose validator set is selected from registered Cardano SPOs by Ariadne, and whose epoch boundaries are tied to Cardano's. We covered the games themselves in the [game templates post](/docs/blog/game-templates); the point here is that the consensus underneath them is *the same delegation system we spent Parts 1–3 indexing from inside an application*. The difference in Part 4 is that the chain itself does the reading.
+
+For SPOs the practical consequence is a second product line:
+
+- Each new partner chain is another network where their existing delegators carry over.
+- Each application on those chains is another place where their delegators can collect benefits.
+- Registration is permissionless and observable; deregistration is symmetric.
+- Block participation rewards (covered in the Partner Chains Toolkit's `block-participation-rewards` module) flow back to delegators in the partner chain's native token.
+
+The outreach mechanic is the registration mechanic. SPOs don't need a marketing pitch from us to participate — they need a Cardano transaction and two epochs of patience.
+
+## Wrap-up
+
+Four parts in, the story has gone from "watch a UTXO change" to "weight a consensus committee." The same `pool` field that started as a string in a `delegations` row in Part 1 ends up, in Part 4, as a vote that decides who produces the next block on a chain that hosts production games. The indexing layer, the state machine, and the batcher we built in Parts 1–3 still apply on top — they just now sit on a chain that already shares their assumption that stake pool delegation is a first-class signal.
+
+---
+
+- [Part 1: Connecting Cardano SPOs](/docs/blog/stakepool-delegation)
+- [Part 2: Building the State Machine](/docs/blog/stakepool-delegation-technical)
+- [Part 3: Building a Pool-Aware Batcher](/docs/blog/stakepool-delegation-batcher)
+- [Partner Chains Toolkit](https://github.com/input-output-hk/partner-chains)
+- [Partner Chains Rust docs](https://input-output-hk.github.io/partner-chains/)
+- [Game templates running on Midnight](/docs/blog/game-templates)

--- a/docs/site/blog/2026-04-28-stakepool-delegation-technical.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation-technical.md
@@ -1,0 +1,379 @@
+---
+slug: stakepool-delegation-technical
+title: "Stake Pool Delegation Part 2: Building a Delegation State Machine"
+authors: [effectstream]
+tags: [cardano, stakepools, delegation, dolos, utxorpc, technical]
+---
+
+A step-by-step walkthrough of how the EffectStream [cardano-delegation template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation) works internally. We'll trace the full path from raw Cardano blocks to application state, covering the config, primitive, grammar, state machine, database, and API layers.
+
+<!-- truncate -->
+
+## Architecture overview
+
+The delegation template is a complete EffectStream application. It connects to a local Cardano devnet (YACI DevKit + Dolos), watches for delegation certificates, and stores them in PostgreSQL. The orchestrator spins up all infrastructure with a single `bun run dev`.
+
+```
+Cardano (YACI DevKit)
+    → Dolos (UTxORPC gRPC)
+        → EffectStream Sync Node
+            → PoolDelegation Primitive (extracts certificates)
+                → State Machine (writes to DB)
+                    → REST API (reads from DB)
+                        → Frontend (Delegation Explorer)
+```
+
+## 1. Configuration: connecting the chains
+
+The config defines two networks and two sync protocols. The NTP network provides the main clock, while the Cardano network connects to Dolos via UTxORPC:
+
+```typescript
+// packages/node/config.dev.ts
+export const config = new ConfigBuilder()
+  .setNamespace((builder) =>
+    builder.setSecurityNamespace("cardano-delegation")
+  )
+  .buildNetworks((builder) =>
+    builder
+      .addNetwork({
+        name: "ntp",
+        type: ConfigNetworkType.NTP,
+        startTime: launchStartTime ?? new Date().getTime(),
+        blockTimeMS: 1000,
+      })
+      .addNetwork({
+        name: "yaci",
+        type: ConfigNetworkType.CARDANO,
+        nodeUrl: "http://127.0.0.1:10000",
+        network: "yaci",
+      }),
+  )
+  .buildSyncProtocols((builder) =>
+    builder
+      .addMain(
+        (networks) => networks.ntp,
+        () => ({
+          name: mainSyncProtocolName,
+          type: ConfigSyncProtocolType.NTP_MAIN,
+          chainUri: "",
+          startBlockHeight: 1,
+          pollingInterval: 1000,
+        }),
+      )
+      .addParallel(
+        (networks) => (networks as any).yaci,
+        () => ({
+          name: "parallelUtxoRpc",
+          type: ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL,
+          rpcUrl: "http://127.0.0.1:50051",
+          startChainPoint: "origin",
+          confirmationDepth: 0,
+          delayMs: yaciDevKitStartTime ?? 0,
+          pollingInterval: 1000,
+          headers: { "x-rpc-key": "dev" },
+        }),
+      ),
+  )
+```
+
+The key detail is `CARDANO_UTXORPC_PARALLEL` — this tells EffectStream to use a parallel sync protocol that streams blocks from Dolos via gRPC, independently of the main NTP clock. The `confirmationDepth: 0` means we process blocks immediately (appropriate for a local devnet).
+
+## 2. The primitive: filtering and extracting delegation certificates
+
+The primitive is registered in the config with a pool filter:
+
+```typescript
+// packages/node/config.dev.ts
+.buildPrimitives((builder) =>
+  builder.addPrimitive(
+    (syncProtocols) => (syncProtocols as any).parallelUtxoRpc,
+    () => ({
+      name: "CardanoPoolDelegation",
+      type: PrimitiveTypeCardanoPoolDelegation,
+      startBlockHeight: 1,
+      stateMachinePrefix: "cardano-pool-delegation",
+      pools: [
+        "7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57",
+        "82ec502f8c0a51e7c0db410e6722dd42df3b8e11f48e833f9fdf2941",
+      ],
+      network: "yaci",
+    }),
+  ),
+)
+```
+
+The `pools` array filters which delegation events to track. Only delegations to these specific pool operator keyhashes will reach the state machine. Remove the filter to track all pools.
+
+Under the hood, the primitive uses a UTxORPC predicate to tell Dolos to only send transactions containing certificates — filtering out the vast majority of transfer-only transactions at the gRPC level:
+
+```typescript
+// CardanoPoolDelegationPrimitive.getConfig()
+predicate: { match: { cardano: { has_certificate: true } } }
+```
+
+The `getPayload()` method then iterates the certificates array, handling both pre-Conway (`stakeDelegation`) and Conway-era (`stakeRegDelegCert`, `stakeVoteDelegCert`) certificate types:
+
+```typescript
+// CardanoPoolDelegationPrimitive.getPayload()
+for (const cert of tx.certificates) {
+  const c = cert.certificate;
+  if (c.case !== "stakeDelegation"
+    && c.case !== "stakeRegDelegCert"
+    && c.case !== "stakeVoteDelegCert") continue;
+
+  const cred = stakeCredentialToHex(deleg.stakeCredential);
+  const poolKeyhash = uint8ArrayToHexString(deleg.poolKeyhash);
+
+  // Filter by configured pools (skip if not in our watch list)
+  if (this.pools.length > 0
+    && !this.pools.includes(poolKeyhash.toLowerCase())) continue;
+
+  // Generate state machine input from the grammar
+  const stateMachinePayload = generateRawStmInput(
+    this.grammar, this.stateMachinePrefix, {
+      address: cred.hash,
+      pool: poolKeyhash,
+      epoch: String(slotToEpoch(absoluteSlot, this.network)),
+    }
+  );
+}
+```
+
+## 3. The grammar: defining the input shape
+
+The grammar is a TypeBox schema that defines the shape of data flowing from the primitive into the state machine. It's intentionally minimal:
+
+```typescript
+// packages/node/grammar.ts
+import { builtinGrammars } from "@effectstream/sm/grammar";
+
+export const grammar = {
+  "cardano-pool-delegation": builtinGrammars.cardanoPoolDelegation,
+} as const satisfies GrammarDefinition;
+```
+
+The built-in grammar resolves to:
+
+```typescript
+// pool-delegation-grammar.ts
+export const poolDelegationGrammar = [
+  ["address", Type.String()],  // staking credential hash (hex)
+  ["pool", Type.String()],     // pool operator keyhash (hex)
+  ["epoch", Type.String()],    // computed from slot + network params
+] as const;
+```
+
+The grammar key `"cardano-pool-delegation"` matches the `stateMachinePrefix` in the primitive config. This is how EffectStream routes primitive outputs to the correct state machine transition.
+
+## 4. The state machine: turning events into application state
+
+This is where on-chain data becomes application state. The state machine receives parsed delegation events and writes them to PostgreSQL:
+
+```typescript
+// packages/node/state-machine.ts
+const stm = new Stm<typeof grammar, {}>(grammar);
+
+stm.addStateTransition("cardano-pool-delegation", function* (data) {
+  const { address, pool, epoch } = data.parsedInput as {
+    address: string;
+    pool: string;
+    epoch: string;
+  };
+
+  if (!address || !pool) return;
+
+  // Insert the delegation record
+  yield* World.resolve(insertDelegation, {
+    block_height: data.blockHeight,
+    address,
+    pool,
+    epoch,
+    tx_hash: null,
+  });
+
+  // Update aggregate pool statistics
+  yield* World.resolve(updatePoolStats, {
+    pool,
+    latest_epoch: epoch,
+    latest_block: data.blockHeight,
+  });
+});
+```
+
+`World.resolve()` executes a [pgtyped](https://pgtyped.dev/) prepared query inside the EffectStream coroutine context. The queries run in the same transaction as the block processing, so if anything fails, the entire block rolls back cleanly.
+
+The `gameStateTransitions` export wires this into the EffectStream runtime:
+
+```typescript
+// packages/node/state-machine.ts
+export const gameStateTransitions: StartConfigGameStateTransitions =
+  function* (
+    blockHeight: number,
+    input: BaseStfInput,
+  ): SyncStateUpdateStream<void> {
+    yield* stm.processInput(input);
+  };
+```
+
+## 5. Database schema
+
+The database has two tables — raw delegation events and aggregate pool statistics:
+
+```sql
+-- packages/database/migrations/000-init.sql
+CREATE TABLE delegations (
+  id SERIAL PRIMARY KEY,
+  block_height INTEGER NOT NULL,
+  address TEXT NOT NULL,
+  pool TEXT NOT NULL,
+  epoch TEXT NOT NULL,
+  tx_hash TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_delegations_pool ON delegations(pool);
+CREATE INDEX idx_delegations_address ON delegations(address);
+
+CREATE TABLE pool_stats (
+  pool TEXT PRIMARY KEY,
+  total_delegators INTEGER NOT NULL DEFAULT 0,
+  latest_epoch TEXT NOT NULL DEFAULT '0',
+  latest_block INTEGER NOT NULL DEFAULT 0
+);
+```
+
+The `pool_stats` table is maintained by an upsert query that recalculates `total_delegators` on each new delegation:
+
+```sql
+INSERT INTO pool_stats (pool, total_delegators, latest_epoch, latest_block)
+VALUES (:pool!, 1, :latest_epoch!, :latest_block!)
+ON CONFLICT (pool) DO UPDATE SET
+  total_delegators = (
+    SELECT COUNT(DISTINCT address) FROM delegations WHERE pool = :pool!
+  ),
+  latest_epoch = GREATEST(pool_stats.latest_epoch, :latest_epoch!),
+  latest_block = GREATEST(pool_stats.latest_block, :latest_block!)
+```
+
+## 6. REST API
+
+The API layer exposes delegation data over HTTP. It's a standard Fastify router registered with the EffectStream runtime:
+
+```typescript
+// packages/node/api.ts
+export const apiRouter: StartConfigApiRouter = async function (
+  server: FastifyInstance,
+  dbConn: Pool,
+): Promise<void> {
+  // All delegations (paginated)
+  server.get("/api/delegations", async (request, reply) => {
+    const { limit = "50", offset = "0" } = request.query as {
+      limit?: string; offset?: string;
+    };
+    const result = await getDelegations.run(
+      { limit: Number(limit), offset: Number(offset) }, dbConn,
+    );
+    reply.send(result);
+  });
+
+  // Delegations filtered by pool
+  server.get("/api/delegations/:pool", async (request, reply) => {
+    const { pool } = request.params as { pool: string };
+    const result = await getDelegationsByPool.run(
+      { pool, limit: Number(limit), offset: Number(offset) }, dbConn,
+    );
+    reply.send(result);
+  });
+
+  // Delegations filtered by staking address
+  server.get("/api/delegations/by-address/:address", ...);
+
+  // Aggregate pool statistics
+  server.get("/api/pool-stats", ...);
+
+  // Current sync heights
+  server.get("/api/block-heights", ...);
+};
+```
+
+## 7. Putting it all together: the entry point
+
+The entry point wires config, grammar, state machine, API, and migrations into the EffectStream runtime:
+
+```typescript
+// packages/node/main.dev.ts
+import { init, start } from "@effectstream/runtime";
+import { main, suspend } from "effection";
+
+main(function* () {
+  yield* init();
+  yield* withEffectstreamStaticConfig(config, function* () {
+    yield* start({
+      appName: "cardano-delegation",
+      appVersion: "1.0.0",
+      syncInfo: toSyncProtocolWithNetwork(config),
+      gameStateTransitions,
+      migrations: migrationTable,
+      apiRouter,
+      grammar,
+    });
+  });
+  yield* suspend();
+});
+```
+
+## 8. The orchestrator: one command to run everything
+
+The `start.dev.ts` orchestrator config launches the full stack in dependency order:
+
+1. **PGLite** — embedded PostgreSQL (no external DB needed)
+2. **YACI DevKit** — local Cardano devnet with instant block production
+3. **Dolos** — lightweight Cardano node exposing UTxORPC gRPC
+4. **Register test pool** — registers a second stake pool on the devnet
+5. **Sync node** — the EffectStream application (config + state machine + API)
+6. **Frontend** — builds and serves the Delegation Explorer dApp
+
+```bash
+git clone https://github.com/effectstream/effectstream.git \
+  --branch v-next-bun-start
+cd effectstream/templates/cardano-delegation
+bun i
+bun run dev
+# Open http://localhost:10599
+```
+
+The orchestrator handles dependency ordering, port management, health checks, and graceful shutdown. Developers only need [Bun](https://bun.sh/) installed.
+
+## Extending the template
+
+To add your own delegation logic, modify the state machine transition in `packages/node/state-machine.ts`. The `data` object gives you:
+
+- `data.parsedInput` — the delegation event (`address`, `pool`, `epoch`)
+- `data.blockHeight` — the block number
+- `data.blockTimestamp` — the block timestamp
+
+For example, to unlock content for delegators of a specific pool:
+
+```typescript
+stm.addStateTransition("cardano-pool-delegation", function* (data) {
+  const { address, pool } = data.parsedInput as {
+    address: string; pool: string; epoch: string;
+  };
+
+  // Your custom logic here
+  if (pool === PARTNER_POOL_HASH) {
+    yield* World.resolve(unlockPremiumContent, {
+      address,
+      block_height: data.blockHeight,
+    });
+  }
+
+  yield* World.resolve(insertDelegation, { ... });
+});
+```
+
+---
+
+- [Template source code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation)
+- [PoolDelegation primitive source](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src/cardano-pool-delegation)
+- [Overview blog post](/docs/blog/stakepool-delegation)
+- [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)

--- a/docs/site/blog/2026-04-28-stakepool-delegation.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation.md
@@ -1,6 +1,6 @@
 ---
 slug: stakepool-delegation
-title: "Stake Pool Delegation: Connecting Cardano SPOs to On-Chain Applications"
+title: "Stake Pool Delegation Part 1: Connecting Cardano SPOs to On-Chain Applications"
 authors: [effectstream]
 tags: [cardano, stakepools, delegation, dolos, utxorpc]
 ---
@@ -11,25 +11,27 @@ Cardano's stake pool ecosystem has millions of ADA delegated across hundreds of 
 
 ```mermaid
 flowchart TB
-    subgraph "Cardano Network"
-        U["👤 User"] -->|"Delegate ADA"| SP["Stake Pool"]
-        SP --> CN[Cardano Node]
+    subgraph Cardano["Cardano Network"]
+        direction LR
+        U["User"] -->|"Delegate ADA"| SP["Stake Pool"] --> CN["Cardano Node"]
     end
 
-    subgraph "Indexing Layer"
-        CN --> Dolos
-        Dolos -->|"gRPC stream\n(by delegation part)"| W[UTxORPC Watch]
+    subgraph Indexing["Indexing Layer"]
+        direction LR
+        Dolos -->|"gRPC stream"| W["UTxORPC Watch"]
     end
 
-    subgraph "EffectStream"
-        W --> PD["PoolDelegation Primitive"]
-        PD --> IVM["IVM (PostgreSQL)"]
-        IVM --> SM["L2 State Machine"]
+    subgraph ES["EffectStream"]
+        direction LR
+        PD["PoolDelegation Primitive"] --> IVM["IVM (PostgreSQL)"] --> SM["L2 State Machine"]
     end
 
-    SM --> R1["🔓 Unlock content"]
-    SM --> R2["🎁 Distribute rewards"]
-    SM --> R3["⚡ Free batching"]
+    subgraph App["Application Logic"]
+        direction LR
+        R1["Unlock content"] ~~~ R2["Distribute rewards"] ~~~ R3["Free batching"]
+    end
+
+    Cardano --> Indexing --> ES --> App
 ```
 
 ## The challenge: indexing delegation state

--- a/docs/site/blog/2026-04-28-stakepool-delegation.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation.md
@@ -67,7 +67,7 @@ And this is the terminal output showing EffectStream detecting delegation change
 
 ![Terminal showing delegation side effects being detected in real-time](/img/blog/delegate-pool2.png)
 
-<iframe src="https://drive.google.com/file/d/1DvNhISjGyhZW93bcKLKl8akLl9iJfLc3/preview" width="100%" height="480" allow="autoplay"></iframe>
+<iframe src="https://drive.google.com/file/d/1KrFfkgRWf_OKqH6agM6T44NyPS5aIqAc/preview" width="100%" height="480" allow="autoplay"></iframe>
 
 ## What developers can build
 

--- a/docs/site/blog/2026-04-28-stakepool-delegation.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation.md
@@ -50,7 +50,7 @@ For stake pool delegation, the "by delegation part" filter is the important one.
 
 ## The PoolDelegation primitive
 
-The new **PoolDelegation** primitive is part of [PR #673](https://github.com/effectstream/effectstream/pull/673), which adds five Cardano primitives to EffectStream. PoolDelegation reads delegation events from Dolos via UTxORPC and materializes them into PostgreSQL using EffectStream's IVM (Indexed View Materializer).
+The **PoolDelegation** primitive is one of [five Cardano primitives](https://github.com/effectstream/effectstream/tree/v-next-bun/packages/node-sdk/sm/primitives/src) in EffectStream. It reads delegation events from Dolos via UTxORPC and materializes them into PostgreSQL using EffectStream's IVM (Indexed View Materializer). See the [Cardano Primitives documentation](/docs/home/chains/cardano#primitives) for the full reference.
 
 The primitive tracks:
 - **Stake registrations** - new stake addresses entering the system
@@ -80,12 +80,14 @@ With delegation data flowing into the state machine, developers can build game l
 
 ## End-to-end testing
 
-The PoolDelegation primitive is covered by EffectStream's E2E test suite, part of 21 tests in PR #673 that verify the full Cardano primitive lifecycle. The delegation tests cover stake address registration, initial delegation to a pool, delegation change detection, and state verification in PostgreSQL materialized views. All tests run against a local Dolos instance with YACI DevKit, so CI runs fast with no mainnet or testnet dependencies.
+The PoolDelegation primitive is covered by EffectStream's [E2E test suite](https://github.com/effectstream/effectstream/tree/v-next-bun/e2e), which verifies the full Cardano primitive lifecycle. The delegation tests cover stake address registration, initial delegation to a pool, delegation change detection, and state verification in PostgreSQL materialized views. All tests run against a local Dolos instance with YACI DevKit, so CI runs fast with no mainnet or testnet dependencies.
 
 ## The bigger picture
 
 Stake pool delegation becomes a game mechanic. SPOs offer in-game benefits, players choose pools based on gameplay advantages, and a new economic layer sits on top of Cardano's existing delegation system. Delegation goes from a passive yield-earning activity to an active strategic decision: you delegate to a pool not just for staking rewards, but for the games and apps that pool supports.
 
-- [EffectStream PR #673](https://github.com/effectstream/effectstream/pull/673) - PoolDelegation primitive implementation
+- [PoolDelegation primitive source](https://github.com/effectstream/effectstream/tree/v-next-bun/packages/node-sdk/sm/primitives/src/cardano-pool-delegation) - implementation
+- [Cardano delegation template](https://github.com/effectstream/effectstream/tree/v-next-bun/templates/cardano-delegation) - starter project
+- [Cardano Primitives documentation](/docs/home/chains/cardano#primitives) - full reference for all five Cardano primitives
 - [UTxORPC Watch Module](https://utxorpc.org/watch/intro/) - streaming transaction protocol
 - [Dolos](https://github.com/txpipe/dolos) - lightweight Cardano node

--- a/docs/site/blog/2026-04-28-user-experience-integrations.md
+++ b/docs/site/blog/2026-04-28-user-experience-integrations.md
@@ -36,8 +36,8 @@ The wallet signature popup in the screenshot shows the on-chain integration. The
 
 The AI doesn't just give a score; it explains its reasoning. Players can see why their answer earned or lost tokens, which creates an engaging feedback loop that feels more like a conversation than a multiple-choice quiz.
 
-- [Play live](https://taiko-demo.paimastudios.com/)
-- [Template code](https://github.com/PaimaStudios/paima-game-templates/pull/78)
+- [Play live](https://tokenquest.zkdojo.com/)
+- [Template code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/shinkai-v2)
 
 ## Why this matters for on-chain games
 

--- a/docs/site/docs/home/100-components/118-primitives.md
+++ b/docs/site/docs/home/100-components/118-primitives.md
@@ -50,6 +50,11 @@ A key advantage of built-in primitives is that many come with automatic database
 | **`PrimitiveTypeEVMERC1155`**| EVM | Tracks `TransferSingle` and `TransferBatch` events for an ERC1155 token. |
 | **`PrimitiveTypeMidnightGeneric`**| Midnight | Monitors the public `ledger` state of a Midnight ZK contract for changes. |
 | **`PrimitiveTypeAvailGeneric`** | Avail | Listens for generic data blobs submitted to a specific application ID on the Avail DA layer. |
+| **`PrimitiveTypeCardanoDelayedAsset`** | Cardano | Tracks creation and spending of native asset UTxOs with a real-time view of unspent holdings. |
+| **`PrimitiveTypeCardanoMintBurn`** | Cardano | Captures native token mint and burn events with transaction metadata and participant addresses. |
+| **`PrimitiveTypeCardanoPoolDelegation`** | Cardano | Tracks stake pool delegation changes with current delegation state per staking credential. |
+| **`PrimitiveTypeCardanoProjectedNFT`** | Cardano | Tracks NFT lock-unlock-claim lifecycle at a Plutus script (hololocker) with time-lock metadata. |
+| **`PrimitiveTypeCardanoTransfer`** | Cardano | Captures ADA and native asset transfers with full output details and input credentials. |
 | **`PrimitiveTypeBitcoinAddress`** | Bitcoin | Watches a specific Bitcoin address for UTXO inputs and outputs. |
 | **`PrimitiveTypeCelestiaGeneric`** | Celestia | Listens for data blobs in a specific Celestia namespace. |
 | **`PrimitiveTypeNEARNEP141`** | NEAR | Tracks NEP-141 fungible token `ft_transfer` events and maintains balance tables. |

--- a/docs/site/docs/home/200-chains/203-cardano.md
+++ b/docs/site/docs/home/200-chains/203-cardano.md
@@ -33,8 +33,181 @@ EffectStream supports syncing via **UTXO-RPC** (using Dolos/Yaci) or **Carp**.
 ```
 
 ### Primitives
-EffectStream provides primitives to track specific UTXO patterns, policy IDs (Native Assets), or metadata labels.
-*(Note: Check `@effectstream/sm/builtin` for the latest list of available Cardano primitives)*.
+
+All Cardano primitives use [Dolos](https://github.com/txpipe/dolos) via the UTxORPC Watch module for real-time transaction streaming. Each primitive specifies a UTxORPC predicate that filters transactions at the source, so only relevant data reaches your application.
+
+```ts
+import {
+  PrimitiveTypeCardanoDelayedAsset,
+  PrimitiveTypeCardanoMintBurn,
+  PrimitiveTypeCardanoPoolDelegation,
+  PrimitiveTypeCardanoProjectedNFT,
+  PrimitiveTypeCardanoTransfer,
+} from "@effectstream/sm/builtin";
+```
+
+#### Delayed Asset (`PrimitiveTypeCardanoDelayedAsset`)
+
+Tracks the creation and spending of native asset UTxOs. "Delayed" refers to asset ownership only becoming final after on-chain confirmation (unlike account-model chains with instant balance updates). The primitive uses the `moves_asset` UTxORPC predicate filtered by policy ID.
+
+Maintains an **IVM materialized view** (`cardano_asset_utxos_view_<name>`) with current unspent asset holdings — INSERTs on UTxO creation, DELETEs on spending.
+
+```ts
+.buildPrimitives(builder =>
+  builder.addPrimitive(
+    (sp) => sp.parallelUtxoRpc,
+    () => ({
+      name: "MyNativeAsset",
+      type: PrimitiveTypeCardanoDelayedAsset,
+      startBlockHeight: 1,
+      stateMachinePrefix: "cardano-asset",
+      policyIds: ["abcdef1234..."], // filter by policy ID
+      network: "yaci",
+    }),
+  )
+)
+```
+
+**Payload fields:**
+
+| Field | Description |
+| :--- | :--- |
+| `address` | Recipient/owner address |
+| `txId` | Transaction hash |
+| `outputIndex` | Output position in the transaction |
+| `cip14Fingerprint` | CIP-14 asset fingerprint (policy ID + asset name) |
+| `amount` | Quantity (`null` signals the UTxO was spent) |
+| `policyId` | Native asset policy ID |
+| `assetName` | Asset name (hex-encoded) |
+
+#### Mint/Burn (`PrimitiveTypeCardanoMintBurn`)
+
+Captures native token minting and burning events. Positive quantities indicate mints; negative indicate burns. Uses the `mints_asset` UTxORPC predicate filtered by policy ID.
+
+```ts
+.buildPrimitives(builder =>
+  builder.addPrimitive(
+    (sp) => sp.parallelUtxoRpc,
+    () => ({
+      name: "MyTokenMints",
+      type: PrimitiveTypeCardanoMintBurn,
+      startBlockHeight: 1,
+      stateMachinePrefix: "cardano-mint",
+      policyIds: ["abcdef1234..."],
+      network: "yaci",
+    }),
+  )
+)
+```
+
+**Payload fields:**
+
+| Field | Description |
+| :--- | :--- |
+| `txId` | Transaction hash |
+| `metadata` | JSON-stringified transaction metadata |
+| `assets` | JSON array of `{amount, policyId, assetName}` |
+| `inputAddresses` | JSON array of addresses that signed inputs |
+| `outputAddresses` | JSON array of recipient addresses |
+
+#### Pool Delegation (`PrimitiveTypeCardanoPoolDelegation`)
+
+Tracks stake pool delegation changes. Monitors both pre-Conway (`stakeDelegation`) and Conway-era (`stakeRegDelegCert`, `stakeVoteDelegCert`) delegation certificates using the `has_certificate` UTxORPC predicate. Supports an optional `pools` allowlist to filter by specific stake pool key hashes.
+
+Maintains an **IVM materialized view** (`cardano_pool_delegation_view_<name>`) with the current delegation per staking credential — UPSERTs on each delegation change.
+
+```ts
+.buildPrimitives(builder =>
+  builder.addPrimitive(
+    (sp) => sp.parallelUtxoRpc,
+    () => ({
+      name: "CardanoPoolDelegation",
+      type: PrimitiveTypeCardanoPoolDelegation,
+      startBlockHeight: 1,
+      stateMachinePrefix: "cardano-pool-delegation",
+      pools: ["7301761068762f..."], // optional: only watch these pools
+      network: "yaci",
+    }),
+  )
+)
+```
+
+**Payload fields:**
+
+| Field | Description |
+| :--- | :--- |
+| `address` | Staking credential hash |
+| `pool` | Target stake pool key hash |
+| `epoch` | Network epoch at delegation time |
+
+See the [cardano-delegation template](https://github.com/effectstream/effectstream/tree/main/templates/cardano-delegation) for a complete working example including a React frontend.
+
+#### Projected NFT (`PrimitiveTypeCardanoProjectedNFT`)
+
+Tracks the lock → unlock → claim lifecycle of NFTs locked at a Plutus script (hololocker). This enables "projecting" on-chain NFTs into off-chain game state while they remain provably locked on-chain. Uses the `has_address` UTxORPC predicate filtered by the script address.
+
+Maintains an **IVM materialized view** (`cardano_projected_nft_view_<name>`) — UPSERTs on Lock/Unlocking transitions, DELETEs on Claims.
+
+```ts
+.buildPrimitives(builder =>
+  builder.addPrimitive(
+    (sp) => sp.parallelUtxoRpc,
+    () => ({
+      name: "GameNFTLocker",
+      type: PrimitiveTypeCardanoProjectedNFT,
+      startBlockHeight: 1,
+      stateMachinePrefix: "cardano-projected-nft",
+      scriptHash: "abc123...", // hololocker script hash
+      network: "yaci",
+    }),
+  )
+)
+```
+
+**Payload fields:**
+
+| Field | Description |
+| :--- | :--- |
+| `ownerAddress` | Owner hash parsed from datum (PKH/NFT/Receipt) |
+| `previousTxId` | Previous transaction hash (for state transitions) |
+| `previousOutputIndex` | Previous output index |
+| `currentTxId` | Current transaction hash |
+| `currentOutputIndex` | Current output index |
+| `policyId` | Native asset policy ID |
+| `assetName` | Native asset name |
+| `status` | `Lock`, `Unlocking`, or `Claim` |
+| `forHowLong` | Time-lock expiry (for `Unlocking` status) |
+
+#### Transfer (`PrimitiveTypeCardanoTransfer`)
+
+Captures ADA and native asset transfers. Tracks outputs (destination UTxOs) and input credentials (payment authorization). The UTxORPC predicate is user-provided, typically `has_address` to watch specific addresses.
+
+```ts
+.buildPrimitives(builder =>
+  builder.addPrimitive(
+    (sp) => sp.parallelUtxoRpc,
+    () => ({
+      name: "WatchMyAddress",
+      type: PrimitiveTypeCardanoTransfer,
+      startBlockHeight: 1,
+      stateMachinePrefix: "cardano-transfer",
+      predicate: {
+        match: { cardano: { has_address: { exact_address: "addr_test1..." } } },
+      },
+      network: "yaci",
+    }),
+  )
+)
+```
+
+**Payload fields:**
+
+| Field | Description |
+| :--- | :--- |
+| `txId` | Transaction hash |
+| `metadata` | JSON-stringified transaction metadata |
+| `inputCredentials` | JSON array of verification key hashes that signed inputs |
+| `outputs` | JSON array of `{index, address, coin, assets[]}` |
 
 ## 2. Batcher Adapters (Write)
 

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -64,15 +64,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "ja"],
-    localeConfigs: {
-      en: {
-        label: "English",
-      },
-      ja: {
-        label: "Japanese",
-      },
-    },
+    locales: ["en"],
   },
   themes: [
     // ... Your other themes.
@@ -257,10 +249,10 @@ const config = {
         items: [
           { to: "/", label: "Docs", position: "left" },
           { to: "/blog", label: "Blog", position: "left" },
-          {
-            type: "localeDropdown",
-            position: "right",
-          },
+          // {
+          //   type: "localeDropdown",
+          //   position: "right",
+          // },
           // {
           //   href: "https://github.com/facebook/docusaurus",
           //   label: "GitHub",

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -238,6 +238,11 @@ const config = {
         }
       },
       image: 'img/no-image.png',
+      blog: {
+        sidebar: {
+          groupByYear: false,
+        },
+      },
       navbar: {
         title: "",
         logo: {

--- a/docs/site/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/docs/site/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -1,0 +1,41 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import type {Props} from '@theme/BlogPostItem/Header/Info';
+
+function useReadingTimePlural() {
+  const {selectMessage} = usePluralForm();
+  return (readingTimeFloat: number) => {
+    const readingTime = Math.ceil(readingTimeFloat);
+    return selectMessage(
+      readingTime,
+      translate(
+        {
+          id: 'theme.blog.post.readingTime.plurals',
+          description:
+            'Pluralized label for "{readingTime} min read".',
+          message: 'One min read|{readingTime} min read',
+        },
+        {readingTime},
+      ),
+    );
+  };
+}
+
+export default function BlogPostItemHeaderInfo({className}: Props): ReactNode {
+  const {metadata} = useBlogPost();
+  const {readingTime} = metadata;
+  const readingTimePlural = useReadingTimePlural();
+
+  if (typeof readingTime === 'undefined') {
+    return null;
+  }
+
+  return (
+    <div className={clsx('margin-vert--md', className)} style={{fontSize: '0.9rem'}}>
+      {readingTimePlural(readingTime)}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add all 5 Cardano primitives (DelayedAsset, MintBurn, PoolDelegation, ProjectedNFT, Transfer) to the built-in primitives table in `118-primitives.md`
- Expand the Cardano chain page (`203-cardano.md`) with full primitive documentation: config examples, payload field tables, and IVM details
- Update stakepool delegation blog post to link to source code and docs instead of PR #673

## Test plan
- [ ] Run `npx docusaurus build` to verify no broken links or markdown errors
- [ ] Check primitives table renders correctly with new Cardano rows
- [ ] Verify Cardano page anchor links (`#primitives`, `#delayed-asset`, etc.) work from blog post cross-references