### PR TITLE
docs: update repo links to v-next, drop merged branch refs

### DIFF
--- a/docs/site/blog/2026-04-28-avail-data-availability.md
+++ b/docs/site/blog/2026-04-28-avail-data-availability.md
@@ -21,7 +21,7 @@ A DA layer like [Celestia](https://celestia.org/) provides an alternative: post 
 
 The Celestia integration adds a new data path to EffectStream's batcher system. The batcher aggregates individual user submissions into batches and posts them to Celestia for data availability, while settlement transactions go to the configured settlement chain.
 
-The integration lives in the [`bun-zswap-da` template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/bun-zswap-da), which includes:
+The integration lives in the [`bun-zswap-da` template](https://github.com/effectstream/effectstream/tree/v-next/bun-zswap-da), which includes:
 
 - **Batcher** that aggregates and posts batches to Celestia
 - **Database** tracking submitted batches, token states, and offer lifecycle
@@ -73,5 +73,5 @@ With Celestia support, developers can build hybrid applications:
 
 The developer configures which data goes where, and the framework handles routing, batching, and event delivery.
 
-- [Celestia integration code (`bun-zswap-da` template)](https://github.com/effectstream/effectstream/tree/v-next-bun-start/bun-zswap-da)
+- [Celestia integration code (`bun-zswap-da` template)](https://github.com/effectstream/effectstream/tree/v-next/bun-zswap-da)
 - [Celestia documentation](https://celestia.org/developer-portal/)

--- a/docs/site/blog/2026-04-28-cardano-primitives.md
+++ b/docs/site/blog/2026-04-28-cardano-primitives.md
@@ -28,7 +28,7 @@ Five primitives ship with EffectStream today, all sharing the same architecture:
 | `Cardano:PoolDelegation` | Stake pool delegations (pre-Conway + Conway) | `has_certificate` | `cardano_pool_delegation_view_<name>` |
 | `Cardano:ProjectedNFT` | Lock/Unlock/Claim on a Hololocker script | `has_address` (by `payment_part`) | `cardano_projected_nft_view_<name>` |
 
-Source for all five lives in [`packages/node-sdk/sm/primitives/src`](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src).
+Source for all five lives in [`packages/node-sdk/sm/primitives/src`](https://github.com/effectstream/effectstream/tree/v-next/packages/node-sdk/sm/primitives/src).
 
 ## Why this isn't just an indexer
 
@@ -120,7 +120,7 @@ Each primitive is paired with a runnable template that exercises it end-to-end:
 Both templates start the same way:
 
 ```bash
-git clone https://github.com/effectstream/effectstream.git --branch v-next-bun-start
+git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/projected-nft-preorder   # or cardano-delegation
 bun install
 bun run dev
@@ -134,9 +134,9 @@ Once a chain has a primitive layer, the cost of adding a new on-chain integratio
 
 ---
 
-- [All five Cardano primitives source](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src)
+- [All five Cardano primitives source](https://github.com/effectstream/effectstream/tree/v-next/packages/node-sdk/sm/primitives/src)
 - [Cardano Primitives reference docs](/docs/home/chains/cardano#primitives)
 - [Stake Pool Delegation post](/docs/blog/stakepool-delegation) — the first primitive built on this architecture
 - [Projected NFTs post](/docs/blog/projected-nfts) — the Hololocker dApp + ProjectedNFT primitive end-to-end
-- [`cardano-delegation` template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation)
-- [`projected-nft-preorder` template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/projected-nft-preorder)
+- [`cardano-delegation` template](https://github.com/effectstream/effectstream/tree/v-next/templates/cardano-delegation)
+- [`projected-nft-preorder` template](https://github.com/effectstream/effectstream/tree/v-next/templates/projected-nft-preorder)

--- a/docs/site/blog/2026-04-28-data-availability-part-2.md
+++ b/docs/site/blog/2026-04-28-data-availability-part-2.md
@@ -121,7 +121,7 @@ The two things to get right at this layer are **idempotency** (each DA blob shou
 
 ## Worked example: indexing ZSwap offers
 
-[ZSwap](https://github.com/effectstream/effectstream/tree/v-next-bun-start/bun-zswap-da) is the concrete case the M2 template demonstrates. ZSwap offers are short JSON records — wallet, token in, token out, amounts, nonce, signature — typically a few hundred bytes each. A busy ZSwap market generates thousands of offers per hour. Three properties matter:
+[ZSwap](https://github.com/effectstream/effectstream/tree/v-next/bun-zswap-da) is the concrete case the M2 template demonstrates. ZSwap offers are short JSON records — wallet, token in, token out, amounts, nonce, signature — typically a few hundred bytes each. A busy ZSwap market generates thousands of offers per hour. Three properties matter:
 
 - Each offer is small (a few hundred bytes).
 - The volume is high (orders of magnitude more than settlement-chain capacity).
@@ -172,6 +172,6 @@ DA layers are a sharp tool, not a free upgrade. They unlock workloads that were 
 ---
 
 - [Part 1: Celestia Data Availability — the integration architecture](/docs/blog/celestia-data-availability)
-- [`bun-zswap-da` template (Celestia DA worked example)](https://github.com/effectstream/effectstream/tree/v-next-bun-start/bun-zswap-da)
-- [Avail Generic primitive source](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src/avail-generic)
-- [Celestia Generic primitive source](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src/celestia-generic)
+- [`bun-zswap-da` template (Celestia DA worked example)](https://github.com/effectstream/effectstream/tree/v-next/bun-zswap-da)
+- [Avail Generic primitive source](https://github.com/effectstream/effectstream/tree/v-next/packages/node-sdk/sm/primitives/src/avail-generic)
+- [Celestia Generic primitive source](https://github.com/effectstream/effectstream/tree/v-next/packages/node-sdk/sm/primitives/src/celestia-generic)

--- a/docs/site/blog/2026-04-28-engine-integrations.md
+++ b/docs/site/blog/2026-04-28-engine-integrations.md
@@ -13,7 +13,7 @@ EffectStream is designed to integrate with any game engine or platform. This art
 
 One of the biggest friction points for multi-chain developers is setting up a local dev environment. Syncing a Cardano indexer like Carp can take days on testnet and even longer on mainnet, which makes rapid iteration pretty much impossible. We built a template that replaces this entire workflow with an instant localhost setup.
 
-The EVM-Cardano template, [available in the monorepo](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/evm-cardano), combines:
+The EVM-Cardano template, [available in the monorepo](https://github.com/effectstream/effectstream/tree/v-next/templates/evm-cardano), combines:
 
 - [**Hardhat v3**](https://hardhat.org/) for EVM smart contract development and a local EVM chain
 - [**YACI DevKit**](https://github.com/bloxbean/yaci-devkit) for a local Cardano devnet
@@ -127,5 +127,5 @@ The mobile app communicates with an EffectStream backend that manages on-chain s
 
 All templates are open-source in the [game templates repository](https://github.com/PaimaStudios/paima-game-templates). The EVM-Cardano template with its Dolos-based local development stack is probably the most impactful: it removes the biggest barrier to Cardano development by getting rid of the sync time that's historically made local testing impractical.
 
-- [EVM-Cardano template code (Dolos + YACI DevKit)](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/evm-cardano)
+- [EVM-Cardano template code (Dolos + YACI DevKit)](https://github.com/effectstream/effectstream/tree/v-next/templates/evm-cardano)
 - [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)

--- a/docs/site/blog/2026-04-28-mina-zk-integration.md
+++ b/docs/site/blog/2026-04-28-mina-zk-integration.md
@@ -56,7 +56,7 @@ Here's the concept: a governance vote where voting power comes from your Cardano
 
 ![Private Delegation Voting: Cardano + Midnight cross-chain ZK voting with stake pool delegation](/img/blog/zk-cardano.png)
 
-The full [ZK-Cardano template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/zk-cardano) is available in the monorepo alongside five new [Cardano primitives](/docs/home/chains/cardano#primitives).
+The full [ZK-Cardano template](https://github.com/effectstream/effectstream/tree/v-next/templates/zk-cardano) is available in the monorepo alongside five new [Cardano primitives](/docs/home/chains/cardano#primitives).
 
 <iframe src="https://drive.google.com/file/d/1qeFPXN3cjsd66aFn-kgu2q8fqTr8SA-A/preview" width="100%" height="480" allow="autoplay"></iframe>
 
@@ -111,7 +111,7 @@ A second template, [Go Fish](https://github.com/effectstream/go-fish), uses the 
 - [Werewolf template code](https://github.com/effectstream/werewolf-game)
 - [Werewolf Compact contract source](https://github.com/effectstream/werewolf-game/tree/main/packages/shared/contracts/midnight/contract-werewolf/src)
 - [Go Fish template (ZK Mental Poker)](https://github.com/effectstream/go-fish)
-- [ZK-Cardano template code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/zk-cardano)
+- [ZK-Cardano template code](https://github.com/effectstream/effectstream/tree/v-next/templates/zk-cardano)
 - [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)
 - [Midnight Network](https://midnight.network/)
 - [UTxORPC Watch Module](https://utxorpc.org/watch/intro/) - streaming protocol for Cardano data

--- a/docs/site/blog/2026-04-28-nft-launchpad.md
+++ b/docs/site/blog/2026-04-28-nft-launchpad.md
@@ -51,9 +51,9 @@ contract PaimaLaunchpad is OwnableUpgradeable, UUPSUpgradeable {
 
 A factory contract (`PaimaLaunchpadFactory`) lets each campaign deploy its own launchpad instance with its own accepted-token list and referrer-reward configuration.
 
-- [Preorder template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/preorder) — full multi-chain stack, runs locally with one command
-- [EVM contract source (`PaimaLaunchpad.sol`)](https://github.com/effectstream/effectstream/blob/v-next-bun-start/templates/preorder/packages/contracts-evm/src/contracts/PaimaLaunchpad.sol)
-- [Cardano contract integration](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/preorder/packages/contracts-cardano)
+- [Preorder template](https://github.com/effectstream/effectstream/tree/v-next/templates/preorder) — full multi-chain stack, runs locally with one command
+- [EVM contract source (`PaimaLaunchpad.sol`)](https://github.com/effectstream/effectstream/blob/v-next/templates/preorder/packages/contracts-evm/src/contracts/PaimaLaunchpad.sol)
+- [Cardano contract integration](https://github.com/effectstream/effectstream/tree/v-next/templates/preorder/packages/contracts-cardano)
 - (Original repository: https://github.com/PaimaStudios/paima-preorder — preserved for reference)
 
 ## Why separate deployments
@@ -144,7 +144,7 @@ The two handlers write to the same `participations` and `launchpad_user_items` t
 The Preorder template ships as a one-command stack: PGLite, Hardhat, YACI DevKit, Dolos, the sync node, and the frontend all come up together under the EffectStream orchestrator.
 
 ```bash
-git clone https://github.com/effectstream/effectstream.git --branch v-next-bun-start
+git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/preorder
 bun install
 bun run dev

--- a/docs/site/blog/2026-04-28-projected-nfts.md
+++ b/docs/site/blog/2026-04-28-projected-nfts.md
@@ -53,7 +53,7 @@ A game could grant in-game powers when a player projects a specific NFT, remove 
 
 The integration is end-to-end tested with 21 E2E tests covering the full lifecycle: stake registration, delegation, lock, unlock, and claim, all verified against a local Dolos instance.
 
-- [ProjectedNFT primitive source code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src)
+- [ProjectedNFT primitive source code](https://github.com/effectstream/effectstream/tree/v-next/packages/node-sdk/sm/primitives/src)
 - [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)
 
 ## The full stack

--- a/docs/site/blog/2026-04-28-stakepool-delegation-batcher.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation-batcher.md
@@ -297,8 +297,7 @@ The complete delegation + batcher stack runs as two pieces: the cardano-delegati
 
 ```bash
 # Terminal 1: Start the delegation sync node
-git clone https://github.com/effectstream/effectstream.git \
-  --branch v-next-bun-start
+git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/cardano-delegation
 bun install
 bun run dev
@@ -316,4 +315,4 @@ bun run dev
 - [Custom Adapters guide](/docs/home/components/batcher/adapter)
 - [Part 1: Connecting Cardano SPOs](/docs/blog/stakepool-delegation)
 - [Part 2: Building the State Machine](/docs/blog/stakepool-delegation-technical)
-- [Cardano delegation template source code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation)
+- [Cardano delegation template source code](https://github.com/effectstream/effectstream/tree/v-next/templates/cardano-delegation)

--- a/docs/site/blog/2026-04-28-stakepool-delegation-technical.md
+++ b/docs/site/blog/2026-04-28-stakepool-delegation-technical.md
@@ -5,7 +5,7 @@ authors: [effectstream]
 tags: [cardano, stakepools, delegation, dolos, utxorpc, technical]
 ---
 
-A step-by-step walkthrough of how the EffectStream [cardano-delegation template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation) works internally. We'll trace the full path from raw Cardano blocks to application state, covering the config, primitive, grammar, state machine, database, and API layers.
+A step-by-step walkthrough of how the EffectStream [cardano-delegation template](https://github.com/effectstream/effectstream/tree/v-next/templates/cardano-delegation) works internally. We'll trace the full path from raw Cardano blocks to application state, covering the config, primitive, grammar, state machine, database, and API layers.
 
 <!-- truncate -->
 
@@ -333,8 +333,7 @@ The `start.dev.ts` orchestrator config launches the full stack in dependency ord
 6. **Frontend** — builds and serves the Delegation Explorer dApp
 
 ```bash
-git clone https://github.com/effectstream/effectstream.git \
-  --branch v-next-bun-start
+git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/cardano-delegation
 bun i
 bun run dev
@@ -373,7 +372,7 @@ stm.addStateTransition("cardano-pool-delegation", function* (data) {
 
 ---
 
-- [Template source code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/cardano-delegation)
-- [PoolDelegation primitive source](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/node-sdk/sm/primitives/src/cardano-pool-delegation)
+- [Template source code](https://github.com/effectstream/effectstream/tree/v-next/templates/cardano-delegation)
+- [PoolDelegation primitive source](https://github.com/effectstream/effectstream/tree/v-next/packages/node-sdk/sm/primitives/src/cardano-pool-delegation)
 - [Overview blog post](/docs/blog/stakepool-delegation)
 - [Cardano Primitives documentation](/docs/home/chains/cardano#primitives)

--- a/docs/site/blog/2026-04-28-user-experience-integrations.md
+++ b/docs/site/blog/2026-04-28-user-experience-integrations.md
@@ -37,7 +37,7 @@ The wallet signature popup in the screenshot shows the on-chain integration. The
 The AI doesn't just give a score; it explains its reasoning. Players can see why their answer earned or lost tokens, which creates an engaging feedback loop that feels more like a conversation than a multiple-choice quiz.
 
 - [Play live](https://tokenquest.zkdojo.com/)
-- [Template code](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/shinkai-v2)
+- [Template code](https://github.com/effectstream/effectstream/tree/v-next/templates/shinkai-v2)
 
 ## Why this matters for on-chain games
 

--- a/docs/site/docs/home/200-chains/210-contracts.md
+++ b/docs/site/docs/home/200-chains/210-contracts.md
@@ -4,17 +4,17 @@ EffectStream ships first-party on-chain contracts that templates and application
 
 ## EVM (Solidity)
 
-Source: [`packages/chains/evm-contracts/src/contracts`](https://github.com/effectstream/effectstream/tree/v-next-bun-start/packages/chains/evm-contracts/src/contracts).
+Source: [`packages/chains/evm-contracts/src/contracts`](https://github.com/effectstream/effectstream/tree/v-next/packages/chains/evm-contracts/src/contracts).
 
 ### Core
 
-- **`EffectstreamL2Contract`** — the canonical L2 batch poster. Calling `effectstreamSubmitGameInput(bytes)` emits an `EffectstreamGameInteraction` event that the sync node picks up to advance the state machine. Most dApps extend this directly; see [`MyEffectstreamL2.sol`](https://github.com/effectstream/effectstream/blob/v-next-bun-start/templates/chess-v2/packages/contracts-evm/src/contracts/MyEffectstreamL2.sol) in the templates.
+- **`EffectstreamL2Contract`** — the canonical L2 batch poster. Calling `effectstreamSubmitGameInput(bytes)` emits an `EffectstreamGameInteraction` event that the sync node picks up to advance the state machine. Most dApps extend this directly; see [`MyEffectstreamL2.sol`](https://github.com/effectstream/effectstream/blob/v-next/templates/chess-v2/packages/contracts-evm/src/contracts/MyEffectstreamL2.sol) in the templates.
 - **`GenericPayment`** + **`Proxy/GenericPaymentProxy`** — UUPS-upgradeable payment receiver with a referrer-reward mechanism, used as a base by sale and launchpad contracts.
 - **`State`** + **`BaseState`** — minimal on-chain state primitives.
 
 ### NFT sales & launchpad
 
-- **`PaimaLaunchpad`** + **`PaimaLaunchpadFactory`** — pre-order launchpad with reward tiers, package bundles, and cart checkout. Each campaign is its own deployment. See the [NFT Launchpad blog post](/docs/blog/nft-launchpad) and the [`preorder` template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/preorder).
+- **`PaimaLaunchpad`** + **`PaimaLaunchpadFactory`** — pre-order launchpad with reward tiers, package bundles, and cart checkout. Each campaign is its own deployment. See the [NFT Launchpad blog post](/docs/blog/nft-launchpad) and the [`preorder` template](https://github.com/effectstream/effectstream/tree/v-next/templates/preorder).
 - **`NativeNftSale`** + **`Proxy/NativeNftSaleProxy`** — NFT sale paid in the chain's native token (ETH/MATIC/…). UUPS-upgradeable.
 - **`Erc20NftSale`** + **`Proxy/Erc20NftSaleProxy`** — NFT sale paid in an ERC-20 token. UUPS-upgradeable.
 - **`AnnotatedMintNft`** — ERC-721 mint that takes calldata at mint time, used to associate on-chain mints with off-chain state machine context.
@@ -44,11 +44,11 @@ Aiken validators ship pre-compiled as `plutus.json` inside the Cardano-side temp
 
 ### Projected NFT
 
-- **`hololocker`** — locks an L1 Cardano NFT into a script address so it can be "projected" into an EffectStream L2 game state, then released back on a cooldown. Exposes both spend and mint validators. Source: [`hololocker.ak`](https://github.com/effectstream/effectstream/blob/v-next-bun-start/e2e/shared/contracts/cardano/hololocker-demo/validators/hololocker.ak). Used by the [`projected-nft-preorder` template](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/projected-nft-preorder).
+- **`hololocker`** — locks an L1 Cardano NFT into a script address so it can be "projected" into an EffectStream L2 game state, then released back on a cooldown. Exposes both spend and mint validators. Source: [`hololocker.ak`](https://github.com/effectstream/effectstream/blob/v-next/e2e/shared/contracts/cardano/hololocker-demo/validators/hololocker.ak). Used by the [`projected-nft-preorder` template](https://github.com/effectstream/effectstream/tree/v-next/templates/projected-nft-preorder).
 
 ### Examples
 
-- **`hello`** — minimal Aiken validator used by the e2e test suite. Reference for the shape of a custom validator inside an EffectStream template. Source: [`hello.ak`](https://github.com/effectstream/effectstream/blob/v-next-bun-start/e2e/shared/contracts/cardano/hello/validators/hello.ak).
+- **`hello`** — minimal Aiken validator used by the e2e test suite. Reference for the shape of a custom validator inside an EffectStream template. Source: [`hello.ak`](https://github.com/effectstream/effectstream/blob/v-next/e2e/shared/contracts/cardano/hello/validators/hello.ak).
 
 ---
 

--- a/docs/site/docs/home/400-paima-standards/prc2.md
+++ b/docs/site/docs/home/400-paima-standards/prc2.md
@@ -101,7 +101,7 @@ Other standards (ERC-20, ERC-1155) can be supported by analogous interfaces with
 The Hololocker pattern is what EffectStream's **`CardanoProjectedNFT` primitive** consumes for Cardano-side projections. The same shape applies to EVM-side Hololockers using the on-chain interface specified above.
 
 - **Primitive**: parses Hololocker `State` datums from the indexer stream and materialises a queryable PostgreSQL view of every projected NFT (`Lock`, `Unlocking`, `Claim` states + nullifier tracking). See the [Cardano Primitives reference](/docs/home/chains/cardano#primitives).
-- **Runnable template**: [`templates/projected-nft-preorder`](https://github.com/effectstream/effectstream/tree/v-next-bun-start/templates/projected-nft-preorder) is a complete devnet + indexer + sync node + React frontend that exercises the full Lock → Unlock → Claim lifecycle.
+- **Runnable template**: [`templates/projected-nft-preorder`](https://github.com/effectstream/effectstream/tree/v-next/templates/projected-nft-preorder) is a complete devnet + indexer + sync node + React frontend that exercises the full Lock → Unlock → Claim lifecycle.
 - **Walkthrough**: the [Projected NFTs blog post](/docs/blog/projected-nfts) walks through the Aiken Cardano contract, the EffectStream primitive, and the dApp end-to-end.
 
 For new EVM Hololocker deployments the [`dcSpark/projected-nft-whirlpool`](https://github.com/dcSpark/projected-nft-whirlpool) repository hosts the reference Solidity contract, the deployment script, and the dApp UI.


### PR DESCRIPTION
## Summary
- The `v-next-bun-start` branch has been merged into `v-next` (the default branch), so all references to it in the docs and blog are now stale.
- Updated `tree/v-next-bun-start/...` and `blob/v-next-bun-start/...` GitHub URLs to point at `v-next` (27 occurrences across 12 files).
- Removed the now-redundant `--branch v-next-bun-start` flag from `git clone` examples in 4 blog posts so readers clone the default branch.

## Test plan
- [ ] `grep -r "v-next-bun-start" docs/site/{blog,docs}` returns no matches.
- [ ] Spot-check a couple of the updated GitHub links resolve on `v-next`.
- [ ] Docusaurus build still succeeds (`cd docs/site && npx docusaurus build`).