### PR TITLE
Rewrite main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,162 @@
 # Effectstream
 
-## Quick Start
+A multi-chain Web3 engine for building multi-chain dApps, infrastructure and onchain games.
 
-Start at [Effectstream's Template](./templates/evm-midnight/) for quickstart
-project
+[Home](https://effectstream.github.io/home/) · [Docs](https://effectstream.github.io/docs/) · [Blog](https://effectstream.github.io/docs/blog/)
 
-## Bun 
+- **Multi-chain by default.** EVM, Midnight, Bitcoin, Cardano, Avail, Celestia, and NEAR — one state machine, many chains.
+- **Sovereign rollups.** App-specific L2s that inherit finality from the underlying L1, with no custodial bridge.
+- **Modular.** Pick the chains and modules you need. Everything ships as a separate `@effectstream/*` package.
+- **Bun-native.** The whole monorepo runs on Bun. No build step for development; TypeScript executes directly.
+
+## Quick start
+
+Run a sample project:  
 ```sh
-rm -rf bun.lock && \
-bun install && \
-bun run --filter '@e2e/midnight-contract-counter-basic' contract:compile && \
-bun run --filter '@e2e/midnight-contract-eip-20' contract:compile  && \
-DISABLE_EVM=true DISABLE_BITCOIN=true DISABLE_AVAIL=true bun run --filter @e2e/node e2e
+git clone https://github.com/effectstream/effectstream.git
+cd effectstream/templates/evm-midnight-v2
+bun i
+bun run dev
 ```
 
-## Testing Development
+`bun run dev` brings up the full local stack: PGLite, Hardhat, a Midnight node, contract deployment, the sync node, the batcher, and the frontend. Open [http://localhost:10599](http://localhost:10599) once everything is up.
 
-Effectstream development mode & tests can be run through e2e testing environment.
+## What it is
+
+Effectstream is a framework for building dApps that read state from multiple chains and fold their updates into a single deterministic state machine. You write your app logic in TypeScript, point it at one or more chains, and Effectstream handles sync (read), batching (write), indexing, and the frontend connection.
+
+For more information visit the [docs site](https://effectstream.github.io/docs/).
+
+## Templates
+
+`templates/` has ready-to-run examples. Each one is a self-contained Bun workspace you can copy and modify.
+
+| Template | What it shows |
+|---|---|
+| [`minimal`](templates/minimal/) | Smallest possible Effectstream app |
+| [`evm-midnight-v2`](templates/evm-midnight-v2/) | EVM + Midnight, ERC-721 sync, ZK contracts, full React frontend |
+| [`chess-v2`](templates/chess-v2/) | Onchain chess with matchmaking |
+| [`batcher-validations`](templates/batcher-validations/) | Custom Batcher Validation |
+| [`preorder`](templates/preorder/) | dApp (Cardano+EVM) for Assets Presale |
+| [`zswap-da`](templates/zswap-da/) | Midnight Zswap for decentralized liquidity | 
+| [`more`](templates/) | Explore the examples | 
+
+
+## Repository layout
+
+| Directory | What lives here |
+|---|---|
+| [`packages/effectstream-sdk/`](packages/effectstream-sdk/) | Core SDK: config, events, crypto, wallets, log, schemas, chain types |
+| [`packages/node-sdk/`](packages/node-sdk/) | Runtime engine: database, state machine, sync, node entry point |
+| [`packages/chains/`](packages/chains/) | Per-chain contract interfaces (EVM, Midnight, Bitcoin, Cardano, Avail) |
+| [`packages/batcher/`](packages/batcher/) | Cross-chain transaction batching |
+| [`packages/binaries/`](packages/binaries/) | NPM-wrapped blockchain node binaries |
+| [`packages/build-tools/`](packages/build-tools/) | Orchestrator, explorer, TUI |
+| [`packages/frontend/`](packages/frontend/) | React frontend SDK |
+| [`e2e/`](e2e/) | Integration test suites (one per chain) |
+| [`docs/site/`](docs/site/) | Docusaurus documentation site |
+
+## Orchestrator
+
+The orchestrator runs your dev stack. It supervises every process an Effectstream app needs (chains, contract deployment, sync node, batcher, frontend, plus any custom action you wire in) and gives you one place to start, stop, and inspect them. You don't have to be building a multi-chain app to want it; a single-chain dev loop is nicer with it too.
 
 ```sh
-# Install dependencies
-deno install --allow-scripts && ./patch.sh
-
-# Build All Contracts
-deno task -r contract:compile
-
-# Run Example Deployment Mode
-deno task -f @e2e/node quickstart
+bunx orchestrator start --background   # --background enables status and logs
+bunx orchestrator status
+bunx orchestrator logs
+bunx orchestrator stop
 ```
 
-## Run Tests
-
-> NOTE: first install dependencies and build contracts
+## Package Development
 
 ```sh
-deno task -f @e2e/node e2e
+# Unit tests
+bun test ./packages
+
+# All e2e suites (run serially because they share ports)
+cd e2e && bun run runner.ts
+
+# Run a single suite (or a few)
+cd e2e && bun run runner.ts evm bitcoin
 ```
 
-## Contracts
+Available suites: `evm`, `bitcoin`, `cardano`, `midnight`, `avail`, `celestia`, `near`, `features`, `wallets`.
 
-Contracts can be built individually or all at once.
-```sh
-# Build All Contracts
-deno task -r contract:compile
+Contribution guide: [`docs/site/docs/home/1000-effectstream-engine/1100-contributions.md`](docs/site/docs/home/1000-effectstream-engine/1100-contributions.md).
 
-# OR Build Contracts Individually
-deno task -f @e2e/evm-contracts build:mod
-deno task -f @e2e/midnight-contract-eip-20 contract:compile
-deno task -f @e2e/midnight-contract-counter contract:compile
-```
+Some templates ship a `link.sh` script that points the dApp at the local `@effectstream/*` source instead of the published packages, so you can make improvements on the engine itself.
+
+## Published packages
+
+Everything below is published on npm under `@effectstream/*`. All packages share the same version line and are released together.
+
+### Core SDK
+
+| Package | Description |
+|---|---|
+| [`@effectstream/utils`](https://www.npmjs.com/package/@effectstream/utils) | Shared utilities |
+| [`@effectstream/log`](https://www.npmjs.com/package/@effectstream/log) | OpenTelemetry observability |
+| [`@effectstream/config`](https://www.npmjs.com/package/@effectstream/config) | Chain and runtime configuration |
+| [`@effectstream/precompile`](https://www.npmjs.com/package/@effectstream/precompile) | Precompile utilities |
+| [`@effectstream/chain-types`](https://www.npmjs.com/package/@effectstream/chain-types) | Chain-specific type definitions |
+| [`@effectstream/crypto`](https://www.npmjs.com/package/@effectstream/crypto) | Multi-chain signature verification |
+| [`@effectstream/concise`](https://www.npmjs.com/package/@effectstream/concise) | Type-safe schemas |
+| [`@effectstream/event-client`](https://www.npmjs.com/package/@effectstream/event-client) | MQTT-based event client |
+| [`@effectstream/wallets`](https://www.npmjs.com/package/@effectstream/wallets) | Wallet connector integrations |
+| [`@effectstream/coroutine`](https://www.npmjs.com/package/@effectstream/coroutine) | Async control flow |
+
+### Node runtime
+
+| Package | Description |
+|---|---|
+| [`@effectstream/db`](https://www.npmjs.com/package/@effectstream/db) | PostgreSQL and PgLite database layer |
+| [`@effectstream/db-emulator`](https://www.npmjs.com/package/@effectstream/db-emulator) | In-memory test database |
+| [`@effectstream/sync`](https://www.npmjs.com/package/@effectstream/sync) | Blockchain sync service |
+| [`@effectstream/sm`](https://www.npmjs.com/package/@effectstream/sm) | State machine DSL |
+| [`@effectstream/runtime`](https://www.npmjs.com/package/@effectstream/runtime) | State machine runtime |
+| [`@effectstream/event-server`](https://www.npmjs.com/package/@effectstream/event-server) | Event server |
+| [`@effectstream/node-sdk`](https://www.npmjs.com/package/@effectstream/node-sdk) | Main application node SDK |
+
+### Chains
+
+| Package | Description |
+|---|---|
+| [`@effectstream/evm-contracts`](https://www.npmjs.com/package/@effectstream/evm-contracts) | EVM smart contract interfaces |
+| [`@effectstream/evm-hardhat`](https://www.npmjs.com/package/@effectstream/evm-hardhat) | Hardhat deployment and JSON-RPC utilities |
+| [`@effectstream/midnight-contracts`](https://www.npmjs.com/package/@effectstream/midnight-contracts) | Midnight network contract interfaces |
+| [`@effectstream/bitcoin-contracts`](https://www.npmjs.com/package/@effectstream/bitcoin-contracts) | Bitcoin script utilities |
+| [`@effectstream/cardano-contracts`](https://www.npmjs.com/package/@effectstream/cardano-contracts) | Cardano contract interfaces |
+| [`@effectstream/avail-contracts`](https://www.npmjs.com/package/@effectstream/avail-contracts) | Avail DA contract interfaces |
+
+### Batcher
+
+| Package | Description |
+|---|---|
+| [`@effectstream/batcher`](https://www.npmjs.com/package/@effectstream/batcher) | Cross-chain transaction batching |
+| [`@effectstream/batcher-sdk`](https://www.npmjs.com/package/@effectstream/batcher-sdk) | Batcher SDK |
+
+### Build tools & frontend
+
+| Package | Description |
+|---|---|
+| [`@effectstream/orchestrator`](https://www.npmjs.com/package/@effectstream/orchestrator) | Multi-chain local development environment |
+| [`@effectstream/tui`](https://www.npmjs.com/package/@effectstream/tui) | Terminal UI |
+| [`@effectstream/frontend-sdk`](https://www.npmjs.com/package/@effectstream/frontend-sdk) | React frontend SDK |
+
+### Binary wrappers
+
+Third-party blockchain binaries packaged for npm so you can install them with `bun add` instead of curl-pipe-bash.
+
+| Package | Description |
+|---|---|
+| [`@effectstream/bitcoin-core`](https://www.npmjs.com/package/@effectstream/bitcoin-core) | Bitcoin Core |
+| [`@effectstream/ord`](https://www.npmjs.com/package/@effectstream/ord) | Ord |
+| [`@effectstream/avail-light-client`](https://www.npmjs.com/package/@effectstream/avail-light-client) | Avail light client |
+| [`@effectstream/avail-node`](https://www.npmjs.com/package/@effectstream/avail-node) | Avail node |
+| [`@effectstream/midnight-node`](https://www.npmjs.com/package/@effectstream/midnight-node) | Midnight node |
+| [`@effectstream/midnight-indexer`](https://www.npmjs.com/package/@effectstream/midnight-indexer) | Midnight indexer |
+| [`@effectstream/midnight-proof-server`](https://www.npmjs.com/package/@effectstream/midnight-proof-server) | Midnight proof server |
+| [`@effectstream/near-sandbox`](https://www.npmjs.com/package/@effectstream/near-sandbox) | NEAR sandbox |
+| [`@effectstream/celestia`](https://www.npmjs.com/package/@effectstream/celestia) | Celestia |
+| [`@effectstream/grafana-alloy`](https://www.npmjs.com/package/@effectstream/grafana-alloy) | Grafana Alloy |
+| [`@effectstream/grafana-loki`](https://www.npmjs.com/package/@effectstream/grafana-loki) | Grafana Loki |


### PR DESCRIPTION
## Summary
- Replace the outdated quick start (Deno commands, removed `templates/evm-midnight/` path) with a Bun-based flow targeting [`templates/evm-midnight-v2`](templates/evm-midnight-v2/).
- Add an overview, template index, repository layout, dedicated orchestrator section, and a grouped table of all 39 published `@effectstream/*` packages so visitors landing from npm can navigate.
- Drop deprecated `DISABLE_*` env var references; document the new positional `runner.ts` suite selector.
- Add `[Home] · [Docs] · [Blog]` link bar.

## Test plan
- [ ] Render preview on GitHub and confirm all internal links resolve.
- [ ] Cross-check the published-packages table against `PACKAGE_DESCRIPTIONS` in [publish-bun.effectstream.ts](publish-bun.effectstream.ts).
- [ ] Run the documented quick start (`bun i && bun run dev` in `templates/evm-midnight-v2`) and confirm [http://localhost:10599](http://localhost:10599) comes up.