### PR TITLE
docs: replace deno/jsr references with bun + npm

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,4 +1,4 @@
 ```
-deno install --allow-scripts
-deno task start
+bun i
+bun run start
 ```

--- a/docs/site/docs/home/0-intro/0-intro.md
+++ b/docs/site/docs/home/0-intro/0-intro.md
@@ -25,25 +25,18 @@ EffectStream is a Web3 Engine optimized for dApps, games, gamification and auton
 
 > This is a preview of the EffectStream V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
 
-First, clone the repository and use the `templates/evm-midnight/` folder as a working template:
+First, clone the repository and use the `templates/evm-midnight-v2/` folder as a working template:
 
 ```sh
-# Clone and move to evm-midnight template
-git clone git@github.com:PaimaStudios/paima-engine.git --branch v-next
-cd paima-engine/templates/evm-midnight
-
-# Check for external dependencies
-../check.sh
+# Clone and move to evm-midnight-v2 template
+git clone https://github.com/effectstream/effectstream.git
+cd effectstream/templates/evm-midnight-v2
 
 # Install packages
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Compile contracts
-deno task build:evm
-deno task build:midnight
-
-# Launch EffectStream Node
-deno task dev
+# Launch EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 ```
 
 Now you should see the dApp running in your browser!

--- a/docs/site/docs/home/10-quickstart/10-quickstart.md
+++ b/docs/site/docs/home/10-quickstart/10-quickstart.md
@@ -9,24 +9,17 @@ slug: /quick-start
 
 > This is a preview of the EffectStream V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
 
-First, clone the repository and use the `templates/evm-midnight/` folder as a working template:
+First, clone the repository and use the `templates/evm-midnight-v2/` folder as a working template:
 
 ```sh
-git clone git@github.com:PaimaStudios/paima-engine.git --branch v-next
-cd effectstream-engine/templates/evm-midnight
-
-# Check for external dependencies
-../check.sh
+git clone https://github.com/effectstream/effectstream.git
+cd effectstream/templates/evm-midnight-v2
 
 # Install packages
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Compile contracts
-deno task build:evm
-deno task build:midnight
-
-# Launch EffectStream Node
-deno task dev
+# Launch EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 ```
 
 Now you should see the dApp running in your browser!
@@ -52,35 +45,32 @@ More [Components](../100-components/100-components.md)
 
 ## Packages & Folder Structure
 
-> We will be using `/templates/evm-midnight/` as example for the following definitions.
+> We will be using `/templates/evm-midnight-v2/` as example for the following definitions.
 
 Default folder structure:
 
 ```
-|-- deno.json                     # workspace definition
+|-- package.json                     # workspace definition
 |-- packages
-     |-- client                   # EffectStream node
-     |     |-- database           # database queries and tables
-     |     |-- node               # node startup, api, and state machine
-     |
-     |-- frontend                 # web app
-     |
-     |-- shared                   # shared components between client and frontend
-     |     |-- contracts/evm      # hardhat & evm contracts
-     |     |-- contracts/midnight # midnight contracts
-     |     |-- data-types         # grammar and node sync/contract definitions
+     |-- database                    # database queries and tables
+     |-- node                        # node startup, api, and state machine
+     |-- frontend                    # web app
+     |-- batcher                     # batcher service
+     |-- contracts-evm               # hardhat & evm contracts
+     |-- contracts-midnight          # midnight contracts
+     |-- tests                       # integration tests
 ```
 
 Workspace packages:
 
 ```
-
-client/database              @example-evm-midnight/database
-client/node                  @example-evm-midnight/node
-frontend                     @example-evm-midnight/frontend
-shared/contracts/evm         @example-evm-midnight/evm-contracts
-shared/contracts/midnight    @example-evm-midnight/midnight-contracts
-shared/contracts/data-types  @example-evm-midnight/data-types
+packages/database          @evm-midnight/database
+packages/node              @evm-midnight/node
+packages/frontend          @evm-midnight/frontend
+packages/batcher           @evm-midnight/batcher
+packages/contracts-evm     @evm-midnight/contracts-evm
+packages/contracts-midnight @evm-midnight/contracts-midnight
+packages/tests             @evm-midnight/tests
 ```
 
 ## Startup Overview
@@ -97,7 +87,7 @@ config:
 ---
 graph TD
     subgraph "User"
-        A["fa:fa-keyboard $ deno task dev"]
+        A["fa:fa-keyboard $ bun run dev"]
     end
 
     subgraph "Phase 1: Orchestration"
@@ -301,7 +291,7 @@ More about [EffectStream L2](../100-components/104-l2-contract.md)
 
 Developing a multi-chain dApp requires running many services at once. The **Process Orchestrator** is a powerful tool that automates your entire local development setup.
 
-When you run `deno task dev`, the orchestrator defined in the `start.ts` file at the `/template/evm-midnight/` example, and launches your complete environment in the correct order.
+When you run `bun run dev`, the orchestrator defined in the `orchestrator.ts` file at the `/templates/evm-midnight-v2/` example launches your complete environment in the correct order.
 
 This includes:
 
@@ -410,5 +400,5 @@ To see how all these components come together to build a complete, complex, and 
 
 For advanced developers interested in the engine's internals or looking to contribute:
 
-- [EffectStream Packages (NPM & JSR)](../1000-effectstream-engine/1000-effectstream-engine.md)
+- [EffectStream Packages (NPM)](../1000-effectstream-engine/1000-effectstream-engine.md)
 - [How to Contribute](../1000-effectstream-engine/1100-contributions.md)

--- a/docs/site/docs/home/100-components/102-state-machine.md
+++ b/docs/site/docs/home/100-components/102-state-machine.md
@@ -193,7 +193,7 @@ To do so, we can follow these steps:
 
     and compile your queries with 
     ```sh
-    deno task -f @example-evm-midnight/database pgtyped:update
+    bun run --cwd packages/database pgtyped:update
     ```
     This will create a safe typescript function to insert into the database.
     More information about [databases](../100-components/109-database.md)  

--- a/docs/site/docs/home/100-components/105-contracts.md
+++ b/docs/site/docs/home/100-components/105-contracts.md
@@ -63,10 +63,10 @@ The EffectStream templates come with pre-configured scripts to compile your smar
 You can compile all contracts in your project with the following commands:
 ```sh
 # Compile EVM contracts (Solidity)
-deno task build:evm
+bun run --cwd packages/contracts-evm build
 
 # Compile Midnight contracts
-deno task build:midnight
+bun run --cwd packages/contracts-midnight build
 ```
 The templates also include scripts for deploying these contracts to local development chains or public testnets/mainnets.
 

--- a/docs/site/docs/home/100-components/106-processes.md
+++ b/docs/site/docs/home/100-components/106-processes.md
@@ -2,7 +2,7 @@
 
 Developing a multi-chain dApp is complex. It often requires running multiple local blockchains, indexers, deploying contracts, and managing various services simultaneously. Doing this manually is tedious, error-prone, and slows down development.
 
-The **Process Orchestrator** is a powerful tool built into EffectStream that solves this problem. It automates the setup of your entire local development environment. When you run `deno task dev` in the `/templates/evm-midnight/` example, the orchestrator reads a configuration file (`start.{env}.ts`) and launches all the necessary processes—from blockchains and databases to the batcher and frontend server—in the correct order.
+The **Process Orchestrator** is a powerful tool built into EffectStream that solves this problem. It automates the setup of your entire local development environment. When you run `bun run dev` in the `/templates/evm-midnight-v2/` example, the orchestrator reads a configuration file (`orchestrator.ts`) and launches all the necessary processes—from blockchains and databases to the batcher and frontend server—in the correct order.
 
 Its main goal is to create a complete, "mini-production" environment on your machine, so you can focus on building your dApp, not on managing infrastructure.
 
@@ -106,7 +106,7 @@ For example, to run a program called `my-program.js` in the `/my-project` direct
 Let's look at the complete `start.ts` example. It sets up a complex, multi-chain environment.
 
 ```ts
-// This file is the entry point for `deno task dev`
+// This file is the entry point for `bun run dev`
 import { OrchestratorConfig, start } from "@effectstream/orchestrator";
 // ... other imports
 

--- a/docs/site/docs/home/100-components/107-explorer.md
+++ b/docs/site/docs/home/100-components/107-explorer.md
@@ -6,7 +6,7 @@ Think of it as a block explorer and a database admin panel rolled into one, spec
 
 ### Running the Explorer
 
-The EffectStream Explorer is typically launched automatically as part of the local development environment when you run `deno task dev`. It is configured within the `processesToLaunch` section of your `orchestrator.ts` file.
+The EffectStream Explorer is typically launched automatically as part of the local development environment when you run `bun run dev`. It is configured within the `processesToLaunch` section of your `orchestrator.ts` file.
 
 ```ts
 // In your orchestrator.ts

--- a/docs/site/docs/home/100-components/108-batcher/1240-configuration.md
+++ b/docs/site/docs/home/100-components/108-batcher/1240-configuration.md
@@ -351,14 +351,14 @@ import {
 // 1. Instantiate adapters
 const evmAdapter = new EffectStreamL2DefaultAdapter(
   "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
-  Deno.env.get("EVM_PRIVATE_KEY")!,
+  process.env["EVM_PRIVATE_KEY"]!,
   0n,
   "mainEvmRPC"
 );
 
 const midnightAdapter = new MidnightAdapter(
   "0xabc...",
-  Deno.env.get("MIDNIGHT_WALLET_SEED")!,
+  process.env["MIDNIGHT_WALLET_SEED"]!,
   {
     indexer: "http://localhost:8088/api/v1/graphql",
     indexerWS: "ws://localhost:8088/api/v1/graphql/ws",

--- a/docs/site/docs/home/100-components/108-batcher/1290-advanced-topics.md
+++ b/docs/site/docs/home/100-components/108-batcher/1290-advanced-topics.md
@@ -1309,18 +1309,18 @@ Without structured concurrency, you'd need manual bookkeeping to track and stop 
 
 ### Installation
 
-Effection is available on both NPM and Deno:
+Effection is available on NPM:
+
+**Bun:**
+```bash
+bun add effection
+```
 
 **NPM/Yarn:**
 ```bash
 npm install effection
 # or
 yarn add effection
-```
-
-**Deno:**
-```typescript
-import { main, suspend } from "https://jsr.io/@effection/effection/doc";
 ```
 
 ---
@@ -1678,7 +1678,7 @@ main(function* () {
   } catch (error) {
     console.error("Fatal error:", error);
     yield* batcher.gracefulShutdownOp();
-    Deno.exit(1);  // or process.exit(1) in Node
+    process.exit(1);
   }
 });
 ```

--- a/docs/site/docs/home/100-components/108-batcher/1290-advanced-topics.md
+++ b/docs/site/docs/home/100-components/108-batcher/1290-advanced-topics.md
@@ -1309,18 +1309,8 @@ Without structured concurrency, you'd need manual bookkeeping to track and stop 
 
 ### Installation
 
-Effection is available on NPM:
-
-**Bun:**
 ```bash
 bun add effection
-```
-
-**NPM/Yarn:**
-```bash
-npm install effection
-# or
-yarn add effection
 ```
 
 ---

--- a/docs/site/docs/home/100-components/109-database.md
+++ b/docs/site/docs/home/100-components/109-database.md
@@ -60,7 +60,7 @@ export const migrationTable: DBMigrations[] = [
 And uses PGTyped to convert SQL into Typescript functions.
 
 To convert the SQL for your project:  
-`deno task -f @example-evm-midnight/database pgtyped:update`
+`bun run --cwd packages/database pgtyped:update`
 
 * SQL Files are located at `/packages/backend/database/src/sql/*.sql`
 

--- a/docs/site/docs/home/100-components/117-node-startup.md
+++ b/docs/site/docs/home/100-components/117-node-startup.md
@@ -88,7 +88,7 @@ config:
 ---
 graph TD
     subgraph "User"
-        A["fa:fa-keyboard $ deno task dev"]
+        A["fa:fa-keyboard $ bun run dev"]
     end
 
     subgraph "Phase 1: Orchestration"

--- a/docs/site/docs/home/100-components/199-environment-variables.md
+++ b/docs/site/docs/home/100-components/199-environment-variables.md
@@ -13,23 +13,22 @@ Setting them allows to have different runtime scripts for different environments
 * `.env.${EFFECTSTREAM_ENV}` is loaded automatically.
 * Optionally `config.{env}.ts` can be created to load specific configuration for the environment, this file is imported by `main.{env}.ts`.
 
-The main entry point for the node is located at: `/packages/client/node/deno.json`.  
+The main entry point for the node is located at: `/packages/node/package.json`.  
 For example, if you have 2 environments: `local` and `testnet`
-```ts
+```json
 {
     "name": "@my-project-name/node",
-    "tasks": {
-        "node:start:local": "deno run -A --inspect --unstable-raw-imports src/main.local.ts",
-        "node:start:testnet": "deno run -A --inspect --unstable-raw-imports src/main.testnet.ts",
+    "scripts": {
+        "node:start:local": "bun --inspect ./src/main.local.ts",
+        "node:start:testnet": "bun --inspect ./src/main.testnet.ts",
 
-        "local": "EFFECTSTREAM_ENV=local NODE_ENV=development deno run -A --check --unstable-raw-imports scripts/start.local.ts",
-        "testnet": "EFFECTSTREAM_ENV=testnet deno run -A --check --unstable-raw-imports scripts/start.testnet.ts",
-        ...
+        "local": "EFFECTSTREAM_ENV=local NODE_ENV=development bun ./scripts/start.local.ts",
+        "testnet": "EFFECTSTREAM_ENV=testnet bun ./scripts/start.testnet.ts"
     }
 }
 ```
 
-By running `deno task testnet`:
+By running `bun run testnet`:
 1. `.env.testnet` is loaded
 2. `start.testnet.ts` is launch all the processes, once completed it will call `node:start:testnet`
 > IMPORTANT: `node:start:testnet` must match the `EFFECTSTREAM_ENV=testnet` value.

--- a/docs/site/docs/home/1000-effectstream-engine/1000-effectstream-engine.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1000-effectstream-engine.md
@@ -2,7 +2,7 @@
 
 > This section is intended for developers who require advanced knowledge about the engine or plan to contribute to `EffectStream`
 
-EffectStream is distributed for `deno` through `NPM` and `JSR` packages
+EffectStream is distributed through `NPM` packages.
 
 ## NPM Packages:
 
@@ -24,7 +24,6 @@ EffectStream is distributed for `deno` through `NPM` and `JSR` packages
 *  @effectstream/npm-midnight-proof-server  
     A wrapper for the Midnight proof server binary.
 
-## JSR Packages:
 *  @effectstream/batcher  
     HTTP service to collect and submit user inputs, replacing the need for manually sending input to the blockchain EffectStream L2 contract.
 

--- a/docs/site/docs/home/1000-effectstream-engine/1002-database.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1002-database.md
@@ -45,7 +45,7 @@ You write your SQL queries in files within the `/TODO` directory. To make a quer
 ### Generating TypeScript Functions
 After writing your queries, you run a simple command:
 ```sh
-deno task -f @effectstream/db pgtyped:update
+bun run --cwd packages/node-sdk/db pgtyped:update
 ```
 This command introspects your SQL files and your database schema, then generates corresponding TypeScript functions.
 

--- a/docs/site/docs/home/1000-effectstream-engine/1100-contributions.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1100-contributions.md
@@ -9,7 +9,7 @@ We use the standard "Fork & Pull Request" model for contributions.
 * Create a New Branch
 * Make Your Changes
 * Test Your Changes
-    `deno task @e2e/node test`
+    `cd e2e && bun run runner.ts`
 * Commit & Push your Changes
 * Open a Pull Request
 

--- a/docs/site/docs/home/1200-templates/1201-evm-midnight.md
+++ b/docs/site/docs/home/1200-templates/1201-evm-midnight.md
@@ -22,18 +22,11 @@ This pattern is a blueprint for many real-world applications, such as:
 ## Quick Start
 
 ```sh
-# Check for external dependencies
-./../check.sh
-
 # Install packages
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Compile contracts
-deno task build:evm
-deno task build:midnight
-
-# Launch EffectStream Node
-deno task dev
+# Launch EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 ```
 
 Now you should see the dApp running in your browser!
@@ -46,7 +39,7 @@ Now you should see the dApp running in your browser!
 
 ## The Components in Action
 
-When you run `deno task dev` for this template, the [Process Orchestrator](../100-components/106-processes.md) sets up a complete local environment:
+When you run `bun run dev` for this template, the [Process Orchestrator](../100-components/106-processes.md) sets up a complete local environment:
 *   **Hardhat EVM Node**: A local EVM blockchain.
 *   **Midnight Stack**: The full local Midnight environment, including the node, indexer, and proof server.
 *   **EffectStream Services**: The development database, log collector, TUI, and the EffectStream Explorer.

--- a/docs/site/docs/home/1200-templates/1202-wallets.md
+++ b/docs/site/docs/home/1200-templates/1202-wallets.md
@@ -27,15 +27,15 @@ This demo is an essential resource for any developer looking to build a multi-ch
 
 (TODO move to own template)
 ```
-deno install --allow-scripts && ./patch.sh
-deno task -f @e2e/evm-contracts build
-deno task -f @e2e/evm-contracts deploy:standalone
-deno task -f @e2e/midnight-contracts midnight-contract:compile
-deno task -f @e2e/node dev
+bun i
+bun run --cwd e2e/shared/contracts/evm build
+bun run --cwd e2e/shared/contracts/evm deploy:standalone
+bun run --cwd e2e/shared/contracts/midnight midnight-contract:compile
+bun run --cwd e2e/evm dev
 ```
 In another terminal, run the demo:
 ```
-deno task -f @e2e/wallets-ui dev
+bun run --cwd e2e/wallets-ui dev
 ```
 
 ## The Components in Action

--- a/docs/site/docs/home/1200-templates/1203-chess.md
+++ b/docs/site/docs/home/1200-templates/1203-chess.md
@@ -20,18 +20,11 @@ This template is a great starting point for any turn-based game, not just chess.
 ## Quick Start
 
 ```sh
-# Check for external dependencies
-./../check.sh
-
 # Install packages
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Compile contracts
-# TODO: Verify if there is a specific build command for chess contracts, assuming it is build:evm for now.
-deno task build:evm
-
-# Launch EffectStream Node
-deno task dev
+# Launch EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 ```
 
 Now you should see the dApp running in your browser!
@@ -41,7 +34,7 @@ Now you should see the dApp running in your browser!
 
 ## The Components in Action
 
-When you run `deno task dev` for this template, the [Process Orchestrator](../100-components/106-processes.md) sets up a complete local environment:
+When you run `bun run dev` for this template, the [Process Orchestrator](../100-components/106-processes.md) sets up a complete local environment:
 *   **Hardhat EVM Node**: A local EVM blockchain.
 *   **Development Services**: The development database, log collector, TUI, and the Explorer.
 *   **EffectStream**: Node to sync the chain and process game logic.

--- a/docs/site/docs/home/1200-templates/1204-multi-chain-swap.md
+++ b/docs/site/docs/home/1200-templates/1204-multi-chain-swap.md
@@ -26,22 +26,14 @@ This template addresses a common challenge in Web3: asset fragmentation across d
 
 ```sh
 # Clone the repository
-git clone git@github.com:PaimaStudios/paima-engine.git --branch v-next effectstream-demo
-cd effectstream-demo/templates/multi-chain-token-transfer
-
-## Please install missing dependencies.
-## This will be automatically done in the future.
-./../check.sh
+git clone https://github.com/effectstream/effectstream.git
+cd effectstream/templates/multi-chain-token-transfer
 
 # Install packages
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Compile contracts
-deno task build:evm
-deno task build:midnight
-
-# Launch EffectStream Node
-deno task dev
+# Launch EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 
 # You will need the Midnight Lace Wallet to interact with the dApp.
 # Wait until the EffectStream Node is Syncing Blocks
@@ -293,7 +285,7 @@ export const apiRouter: StartConfigApiRouter = async function (
   
   // A faucet endpoint for local development on Midnight
   server.get("/api/faucet", async (request) => {
-    // ... logic to call a Deno task to fund a Midnight address ...
+    // ... logic to call a script to fund a Midnight address ...
   });
 };
 ```
@@ -341,7 +333,7 @@ export const grammar = {
 
 ### 9. DevOps and Startup (`start.ts`)
 
-The Process Orchestrator is configured in `/packages/client/node/scripts/start.ts` to launch the entire multi-chain development environment with a single command (`deno task dev`). It uses helper functions like `launchEvm` and `launchMidnight` to manage the lifecycle of each blockchain, and also starts the Batcher and frontend services.
+The Process Orchestrator is configured in `/packages/client/node/scripts/start.ts` to launch the entire multi-chain development environment with a single command (`bun run dev`). It uses helper functions like `launchEvm` and `launchMidnight` to manage the lifecycle of each blockchain, and also starts the Batcher and frontend services.
 
 ```ts
 // In packages/client/node/scripts/start.ts
@@ -593,11 +585,11 @@ Finally, the custom primitive is registered in the main configuration file, wher
 
 ### Project Folder Structure
 
-The `multi-chain-token-swap` template is organized as a Deno workspace monorepo. This structure helps separate concerns, with distinct packages for the frontend, the EffectStream node, and shared code. Understanding this layout is key to navigating and modifying the template.
+The `multi-chain-token-swap` template is organized as a Bun workspace monorepo. This structure helps separate concerns, with distinct packages for the frontend, the EffectStream node, and shared code. Understanding this layout is key to navigating and modifying the template.
 
 ```
 /
-|-- deno.json                 # Deno workspace configuration and top-level tasks
+|-- package.json              # Bun workspace configuration and top-level scripts
 |-- README.md                 # Main project instructions
 |-- packages/
 |   |-- client/               # Contains the EffectStream Node implementation

--- a/docs/site/docs/home/1200-templates/1205-intent-swap.md
+++ b/docs/site/docs/home/1200-templates/1205-intent-swap.md
@@ -19,21 +19,14 @@ The `night-bitcoin` template demonstrates a cutting-edge pattern in Web3: **Inte
 
 ```sh
 # Clone the repository
-git clone git@github.com:PaimaStudios/paima-engine.git --branch v-next effectstream-demo
-cd effectstream-demo/templates/night-bitcoin
-
-# Check for external dependencies
-./../check.sh
+git clone https://github.com/effectstream/effectstream.git
+cd effectstream/templates/night-bitcoin
 
 # Install packages
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Compile contracts (Compact for Midnight)
-deno task build:midnight
-deno task build:bitcoin
-
-# Launch EffectStream Node
-deno task dev
+# Launch EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 ```
 
 **Terminal:**

--- a/docs/site/docs/home/1200-templates/1206-world-map-2d.md
+++ b/docs/site/docs/home/1200-templates/1206-world-map-2d.md
@@ -28,13 +28,10 @@ This template serves as a foundation for:
 
 ```sh
 # Install dependencies
-deno install --allow-scripts && ./patch.sh
+bun i
 
-# Build EVM contracts
-deno task build:evm
-
-# Start the EffectStream Node
-deno task dev
+# Start the EffectStream Node (compiles contracts and starts the full local stack)
+bun run dev
 ```
 
 ### Frontend Setup
@@ -43,14 +40,14 @@ In a separate terminal:
 
 ```sh
 cd packages/frontend
-npm install
-node esbuild.js      # Build the frontend bundle
-npx http-server .    # Serve on http://127.0.0.1:8080
+bun i
+bun run build       # Build the frontend bundle
+bun run serve       # Serve on http://127.0.0.1:8080
 ```
 
-Or use the Deno task:
+Or from the repository root:
 ```sh
-deno task -f @world-map-2d/frontend dev
+bun run --cwd packages/frontend dev
 ```
 
 Then open http://127.0.0.1:8080 in your browser.
@@ -84,7 +81,7 @@ docker build -t world-map-2d-sample -f Dockerfile .
 ```
 
 This will:
-- Install all dependencies (Deno, Node.js, Foundry)
+- Install all dependencies (Bun, Node.js, Foundry)
 - Build the EVM contracts
 - Build the frontend bundle
 - Set up the launch script
@@ -126,7 +123,7 @@ docker run --rm world-map-2d-sample ls -la /app/packages/frontend/
 
 ## The Components in Action
 
-When you run `deno task dev` for this template, the [Process Orchestrator](../100-components/106-processes.md) sets up a complete local environment:
+When you run `bun run dev` for this template, the [Process Orchestrator](../100-components/106-processes.md) sets up a complete local environment:
 *   **Hardhat EVM Node**: A local EVM blockchain running on port 8545.
 *   **Development Services**: The development database, log collector, TUI, and the Explorer.
 *   **EffectStream Node**: Backend service on port 9999 to sync the chain and process game logic.

--- a/docs/site/docs/home/1200-templates/1207-rock-paper-scissors.md
+++ b/docs/site/docs/home/1200-templates/1207-rock-paper-scissors.md
@@ -28,21 +28,10 @@ This template serves as a foundation for:
 
 ```sh
 # Install dependencies
-npm install
-deno install --allow-scripts
-./patch.sh
+bun i
 
-# Build EVM contracts
-deno task build:evm
-
-# Build frontend
-cd packages/frontend
-npm install
-node esbuild.js
-cd ../..
-
-# Start the EffectStream Node
-deno task dev
+# Start the EffectStream Node (compiles contracts, builds the frontend, and starts the full local stack)
+bun run dev
 ```
 
 The game will be available at:
@@ -99,7 +88,7 @@ The container exposes:
 
 ## The Components in Action
 
-When you run `deno task dev`, the [Process Orchestrator](../100-components/106-processes.md) sets up:
+When you run `bun run dev`, the [Process Orchestrator](../100-components/106-processes.md) sets up:
 *   **Hardhat EVM Node**: Local blockchain on port 8545
 *   **Development Services**: Database, log collector, TUI, and Explorer
 *   **EffectStream Node**: Backend service on port 9999
@@ -483,11 +472,10 @@ CREATE TABLE final_match_state (
 The template uses **pgtyped** to generate TypeScript types from SQL queries. To regenerate types after modifying SQL files:
 
 ```sh
-cd packages/client/database
-deno task pgtyped:update
+bun run --cwd packages/client/database pgtyped:update
 ```
 
-**Important**: Always run `deno task pgtyped:update` after converting functions from synchronous to async, as the type definitions need to be regenerated.
+**Important**: Always run `bun run --cwd packages/client/database pgtyped:update` after converting functions from synchronous to async, as the type definitions need to be regenerated.
 
 ## API Endpoints
 
@@ -679,13 +667,12 @@ node esbuild.js  # Regenerate bundle
 ### Database Query Types Out of Sync
 After modifying SQL files or converting functions to async:
 ```sh
-cd packages/client/database
-deno task pgtyped:update
+bun run --cwd packages/client/database pgtyped:update
 ```
 
 ### Lobby Not Creating
 Check that:
 1. MetaMask is connected to Localhost 8545
 2. You have test ETH in your account
-3. The EffectStream node is running (`deno task dev`)
+3. The EffectStream node is running (`bun run dev`)
 4. Check browser console for errors

--- a/docs/site/docs/home/1200-templates/1208-dice.md
+++ b/docs/site/docs/home/1200-templates/1208-dice.md
@@ -28,14 +28,10 @@ This template serves as a foundation for:
 
 ```sh
 # Install dependencies
-deno install --allow-scripts
-./patch.sh
+bun i
 
-# Build EVM contracts
-deno task build:evm
-
-# Start the EffectStream Node (automatically builds and serves frontend)
-deno task dev
+# Start the EffectStream Node (compiles contracts, builds and serves the frontend, and starts the full local stack)
+bun run dev
 ```
 
 The game will be available at:
@@ -92,7 +88,7 @@ The container exposes:
 
 ## The Components in Action
 
-When you run `deno task dev`, the [Process Orchestrator](../100-components/106-processes.md) sets up:
+When you run `bun run dev`, the [Process Orchestrator](../100-components/106-processes.md) sets up:
 *   **Hardhat EVM Node**: Local blockchain on port 8545
 *   **Development Services**: PGlite database, log collector, TUI, and Explorer
 *   **EffectStream Node**: Backend service on port 9999
@@ -540,11 +536,10 @@ CREATE INDEX IF NOT EXISTS idx_nft_ownership_wallet ON nft_ownership(wallet_addr
 The template uses **pgtyped** to generate TypeScript types from SQL queries. To regenerate types after modifying SQL files:
 
 ```sh
-cd packages/client/database
-deno task pgtyped:update
+bun run --cwd packages/client/database pgtyped:update
 ```
 
-**Important**: Always run `deno task pgtyped:update` after modifying SQL queries, as the type definitions need to be regenerated.
+**Important**: Always run `bun run --cwd packages/client/database pgtyped:update` after modifying SQL queries, as the type definitions need to be regenerated.
 
 ## API Endpoints
 
@@ -785,7 +780,7 @@ export { WalletMode };
 
 ### Building the Frontend
 
-The frontend uses esbuild for bundling. When you run `deno task dev`, the frontend is automatically built and served. To manually rebuild:
+The frontend uses esbuild for bundling. When you run `bun run dev`, the frontend is automatically built and served. To manually rebuild:
 
 ```sh
 cd packages/frontend
@@ -933,8 +928,7 @@ node esbuild.js  # Regenerate bundle
 
 After modifying SQL files:
 ```sh
-cd packages/client/database
-deno task pgtyped:update
+bun run --cwd packages/client/database pgtyped:update
 ```
 
 ### Lobby Not Creating
@@ -942,7 +936,7 @@ deno task pgtyped:update
 Check that:
 1. MetaMask is connected to Localhost 8545
 2. You have test ETH in your account
-3. The EffectStream node is running (`deno task dev`)
+3. The EffectStream node is running (`bun run dev`)
 4. Check browser console for errors
 5. Verify you've minted an NFT account first
 

--- a/docs/site/docs/home/200-chains/201-evm.md
+++ b/docs/site/docs/home/200-chains/201-evm.md
@@ -167,56 +167,27 @@ processesToLaunch: [
 ]
 ```
 
-> NOTE: To use this launcher you need to implement some `deno task` in your project. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
+> NOTE: To use this launcher you need to implement some scripts in your project's `package.json`. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
 
 ```json
 {
   "name": "@chess/evm-contracts",
-  ...
-  "tasks": {
-    "swap:remappings:forge": "deno -A @paimaexample/evm-hardhat/remappings-forge --depth 4 --package @paimaexample",
-    "swap:remappings:hardhat": "deno -A @paimaexample/evm-hardhat/remappings-hardhat",
+  "scripts": {
+    "swap:remappings:forge": "bun ./node_modules/.bin/effectstream-remappings-forge --depth 4 --package @paimaexample",
+    "swap:remappings:hardhat": "bun ./node_modules/.bin/effectstream-remappings-hardhat",
     "check": "echo 'check'",
-    "build:mod": {
-      // deploy:standalone does not return 'success', as the hardhat process is terminated by chain:stop - so it cannot be invoked as dependency
-      "command": "(deno task deploy:standalone || true) && deno run -A @paimaexample/evm-hardhat/builder"
-    },
     "build:clean": "rm -rf build || true",
-    "build:forge": {
-      "command": "forge build",
-      "dependencies": [
-        "swap:remappings:forge"
-      ]
-    },
-    "build:hardhat": {
-      "command": "deno run -A npm:hardhat@3.0.4 compile",
-      "dependencies": [
-        "swap:remappings:hardhat"
-      ]
-    },
-    "build": {
-      "command": "deno task build:forge && deno task build:hardhat",
-      "dependencies": [
-        "build:clean"
-      ]
-    },
-    "contract:compile": "deno task build:mod",
+    "build:forge": "bun run swap:remappings:forge && forge build",
+    "build:hardhat": "bun run swap:remappings:hardhat && bun ./node_modules/.bin/hardhat compile",
+    "build": "bun run build:clean && bun run build:forge && bun run build:hardhat",
+    "build:mod": "(bun run deploy:standalone || true) && bun ./node_modules/.bin/effectstream-hardhat-builder",
+    "contract:compile": "bun run build:mod",
     "deploy:clean": "rm -rf ignition/deployments || true",
-    "deploy:standalone": {
-      "command": "(((deno task chain:start) &) && (deno task chain:wait) && (deno task deploy) && deno task chain:stop) || true",
-      "dependencies": [
-        "build"
-      ]
-    },
-    "deploy": {
-      "command": "deno run -A deploy.ts",
-      "dependencies": [
-        "deploy:clean"
-      ]
-    },
-    "chain:start": "deno run -A npm:hardhat@3.0.4 node",
+    "deploy:standalone": "bun run build && (((bun run chain:start) &) && (bun run chain:wait) && (bun run deploy) && (bun run chain:stop)) || true",
+    "deploy": "bun run deploy:clean && bun ./deploy.ts",
+    "chain:start": "bun ./node_modules/.bin/hardhat node",
     "chain:stop": "kill -9 $(lsof -ti tcp:8545) || true",
-    "chain:wait": "deno run -A npm:hardhat@3.0.4 node wait"
+    "chain:wait": "bun ./node_modules/.bin/hardhat node wait"
   }
 }
 ```

--- a/docs/site/docs/home/200-chains/202-midnight.md
+++ b/docs/site/docs/home/200-chains/202-midnight.md
@@ -83,7 +83,7 @@ The protocol type `MIDNIGHT_PARALLEL` connects to the Midnight Indexer (GraphQL)
 ### Contract Development
 
 *   **Language**: Compact (a TypeScript-inspired DSL for ZK).
-*   **Compilation**: `deno task build:midnight`
+*   **Compilation**: `bun run --cwd packages/contracts-midnight build`
 
 A Midnight contract defines private state transitions (`circuits`) and can choose to expose certain data publicly in its `ledger`. EffectStream can only see what is in the public `ledger`.
 
@@ -217,22 +217,21 @@ processesToLaunch: [
 ]
 ```
 
-> NOTE: To use this launcher you need to implement some `deno task` in your project. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
+> NOTE: To use this launcher you need to implement some scripts in your project's `package.json`. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
 
 ```json
 {
   "name": "@e2e/midnight-contracts",
-  ...
-  "tasks": {
-    "midnight-node:start": "CFG_PRESET=dev deno run -A --unstable-detect-cjs @effectstream/npm-midnight-node --dev --rpc-port 9944 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
+  "scripts": {
+    "midnight-node:start": "CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
-    "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" deno run -A --unstable-detect-cjs @effectstream/npm-midnight-indexer --binary --clean",
+    "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
     "midnight-indexer:wait": "wait-on tcp:8088",
-    "midnight-proof-server:start": "LEDGER_NETWORK_ID=\"Undeployed\" RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" deno run -A --unstable-detect-cjs @effectstream/npm-midnight-proof-server",
+    "midnight-proof-server:start": "LEDGER_NETWORK_ID=\"Undeployed\" RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db contract-eip-20.json contract-counter.json",
-    "midnight-contract:deploy": "deno task midnight-contract:clean && deno task contract-eip20:deploy && deno task contract-counter:deploy",
-    "contract-counter:deploy": "deno --unstable-detect-cjs -A contract-counter-deploy.ts",
-    "contract-eip20:deploy": "deno --unstable-detect-cjs -A contract-eip-20-deploy.ts"
+    "midnight-contract:deploy": "bun run midnight-contract:clean && bun run contract-eip20:deploy && bun run contract-counter:deploy",
+    "contract-counter:deploy": "bun ./contract-counter-deploy.ts",
+    "contract-eip20:deploy": "bun ./contract-eip-20-deploy.ts"
   }
 }

--- a/docs/site/docs/home/200-chains/203-cardano.md
+++ b/docs/site/docs/home/200-chains/203-cardano.md
@@ -290,18 +290,17 @@ processesToLaunch: [
 ]
 ```
 
-> NOTE: To use this launcher you need to implement some `deno task` in your project. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
+> NOTE: To use this launcher you need to implement some scripts in your project's `package.json`. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
 
 ```json
 {
   "name": "@e2e/cardano-contracts",
-  ...
-  "tasks": {
-    "devkit:start": "deno run -A --node-modules-dir npm:@bloxbean/yaci-devkit up",
+  "scripts": {
+    "devkit:start": "bun ./node_modules/.bin/yaci-devkit up",
     "devkit:wait": "wait-on tcp:3001",
-    "dolos:fill-template": "deno run -A ./fill-template.ts",
-    "dolos:start": "rm -rf ./data && rm -rf ./dolos.socket && deno task dolos:fill-template && deno run -A --node-modules-dir npm:@txpipe/dolos bootstrap relay && deno run -A --node-modules-dir npm:@txpipe/dolos daemon",
-    "dolos:wait": "wait-on tcp:50051" // utxorpc port
+    "dolos:fill-template": "bun ./fill-template.ts",
+    "dolos:start": "rm -rf ./data && rm -rf ./dolos.socket && bun run dolos:fill-template && bun ./node_modules/.bin/dolos bootstrap relay && bun ./node_modules/.bin/dolos daemon",
+    "dolos:wait": "wait-on tcp:50051"
   }
 }
 ```

--- a/docs/site/docs/home/200-chains/204-avail.md
+++ b/docs/site/docs/home/200-chains/204-avail.md
@@ -121,17 +121,16 @@ processesToLaunch: [
 ]
 ```
 
-> NOTE: To use this launcher you need to implement some `deno task` in your project. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
+> NOTE: To use this launcher you need to implement some scripts in your project's `package.json`. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
 
 ```json
 {
   "name": "@e2e/avail-contracts",
-  ...
-  "tasks": {
-    "avail-node:start": "deno run -A --unstable-detect-cjs @effectstream/npm-avail-node --dev --rpc-port 9955 --no-telemetry",
+  "scripts": {
+    "avail-node:start": "bun ./node_modules/.bin/npm-avail-node --dev --rpc-port 9955 --no-telemetry",
     "avail-node:wait": "wait-on tcp:9955",
-    "avail-light-client:deploy": "deno task avail-light-client:clean && deno run -A --unstable-detect-cjs ./deploy.ts",
-    "avail-light-client:start": "deno run -A --unstable-detect-cjs @effectstream/npm-avail-light-client --config ./config.yml --app-id $AVAIL_APP_ID",
+    "avail-light-client:deploy": "bun run avail-light-client:clean && bun ./deploy.ts",
+    "avail-light-client:start": "bun ./node_modules/.bin/npm-avail-light-client --config ./config.yml --app-id $AVAIL_APP_ID",
     "avail-light-client:wait": "wait-on tcp:7007",
     "avail-light-client:clean": "rm -rf ./avail_path"
   }

--- a/docs/site/docs/home/200-chains/205-bitcoin.md
+++ b/docs/site/docs/home/200-chains/205-bitcoin.md
@@ -88,16 +88,15 @@ processesToLaunch: [
 
 It is also common to include a process to mine blocks automatically in the background to ensure transaction processing during development.
 
-> NOTE: To use this launcher you need to implement some `deno task` in your project. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
+> NOTE: To use this launcher you need to implement some scripts in your project's `package.json`. A working implementation is provided in the `template generator`, `templates` or `e2e tests`.
 
 ```json
 {
   "name": "@e2e/bitcoin-contracts",
-  ...
-  "tasks": {
-    "chain:start": "deno run -A @effectstream/bitcoin-core",
+  "scripts": {
+    "chain:start": "bun ./node_modules/.bin/bitcoin-core",
     "chain:wait": "wait-on tcp:18443",
-    "generate:blocks": "deno run -A ./generate-blocks.ts",
-    "wait-for-block": "deno run -A wait-for-block.ts"
+    "generate:blocks": "bun ./generate-blocks.ts",
+    "wait-for-block": "bun ./wait-for-block.ts"
   }
 }

--- a/docs/site/docs/home/500-packages/510-sdk/chain-types.md
+++ b/docs/site/docs/home/500-packages/510-sdk/chain-types.md
@@ -14,6 +14,11 @@ rollup inputs, and timer triggers. Re-exported through
 Use it to compute EffectStream block / input / timer hashes off-chain —
 for example, in an external indexer, a proof system, or a verifier.
 
+- Type definitions and deterministic block / input / timer hashes for Effectstream.
+- Pure functions, no runtime dependency on the rest of the framework.
+- Useful for off-chain verifiers and external indexers.
+- Re-exported through `@effectstream/node-sdk/chain-types`.
+
 ## Install
 
 ```bash
@@ -73,4 +78,4 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/chain-types
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/chain-types
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/chain-types

--- a/docs/site/docs/home/500-packages/510-sdk/concise.md
+++ b/docs/site/docs/home/500-packages/510-sdk/concise.md
@@ -13,6 +13,11 @@ batcher uses to pack many small user inputs into one on-chain transaction.
 Define a grammar of allowed commands; the package generates, parses, and
 validates inputs against it with TypeBox.
 
+- Type-safe, compact message schemas for Effectstream's batcher.
+- TypeBox grammar, encoder + parser + batcher message construction.
+- Used by the batcher to pack many small inputs into one on-chain transaction.
+- Also exports the canonical wallet-signing message and subunit hashing helpers for client SDKs.
+
 ## Install
 
 ```bash
@@ -98,22 +103,22 @@ later reads.
 
 Grammar / schema (heavily used across the runtime + state machine):
 
-- `generateRawStmInput(grammarEntry, prefix, data)` — the high-volume encoder (`~46` cross-package call sites in this repo).
-- `buildBatchData(maxSize, inputs)` — pack as many subunits as fit under a byte budget (used in the batcher's submission path; `~35` sites).
-- `BatcherGrammar`, `BuiltinGrammar` — built-in command sets.
-- `generateStmInput(grammar, command, data)` — typed value → JSON tuple.
-- `parseStmInput(rawJson, grammar, keyed)` — parse and validate.
-- `toFullJsonGrammar(...)`, `toKeyedJsonGrammar(...)` — derive TypeBox schemas from a grammar map.
-- `extractBatches(inputData)` — inverse of `buildBatchData`.
-- `extractDelegateWallet(...)` — pull the delegated wallet out of an account-delegation input.
+- `generateRawStmInput(grammarEntry, prefix, data)`: the high-volume encoder (~46 cross-package call sites in this repo).
+- `buildBatchData(maxSize, inputs)` packs as many subunits as fit under a byte budget; used in the batcher's submission path with ~35 sites.
+- `BatcherGrammar`, `BuiltinGrammar`: built-in command sets.
+- `generateStmInput(grammar, command, data)`: typed value to JSON tuple.
+- `parseStmInput(rawJson, grammar, keyed)` parses and validates.
+- `toFullJsonGrammar(...)`, `toKeyedJsonGrammar(...)`: derive TypeBox schemas from a grammar map.
+- `extractBatches(inputData)`: inverse of `buildBatchData`.
+- `extractDelegateWallet(...)` pulls the delegated wallet out of an account-delegation input.
 - `accountMessages`, `accountPayload_` — helpers for the standard account-linking commands.
 
 Batcher message construction (intended for external client SDKs and
 tests; the in-repo batcher uses a lower-level path):
 
-- `createMessageForBatcher(namespace, ts, address, addressType, input, target?)` — canonical string the wallet signs.
-- `createBatcherSubunit(ts, address, addressType, signature, input)` — pack a signed input into a subunit shape.
-- `hashBatchSubunit(input)` — `0x`-prefixed keccak256 over the subunit.
+- `createMessageForBatcher(namespace, ts, address, addressType, input, target?)`: canonical string the wallet signs.
+- `createBatcherSubunit(ts, address, addressType, signature, input)` packs a signed input into a subunit shape.
+- `hashBatchSubunit(input)`: `0x`-prefixed keccak256 over the subunit.
 
 Also exported: `KeyedBatcherGrammar`, `parseRawStmInput`, `usesPrefix`.
 
@@ -124,9 +129,9 @@ Runnable: [`src/batcher.test.ts`](https://github.com/PaimaStudios/paima-engine/b
 [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/effectstream-sdk/concise/test/examples.test.ts).
 
 End-to-end batcher flow:
-[`e2e/evm/sync/batcher.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/e2e/evm/sync/batcher.test.ts).
+[`e2e/evm/sync/batcher.test.ts`](https://github.com/effectstream/effectstream/blob/main/e2e/evm/sync/batcher.test.ts).
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/concise
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/concise
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/concise

--- a/docs/site/docs/home/500-packages/510-sdk/config.md
+++ b/docs/site/docs/home/500-packages/510-sdk/config.md
@@ -13,6 +13,11 @@ contract addresses, sync protocols, primitives, and security namespaces. A
 fluent API with strict TypeScript inference: each builder step refines the
 type of what comes next, so misuse fails at compile time.
 
+- Fluent, type-safe configuration builders for Effectstream nodes.
+- Strict inference: each step refines the type of what comes next, so misuse is a compile error.
+- Used by every template's `packages/node/config.dev.ts`.
+- Covers networks, deployed contract addresses, sync protocols, primitives, security namespaces.
+
 ## Install
 
 ```bash
@@ -57,7 +62,7 @@ running a full node.
 
 `config` is what every node component reads to find out which chains to
 sync from, where contracts live, and what primitives to emit. The
-templates under [`templates/*`](https://github.com/PaimaStudios/paima-engine/tree/main/templates)
+templates under [`templates/*`](https://github.com/effectstream/effectstream/tree/main/templates)
 all define their config with `ConfigBuilder` in `packages/node/config.dev.ts`.
 
 ## Key exports
@@ -85,10 +90,10 @@ and aren't typically imported by app code.
 Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/effectstream-sdk/config/test/examples.test.ts).
 
 Real-world usage in templates:
-- [`templates/preorder/packages/node/config.dev.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/templates/preorder/packages/node/config.dev.ts)
-- [`templates/evm-cardano/packages/node/config.dev.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/templates/evm-cardano/packages/node/config.dev.ts)
+- [`templates/preorder/packages/node/config.dev.ts`](https://github.com/effectstream/effectstream/blob/main/templates/preorder/packages/node/config.dev.ts)
+- [`templates/evm-cardano/packages/node/config.dev.ts`](https://github.com/effectstream/effectstream/blob/main/templates/evm-cardano/packages/node/config.dev.ts)
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/config
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/config
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/config

--- a/docs/site/docs/home/500-packages/510-sdk/coroutine.md
+++ b/docs/site/docs/home/500-packages/510-sdk/coroutine.md
@@ -13,6 +13,11 @@ Defines the `StateUpdateStream` generator type and the `World.*` helpers
 that EffectStream's runtime executes — the API your state-transition
 functions yield against.
 
+- Generator-based control flow for state transitions: `World.resolve`, `World.all`, `World.promise`.
+- Used by the runtime to execute pgtyped queries inside a transaction.
+- Most authors reach for it through `@effectstream/sm`.
+- Threads pgtyped query results back into the generator transparently.
+
 ## Install
 
 ```bash
@@ -71,9 +76,9 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 
 For real state-machine code that uses these primitives, see the primitives
 implemented in
-[`packages/node-sdk/sm/primitives/src/`](https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/sm/primitives/src).
+[`packages/node-sdk/sm/primitives/src/`](https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/sm/primitives/src).
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/coroutine
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/coroutine
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/coroutine

--- a/docs/site/docs/home/500-packages/510-sdk/crypto.md
+++ b/docs/site/docs/home/500-packages/510-sdk/crypto.md
@@ -12,6 +12,11 @@ Multi-chain signature verification — one API that verifies wallet signatures
 from EVM, Cardano, Polkadot, Algorand, Mina, and Midnight. Also includes the
 `Prando` seeded RNG used for on-chain-derived randomness.
 
+- Multi-chain signature verification: EVM, Cardano, Polkadot, Algorand, Mina, Midnight.
+- Bundles the `Prando` seeded RNG for on-chain-derived randomness.
+- Used by the batcher to verify user-submitted input signatures.
+- Only depends on `@effectstream/utils`; safe to use standalone.
+
 ## Install
 
 ```bash
@@ -83,9 +88,9 @@ Runnable examples: [`src/Prando.test.ts`](https://github.com/PaimaStudios/paima-
 `bun test ./packages`.
 
 For end-to-end signature flows, see
-[`e2e/evm/sync/batcher.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/e2e/evm/sync/batcher.test.ts).
+[`e2e/evm/sync/batcher.test.ts`](https://github.com/effectstream/effectstream/blob/main/e2e/evm/sync/batcher.test.ts).
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/crypto
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/crypto
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/crypto

--- a/docs/site/docs/home/500-packages/510-sdk/event-client.md
+++ b/docs/site/docs/home/500-packages/510-sdk/event-client.md
@@ -12,6 +12,11 @@ MQTT-based event subscriber for EffectStream. Subscribe to type-safe events
 streamed by the engine and the batcher — blocks, transactions, primitive
 events, and any app-defined event — without writing raw MQTT topic strings.
 
+- MQTT subscriber for Effectstream events: blocks, transactions, primitives, app-defined.
+- Type-safe topics; no raw topic strings.
+- Connects to the broker run by `@effectstream/event-server` (or any MQTT broker).
+- Bun caveat: the `mqtt` WebSocket transport isn't supported on Bun yet; use Node for programmatic consumption.
+
 ## Install
 
 ```bash
@@ -91,4 +96,4 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/event-client
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/events
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/events

--- a/docs/site/docs/home/500-packages/510-sdk/log.md
+++ b/docs/site/docs/home/500-packages/510-sdk/log.md
@@ -13,6 +13,11 @@ OpenTelemetry-instrumented structured logging for EffectStream. Wraps
 both pretty console output (`log.local`) and OTLP traces/logs to your
 collector (`log.remote`).
 
+- OpenTelemetry-instrumented structured logging on top of `tslog`.
+- Pretty console output and OTLP traces / logs from one `log` object.
+- Used by every package in the framework so the node emits one trace tree.
+- `ComponentNames` constants tag log records by component, powering per-component log views.
+
 ## Install
 
 ```bash
@@ -70,16 +75,16 @@ powers the orchestrator's per-component log views.
 
 ## Key exports
 
-- `log.local(component, namespace, level, deferred)` — console-only logging. `level` is `SeverityNumber`; `deferred = (l) => l(...args)` is called only if the level passes the filter.
-- `log.localForce(...)` — bypasses level filtering.
-- `log.remote(...)` — console + OpenTelemetry log record. Same signature as `local`.
-- `log.remoteForce(...)` — `remote` without level filtering.
+- `log.local(component, namespace, level, deferred)`: console-only logging. `level` is `SeverityNumber`; `deferred = (l) => l(...args)` is called only if the level passes the filter.
+- `log.localForce(...)` bypasses level filtering.
+- `log.remote(...)`: console + OpenTelemetry log record. Same signature as `local`.
+- `log.remoteForce(...)` is `remote` without level filtering.
 - `log.formatMessage(...)` — the formatter used internally; useful for custom transports.
-- `defaultOtelSetup(opts)` — one-call OpenTelemetry SDK setup with sensible defaults.
-- `attachTransport(transport)` — register a custom tslog transport (e.g. ship logs to a file).
-- `SeverityNumber` — re-export of OpenTelemetry severity levels.
-- `ComponentNames` — string-enum constants used to tag logs by component.
-- `Namespace` — `string | string[]` for log namespacing.
+- `defaultOtelSetup(opts)`: one-call OpenTelemetry SDK setup with sensible defaults.
+- `attachTransport(transport)` registers a custom tslog transport (e.g. ship logs to a file).
+- `SeverityNumber`: re-export of OpenTelemetry severity levels.
+- `ComponentNames`: string-enum constants used to tag logs by component.
+- `Namespace`: `string | string[]` for log namespacing.
 
 ## Examples
 
@@ -88,4 +93,4 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/log
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/log
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/log

--- a/docs/site/docs/home/500-packages/510-sdk/precompile.md
+++ b/docs/site/docs/home/500-packages/510-sdk/precompile.md
@@ -13,6 +13,11 @@ by hashing with keccak256. The intended use is "precompile" addresses —
 synthetic 0x-addresses reserved by an EffectStream node for non-user
 logic (intrinsic primitives, timers, internal accounts).
 
+- Deterministic 20-byte addresses from string names via keccak256.
+- Pure functions; same name in, same address out.
+- Used by intrinsic primitives, timers, and internal accounts.
+- Result is an EVM-shaped `0x[40 hex chars]` string, usable wherever viem/ethers expects an `Address`.
+
 ## Install
 
 ```bash
@@ -63,4 +68,4 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/precompile
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/precompile
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/precompile

--- a/docs/site/docs/home/500-packages/510-sdk/utils.md
+++ b/docs/site/docs/home/500-packages/510-sdk/utils.md
@@ -18,6 +18,11 @@ This is the bottom-of-stack package: `@effectstream/crypto`,
 `@effectstream/concise`, `@effectstream/wallets`, and most node packages
 depend on it.
 
+- Shared chain-aware types, TypeBox schemas, viem helpers, Effection primitives.
+- Bottom-of-stack: `crypto`, `concise`, `wallets`, and most node packages depend on it.
+- Safe to use standalone, no runtime dependency on the rest of Effectstream.
+- `AddressType` is the most-imported symbol from the package (~170 cross-package references).
+
 ## Install
 
 ```bash
@@ -112,4 +117,4 @@ Runnable: [`src/binary-search.test.ts`](https://github.com/PaimaStudios/paima-en
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/utils
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/utils
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/utils

--- a/docs/site/docs/home/500-packages/510-sdk/wallets.md
+++ b/docs/site/docs/home/500-packages/510-sdk/wallets.md
@@ -14,6 +14,11 @@ wait for them to be processed. Spans MetaMask (and any EVM-injected
 wallet), Cardano (CIP-30), Midnight, Mina, Polkadot, Algorand, and
 Avail.
 
+- Browser wallet connectors plus the runtime client a frontend uses to log in, sign, and submit.
+- Spans MetaMask + injected EVM, Cardano (CIP-30), Midnight, Mina, Polkadot, Algorand, Avail.
+- Used together with `@effectstream/crypto` (server-side verification).
+- High-level helpers `walletLogin` and `sendTransaction` hide the polling loop.
+
 ## Install
 
 ```bash
@@ -77,27 +82,27 @@ hide the polling loop.
 
 Login + signing:
 
-- `walletLogin(args)` — top-level helper: discover, connect, produce a signed batcher login.
-- `EffectstreamConfig` — runtime config (chain URLs, batcher URL, …) the helpers consume.
+- `walletLogin(args)`: top-level helper that discovers, connects, and produces a signed batcher login.
+- `EffectstreamConfig`: runtime config (chain URLs, batcher URL, ...) the helpers consume.
 - `signMessage(wallet, message)` — sign an arbitrary message with the connected wallet.
 
 Sending transactions:
 
-- `sendTransaction(wallet, conciseInput, opts?)` — submit through the batcher and (by default) wait for processing.
-- `sendBatcherTransaction(...)` — explicit batcher submission.
-- `sendSelfSequencedTransaction(...)` — bypass the batcher.
+- `sendTransaction(wallet, conciseInput, opts?)`: submit through the batcher and (by default) wait for processing.
+- `sendBatcherTransaction(...)`: explicit batcher submission.
+- `sendSelfSequencedTransaction(...)` bypasses the batcher.
 - `waitForEffectstreamBlockProcessed(...)` — block-height poller used by the above.
 
 Wallet discovery / identification:
 
-- `WalletMode` — enum: `EvmInjected`, `EvmEthers`, `Midnight`, `Cardano`, `Polkadot`, `Algorand`, `Mina`, `AvailJs`.
-- `WalletNameMap` — `Record<WalletMode, string>` for display.
-- `allInjectedWallets(config)` — list installed wallets in the browser.
-- `getAddressType(walletMode)` — map a `WalletMode` to its `@effectstream/utils` `AddressType`.
+- `WalletMode`: enum of `EvmInjected`, `EvmEthers`, `Midnight`, `Cardano`, `Polkadot`, `Algorand`, `Mina`, `AvailJs`.
+- `WalletNameMap`: `Record<WalletMode, string>` for display.
+- `allInjectedWallets(config)` lists installed wallets in the browser.
+- `getAddressType(walletMode)` maps a `WalletMode` to its `@effectstream/utils` `AddressType`.
 
 Types:
 
-- `Wallet` — handle returned by `walletLogin`, used by send/sign helpers.
+- `Wallet`: handle returned by `walletLogin`, used by send/sign helpers.
 - `UserSignature`, `Hash`, `BatcherPostResponse`, `BatcherTrackResponse`, `PostDataResponse`, `PostDataResponseAsync`, `SignFunction`.
 
 Lower-level connector machinery (used internally; export surface is
@@ -113,11 +118,11 @@ Runnable: [`src/utils.test.ts`](https://github.com/PaimaStudios/paima-engine/blo
 Real-world usage in templates (each imports `walletLogin`, `WalletMode`,
 `EffectstreamConfig`, `sendTransaction`):
 
-- [`templates/chess-v2/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/chess-v2)
-- [`templates/evm-midnight-v2/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/evm-midnight-v2)
-- [`templates/shinkai-v2/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/shinkai-v2)
+- [`templates/chess-v2/`](https://github.com/effectstream/effectstream/tree/main/templates/chess-v2)
+- [`templates/evm-midnight-v2/`](https://github.com/effectstream/effectstream/tree/main/templates/evm-midnight-v2)
+- [`templates/shinkai-v2/`](https://github.com/effectstream/effectstream/tree/main/templates/shinkai-v2)
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/sdk/wallets
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/effectstream-sdk/wallets
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/effectstream-sdk/wallets

--- a/docs/site/docs/home/500-packages/520-node/db-emulator.md
+++ b/docs/site/docs/home/500-packages/520-node/db-emulator.md
@@ -13,6 +13,11 @@ EffectStream system schema plus your migrations to a Postgres or PgLite
 instance without booting the full runtime — handy for unit tests and CI
 fixtures.
 
+- Standalone migration runner: apply Effectstream's system schema + your migrations to a fresh DB.
+- For tests and CI fixtures; do not point at a production database.
+- Exists separately from `@effectstream/db` to break a circular dep with `@effectstream/sm`.
+- Single export: `standAloneApplyMigrations`.
+
 ## Install
 
 ```bash
@@ -70,4 +75,4 @@ For the broader migration pattern, see
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/db-emulator
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/db-emulator
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/db-emulator

--- a/docs/site/docs/home/500-packages/520-node/db.md
+++ b/docs/site/docs/home/500-packages/520-node/db.md
@@ -13,6 +13,11 @@ connection pool, ships every pgtyped-generated SQL query the runtime
 needs, owns the snapshot loop, and provides a mutex needed for safe
 single-threaded PgLite access.
 
+- Pooled Postgres client plus every pgtyped query the runtime needs.
+- Snapshot loop (`runSnapshotLoop`) and `acquireDBMutex` / `releaseDBMutex` for PgLite.
+- Subpath scripts for in-memory PgLite, migrations, and version checks.
+- `getConnection()` is the dominant entry point, ~31 call sites across the repo.
+
 ## Install
 
 ```bash
@@ -70,34 +75,34 @@ can rejoin without re-syncing from genesis.
 
 Connection management (heavily used):
 
-- `getConnection(creds?)` — pooled `Pool` singleton. The dominant entry point (~31 cross-package call sites).
-- `acquireDBMutex(name, priority?)` / `releaseDBMutex(name)` — coordination for PgLite (~7 cross-package call sites each).
+- `getConnection(creds?)`: pooled `Pool` singleton. Dominant entry point (~31 call sites across the repo).
+- `acquireDBMutex(name, priority?)` and `releaseDBMutex(name)` coordinate PgLite access; ~7 call sites each.
 - `waitUntilFree()` — companion to the mutex.
-- `getPersistentConnection(creds)` — a non-pooled `Client` for long-lived listeners.
+- `getPersistentConnection(creds)` returns a non-pooled `Client` for long-lived listeners.
 
 Queries (pgtyped-generated, shipped under one umbrella):
 
-- `getBlockHeights`, `getBlockByHash`, `blockHeightDone`, `saveLastBlock`, `getLatestProcessedBlockHeight` — block bookkeeping.
-- `getAchievementProgress`, `setAchievementProgress` — achievements.
+- Block bookkeeping: `getBlockHeights`, `getBlockByHash`, `blockHeightDone`, `saveLastBlock`, `getLatestProcessedBlockHeight`.
+- Achievements: `getAchievementProgress`, `setAchievementProgress`.
 - Re-exports of `*.queries.ts` for statistics, nonces, rollup inputs, accounts, events, sync protocol pages, primitives, system, tables.
 
 Snapshots:
 
 - `runSnapshotLoop` — periodic `pg_dump` of synced state.
-- `createSnapshot` — single-shot snapshot helper.
-- `SnapshotConfig`, `SnapshotRetentionConfig` — config types.
+- `createSnapshot`: single-shot snapshot helper.
+- `SnapshotConfig`, `SnapshotRetentionConfig`: config types.
 
 Dynamic table / event helpers:
 
-- `createDynamicTables` — register tables a primitive wants to own.
-- `createIndexesForEvents`, `registerEventHandlers` — register pgtyped indexes for app events.
+- `createDynamicTables` registers tables a primitive wants to own.
+- `createIndexesForEvents` and `registerEventHandlers` register pgtyped indexes for app events.
 
 Subpath entry points (executable scripts):
 
-- `@effectstream/db/start-pglite` — boot a PgLite instance.
+- `@effectstream/db/start-pglite`: boot a PgLite instance.
 - `@effectstream/db/apply-migrations` — apply SQL migrations against the active DB.
-- `@effectstream/db/db-wait` — block until the DB accepts a connection.
-- `@effectstream/db/pgtyped-update` — regenerate pgtyped types.
+- `@effectstream/db/db-wait`: block until the DB accepts a connection.
+- `@effectstream/db/pgtyped-update`: regenerate pgtyped types.
 - `@effectstream/db/version` — print schema version.
 
 ## Examples
@@ -108,4 +113,4 @@ Subpath entry points (executable scripts):
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/db
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/db
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/db

--- a/docs/site/docs/home/500-packages/520-node/event-server.md
+++ b/docs/site/docs/home/500-packages/520-node/event-server.md
@@ -13,6 +13,11 @@ EffectStream's event system. The runtime publishes block, transaction,
 primitive, and app events to this broker; frontends and workers
 subscribe via `@effectstream/event-client`.
 
+- Localhost-only MQTT broker (Aedes) for Effectstream events.
+- Publishes from non-loopback connections are rejected at the broker.
+- Paired with `@effectstream/event-client` on the consuming side.
+- Runs two brokers in production: one for engine events, one for batcher events.
+
 ## Install
 
 ```bash
@@ -65,4 +70,4 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/event-server
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/events
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/events

--- a/docs/site/docs/home/500-packages/520-node/node-sdk.md
+++ b/docs/site/docs/home/500-packages/520-node/node-sdk.md
@@ -13,6 +13,11 @@ An umbrella package that re-exports every EffectStream runtime piece
 schemas) under stable subpaths. Depend on this if you want a single
 name; import the underlying packages directly if you prefer.
 
+- Umbrella package: every Effectstream node piece reachable from one dependency.
+- Stable subpaths re-exporting the underlying packages (`/runtime`, `/sm`, `/db`, `/config`, ...).
+- Depend on this if you want a single name; import the underlying packages directly if you prefer.
+- Subpaths are thin re-exports, identical semantics to the source packages.
+
 ## Install
 
 ```bash
@@ -49,18 +54,18 @@ the corresponding package:
 
 ## Subpath exports
 
-- `@effectstream/node-sdk/runtime` — `init`, `start`, `StartConfig`, `DBMigrations`.
-- `@effectstream/node-sdk/sm` — `Stm`, state-machine types and helpers.
-- `@effectstream/node-sdk/sm/builtin` — built-in primitive type tags (ERC20, ERC721, ERC1155, Cardano transfer/mint-burn/pool-delegation, Midnight generic, NEAR, Avail, Celestia, …).
-- `@effectstream/node-sdk/sm/grammar` — concise/grammar parsing utilities.
-- `@effectstream/node-sdk/sync` — `genSyncProtocols`, per-chain fetcher classes.
-- `@effectstream/node-sdk/db` — `getConnection`, query helpers, snapshot utilities.
-- `@effectstream/node-sdk/db/start-pglite`, `./db/apply-migrations`, `./db/db-wait`, `./db/pgtyped-update`, `./db/version` — DB operations scripts.
-- `@effectstream/node-sdk/db-emulator` — in-memory test DB migration runner.
-- `@effectstream/node-sdk/event-server` — local MQTT broker.
-- `@effectstream/node-sdk/config` — `ConfigBuilder` and friends.
-- `@effectstream/node-sdk/chain-types`, `./precompile`, `./concise`, `./coroutine` — pass-throughs to the same-named SDK packages.
-- `@effectstream/node-sdk/utils`, `./utils/node-env`, `./utils/runtime` — utility helpers.
+- `@effectstream/node-sdk/runtime`: `init`, `start`, `StartConfig`, `DBMigrations`.
+- `@effectstream/node-sdk/sm`: `Stm` plus state-machine types and helpers.
+- `@effectstream/node-sdk/sm/builtin` ships built-in primitive type tags (ERC20, ERC721, ERC1155, Cardano transfer/mint-burn/pool-delegation, Midnight generic, NEAR, Avail, Celestia, ...).
+- `@effectstream/node-sdk/sm/grammar`: concise/grammar parsing utilities.
+- `@effectstream/node-sdk/sync` — `genSyncProtocols` and per-chain fetcher classes.
+- `@effectstream/node-sdk/db`: `getConnection`, query helpers, snapshot utilities.
+- `@effectstream/node-sdk/db/start-pglite`, `./db/apply-migrations`, `./db/db-wait`, `./db/pgtyped-update`, `./db/version`: DB operations scripts.
+- `@effectstream/node-sdk/db-emulator`: in-memory test DB migration runner.
+- `@effectstream/node-sdk/event-server`: local MQTT broker.
+- `@effectstream/node-sdk/config`: `ConfigBuilder` and friends.
+- `@effectstream/node-sdk/chain-types`, `./precompile`, `./concise`, `./coroutine` are pass-throughs to the same-named SDK packages.
+- `@effectstream/node-sdk/utils`, `./utils/node-env`, `./utils/runtime`: utility helpers.
 
 ## Examples
 
@@ -69,10 +74,10 @@ each subpath resolves.
 
 For full working nodes, see:
 
-- [`templates/minimal/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/minimal)
-- [`templates/dice/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/dice)
+- [`templates/minimal/`](https://github.com/effectstream/effectstream/tree/main/templates/minimal)
+- [`templates/dice/`](https://github.com/effectstream/effectstream/tree/main/templates/dice)
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/node-sdk
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/node
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/node

--- a/docs/site/docs/home/500-packages/520-node/runtime.md
+++ b/docs/site/docs/home/500-packages/520-node/runtime.md
@@ -13,6 +13,11 @@ database, events, and HTTP API together inside an EffectStream node.
 Boot it with `init()` then drive it with `start(config)` and your node
 is up.
 
+- The state-machine runtime that owns an Effectstream node's process model.
+- `init()` once, `start(config)` to run; ties sync, state machine, DB, events, and HTTP API together.
+- Used by every template.
+- Also reachable through `@effectstream/node-sdk/runtime`.
+
 ## Install
 
 ```bash
@@ -82,16 +87,16 @@ Types and helpers re-exported alongside `init` / `start`:
 ## Examples
 
 The templates under
-[`templates/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates)
+[`templates/`](https://github.com/effectstream/effectstream/tree/main/templates)
 are full working `init()` + `start()` examples. The simplest is
-[`templates/minimal/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/minimal).
+[`templates/minimal/`](https://github.com/effectstream/effectstream/tree/main/templates/minimal).
 
 End-to-end EVM sync test:
-[`e2e/evm/sync/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e/evm/sync).
+[`e2e/evm/sync/`](https://github.com/effectstream/effectstream/tree/main/e2e/evm/sync).
 
 Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/node-sdk/runtime/test/examples.test.ts).
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/runtime
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/runtime
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/runtime

--- a/docs/site/docs/home/500-packages/520-node/sm.md
+++ b/docs/site/docs/home/500-packages/520-node/sm.md
@@ -13,6 +13,11 @@ of commands, register one generator per command, and `Stm` parses each
 incoming batcher input, dispatches it to the right handler, and yields
 SQL updates through the runtime.
 
+- State-machine DSL: define a typed grammar, register one generator per command.
+- Parses each batcher input, dispatches to the handler, yields SQL through the runtime.
+- `@effectstream/sm/builtin` ships common on-chain event primitives (ERC-20/721/1155, Cardano, Midnight, ...).
+- DSL is directly testable in a pure-TS unit test, without a database.
+
 ## Install
 
 ```bash
@@ -31,7 +36,7 @@ the runtime executes it.
 
 The DSL is also directly testable in a pure-TS unit test (parse + dispatch
 without a database) — see
-[`primitives/src/evm-erc20/erc20-primitive.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/node-sdk/sm/primitives/src/evm-erc20/erc20-primitive.test.ts).
+[`primitives/src/evm-erc20/erc20-primitive.test.ts`](https://github.com/effectstream/effectstream/blob/main/packages/node-sdk/sm/primitives/src/evm-erc20/erc20-primitive.test.ts).
 
 ```typescript
 import { Stm } from "@effectstream/sm";
@@ -70,9 +75,9 @@ Midnight events, etc. — so you don't re-implement them.
 
 ## Key exports
 
-- `Stm<Grammar, Events>` — the state machine. `.addStateTransition(prefix, handler)`, `.processInput(input)`, `.grammar`, `.fullJsonGrammar`, `.keyedJsonGrammar`.
-- `ParamToData<Params>` — derives the typed argument shape from a grammar entry.
-- `BaseStfInput` — the input shape passed to every handler (includes `msTimestamp`, `blockHeight`, etc.).
+- `Stm<Grammar, Events>`: the state machine. `.addStateTransition(prefix, handler)`, `.processInput(input)`, `.grammar`, `.fullJsonGrammar`, `.keyedJsonGrammar`.
+- `ParamToData<Params>` derives the typed argument shape from a grammar entry.
+- `BaseStfInput`: input shape passed to every handler. Includes `msTimestamp`, `blockHeight`, etc.
 - `delegate-wallet` helpers — account delegation primitives reused by built-ins.
 
 `MessageListener<Events, Params>` is exported as the handler type but is
@@ -80,14 +85,14 @@ inferred at call sites rather than imported directly.
 
 Subpath exports:
 
-- `@effectstream/sm/builtin` — `PrimitiveTypeERC20`, `PrimitiveTypeERC721`, `PrimitiveTypeERC1155`, `PrimitiveTypeCardanoTransfer`, `PrimitiveTypeMidnightGeneric`, and many more (20+ chain-specific event tags).
-- `@effectstream/sm/grammar` — the underlying grammar/parsing utilities (also re-exported from `@effectstream/concise`).
+- `@effectstream/sm/builtin`: `PrimitiveTypeERC20`, `PrimitiveTypeERC721`, `PrimitiveTypeERC1155`, `PrimitiveTypeCardanoTransfer`, `PrimitiveTypeMidnightGeneric`, and 20+ more chain-specific event tags.
+- `@effectstream/sm/grammar`: the underlying grammar/parsing utilities, also re-exported from `@effectstream/concise`.
 
 ## Examples
 
-- [`primitives/src/evm-erc20/erc20-primitive.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/node-sdk/sm/primitives/src/evm-erc20/erc20-primitive.test.ts) — a real primitive's behavior unit-tested.
+- [`primitives/src/evm-erc20/erc20-primitive.test.ts`](https://github.com/effectstream/effectstream/blob/main/packages/node-sdk/sm/primitives/src/evm-erc20/erc20-primitive.test.ts) — a real primitive's behavior unit-tested.
 - Game logic in
-  [`templates/dice/packages/node/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/dice/packages/node)
+  [`templates/dice/packages/node/`](https://github.com/effectstream/effectstream/tree/main/templates/dice/packages/node)
   shows the full `new Stm(...).addStateTransition(...)` pattern.
 
 Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/node-sdk/sm/test/examples.test.ts).
@@ -95,4 +100,4 @@ Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/sm
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/sm
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/sm

--- a/docs/site/docs/home/500-packages/520-node/sync.md
+++ b/docs/site/docs/home/500-packages/520-node/sync.md
@@ -13,6 +13,11 @@ blocks from every chain you've configured (EVM, Bitcoin, Cardano, Midnight,
 Avail, Celestia, NEAR…), normalizes them into a single rollup ordering,
 and stages the inputs the state machine consumes.
 
+- Blockchain-sync service: reads finalized blocks from every configured chain.
+- Normalises into a single rollup ordering and stages inputs for the state machine.
+- Drop-in fetchers: EVM, Bitcoin, Cardano UTXO-RPC, Midnight, Avail, Celestia, NEAR, NTP.
+- `genSyncProtocols(config)` is what the runtime calls during boot.
+
 ## Install
 
 ```bash
@@ -32,7 +37,7 @@ author you declare which protocols to sync in your config; everything
 else runs automatically.
 
 If you're building a new chain integration, implement the sync-protocol
-interfaces in [`src/sync-protocols/`](https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/sync/src/sync-protocols).
+interfaces in [`src/sync-protocols/`](https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/sync/src/sync-protocols).
 
 ## Inside EffectStream
 
@@ -66,11 +71,11 @@ custom orchestration layer.
 ## Examples
 
 End-to-end sync test (boots a node, reads blocks, asserts the DB):
-[`e2e/evm/sync/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e/evm/sync).
+[`e2e/evm/sync/`](https://github.com/effectstream/effectstream/tree/main/e2e/evm/sync).
 
 Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/node-sdk/sync/test/examples.test.ts).
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/node/sync
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/node-sdk/sync
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/node-sdk/sync

--- a/docs/site/docs/home/500-packages/530-chains/avail-contracts.md
+++ b/docs/site/docs/home/500-packages/530-chains/avail-contracts.md
@@ -13,6 +13,11 @@ EffectStream. Reserved as the home for Avail-side bindings, helpers, and
 deployment scripts that an EffectStream app might use when posting data
 blobs to or syncing rollup inputs from Avail.
 
+- Reserved namespace for Avail-side bindings, helpers, and deployment scripts.
+- Ships intentionally empty today: `mod.ts` re-exports nothing.
+- Mirrors the per-chain "contracts" slot used by EVM, Midnight, Cardano, Bitcoin.
+- For sync-side Avail support today, see `@effectstream/sync` and the Avail binary wrappers.
+
 ## Install
 
 ```bash
@@ -23,17 +28,13 @@ npm install @effectstream/avail-contracts
 
 ## Standalone usage
 
-This package is currently a **stub**. It ships so that
-`@effectstream/sync` and `@effectstream/orchestrator` can declare a
-stable dependency on the Avail integration namespace; concrete exports
-(message-encoding helpers, address utilities) will land here as the
-Avail integration evolves.
+This package is intentionally empty today. It ships so that `@effectstream/sync` and `@effectstream/orchestrator` can declare a stable dependency on the Avail integration namespace; concrete exports (message-encoding helpers, address utilities) land here as the Avail integration grows.
 
 For sync-side Avail support today, see:
 
 - `@effectstream/sync` — `AvailFetcher`, `AvailSyncState`.
 - `@effectstream/npm-avail-node`, `@effectstream/npm-avail-light-client` — pinned binary wrappers.
-- [`templates/avail/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/avail) — a working node configured against an Avail testnet.
+- [`e2e/avail/`](https://github.com/effectstream/effectstream/tree/main/e2e/avail) — Avail-side E2E suite.
 
 ## Inside EffectStream
 
@@ -51,5 +52,5 @@ helper.
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/chains/avail-contracts
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/chains/avail-contracts
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/chains/avail-contracts
 - Avail docs: https://docs.availproject.org/

--- a/docs/site/docs/home/500-packages/530-chains/bitcoin-contracts.md
+++ b/docs/site/docs/home/500-packages/530-chains/bitcoin-contracts.md
@@ -13,6 +13,11 @@ two `bun run` scripts used by the orchestrator and templates: a regtest
 block generator and a "wait for block N" RPC poller. Built on
 [`bitcoinjs-lib`](https://github.com/bitcoinjs/bitcoinjs-lib).
 
+- Two `bun run` scripts: regtest block generator and wait-for-block RPC poller.
+- Talks to Bitcoin Core's JSON-RPC at `http://127.0.0.1:18443` by default.
+- Pair with `@effectstream/bitcoin-core` for the binary.
+- Used by the orchestrator's Bitcoin step and the Bitcoin E2E suite.
+
 ## Install
 
 ```bash
@@ -59,7 +64,7 @@ consume the regtest chain that these scripts keep moving.
 ## Examples
 
 The Bitcoin sync E2E suite at
-[`e2e/bitcoin/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e/bitcoin)
+[`e2e/bitcoin/`](https://github.com/effectstream/effectstream/tree/main/e2e/bitcoin)
 shows the full flow: orchestrator boots `@effectstream/bitcoin-core`,
 this package generates blocks, sync ingests them, the test asserts on
 the DB.
@@ -67,5 +72,5 @@ the DB.
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/chains/bitcoin-contracts
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/chains/bitcoin-contracts
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/chains/bitcoin-contracts
 - bitcoinjs-lib: https://github.com/bitcoinjs/bitcoinjs-lib

--- a/docs/site/docs/home/500-packages/530-chains/cardano-contracts.md
+++ b/docs/site/docs/home/500-packages/530-chains/cardano-contracts.md
@@ -13,6 +13,11 @@ the home for Cardano-side bindings, helpers, and deployment scripts that
 an EffectStream app might use when interacting with Cardano-native
 contracts (Plutus, Aiken).
 
+- Reserved namespace for Cardano-side bindings, helpers, and deployment scripts.
+- Ships intentionally empty today: `mod.ts` re-exports nothing.
+- Mirrors the per-chain "contracts" slot used by EVM, Midnight, Bitcoin, Avail.
+- For Cardano support today, see `@effectstream/sync`'s `UtxoRpcFetcher` and `@effectstream/sm/builtin`'s Cardano primitives.
+
 ## Install
 
 ```bash
@@ -23,17 +28,13 @@ npm install @effectstream/cardano-contracts
 
 ## Standalone usage
 
-This package is currently a **stub**. It ships so that
-`@effectstream/sync`, `@effectstream/orchestrator`, and the templates can
-depend on a stable Cardano integration namespace. Concrete exports —
-script encoders, datum types, common policy IDs — will land here as the
-Cardano integration evolves.
+This package is intentionally empty today. It ships so that `@effectstream/sync`, `@effectstream/orchestrator`, and the templates can depend on a stable Cardano integration namespace; concrete exports (script encoders, datum types, common policy IDs) land here as the Cardano integration grows.
 
 For Cardano support today, see:
 
 - `@effectstream/sync` — `UtxoRpcFetcher`, `UtxoRpcSyncState` for Cardano UTXO-RPC sync.
 - `@effectstream/sm/builtin` — `PrimitiveTypeCardanoTransfer`, `PrimitiveTypeCardanoMintBurn`, `PrimitiveTypeCardanoPoolDelegation`, `PrimitiveTypeCardanoDelayedAsset`, `PrimitiveTypeCardanoProjectedNFT`.
-- Templates: [`templates/cardano-delegation/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/cardano-delegation), [`templates/preorder/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/preorder), [`templates/evm-cardano/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/evm-cardano), [`templates/projected-nft-preorder/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/projected-nft-preorder), [`templates/zk-cardano/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/zk-cardano).
+- Templates: [`templates/cardano-delegation/`](https://github.com/effectstream/effectstream/tree/main/templates/cardano-delegation), [`templates/preorder/`](https://github.com/effectstream/effectstream/tree/main/templates/preorder), [`templates/evm-cardano/`](https://github.com/effectstream/effectstream/tree/main/templates/evm-cardano), [`templates/projected-nft-preorder/`](https://github.com/effectstream/effectstream/tree/main/templates/projected-nft-preorder), [`templates/zk-cardano/`](https://github.com/effectstream/effectstream/tree/main/templates/zk-cardano).
 
 ## Inside EffectStream
 
@@ -49,4 +50,4 @@ if you have a Cardano-side helper you'd like to upstream.
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/chains/cardano-contracts
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/chains/cardano-contracts
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/chains/cardano-contracts

--- a/docs/site/docs/home/500-packages/530-chains/evm-contracts.md
+++ b/docs/site/docs/home/500-packages/530-chains/evm-contracts.md
@@ -8,270 +8,55 @@ sidebar_label: "evm-contracts"
 
 > Package: **[`@effectstream/evm-contracts`](https://www.npmjs.com/package/@effectstream/evm-contracts)** · [Source](https://github.com/PaimaStudios/paima-engine/tree/main/packages/chains/evm-contracts)
 
-NPM package for EVM contracts for EffectStream and related utilities.
+Solidity sources and compiled ABIs for Effectstream's EVM contracts, distributed as an npm package. Pairs with [`@effectstream/evm-hardhat`](https://www.npmjs.com/package/@effectstream/evm-hardhat), which ships the Hardhat tooling (config builder, JSON-RPC server, deploy helpers).
 
-See
-[the Effectstream documentation](https://effectstream.github.io/docs/home/libraries/evm-contracts/introduction)
-for full documentation.
+- Canonical home for Effectstream's EVM-side contracts. Other packages import the ABIs from here.
+- Compiled artifacts ship in the tarball so consumers don't need a Solidity toolchain unless they're modifying contracts.
+- Hardhat tooling lives in `@effectstream/evm-hardhat`. This package is kept lean on purpose.
 
-# Hardhat Config Builder
+## Install
 
-This package also provides a unified Hardhat configuration builder that consolidates common Hardhat setup logic used across e2e tests and templates.
-
-## Overview
-
-The unified config builder provides three main functions:
-
-1. **`createHardhatConfig()`** - Creates a complete Hardhat configuration with automatic default networks
-2. **`createNodeTasks()`** - Creates custom Hardhat tasks for running local blockchain nodes
-3. **`initTelemetry()`** - Initializes OpenTelemetry for Hardhat
-
-**Key Features:**
-- **Automatic Default Networks**: Default networks (`evmMain`, `evmMainHttp`, `evmParallel`, `evmParallelHttp`) are included when `networks` is not specified.
-- **Centralized Configuration**: All common Hardhat setup logic in one place
-- **Type Safe**: Full TypeScript support with proper types
-- **Flexible**: Supports both `@effectstream` and `@paimaexample` package namespaces
-
-**Additional Utilities:**
-- **`createDefaultNetworks()`** - Helper function to create default network configurations
-
-## Usage
-
-### Basic Example
-
-```typescript
-import type { HardhatUserConfig } from "hardhat/config";
-import {
-  createHardhatConfig,
-  createNodeTasks,
-  initTelemetry,
-} from "@effectstream/evm-hardhat/hardhat-config-builder";
-// or for templates:
-// } from "@paimaexample/evm-hardhat/hardhat-config-builder";
-
-import {
-  JsonRpcServerImplementation,
-} from "@effectstream/evm-hardhat/json-rpc-server";
-// or for templates:
-// } from "@paimaexample/evm-hardhat/json-rpc-server";
-
-import fs from "node:fs";
-import waitOn from "wait-on";
-import {
-  ComponentNames,
-  log,
-  SeverityNumber,
-} from "@effectstream/log";
-// or for templates:
-// } from "@paimaexample/log";
-
-const __dirname = import.meta.dirname;
-
-// Initialize telemetry (optional)
-// Note: logPackage parameter is kept for backward compatibility but ignored
-initTelemetry("@effectstream/log", "./deno.json");
-// or for templates:
-// initTelemetry("@paimaexample/log", "./deno.json");
-
-// Create node tasks (optional, only if you need local node functionality)
-const nodeTasks = createNodeTasks({
-  JsonRpcServer: {} as unknown as never, // Type placeholder, optional and not used
-  JsonRpcServerImplementation,
-  ComponentNames,
-  log,
-  SeverityNumber,
-  waitOn,
-  fs,
-});
-
-// Create unified config with default networks
-const config: HardhatUserConfig = createHardhatConfig({
-  sourcesDir: `${__dirname}/src/contracts`,
-  artifactsDir: `${__dirname}/build/artifacts/hardhat`,
-  cacheDir: `${__dirname}/build/cache/hardhat`,
-  // Default networks (evmMain, evmMainHttp, evmParallel, evmParallelHttp) are used automatically
-  tasks: nodeTasks, // Optional: only include if you created node tasks
-  solidityVersion: "0.8.30", // Optional: defaults to "0.8.30"
-});
-
-export default config;
+```bash
+bun add @effectstream/evm-contracts
+# or
+npm install @effectstream/evm-contracts
 ```
 
-## API Reference
+## Standalone usage
 
-### `createDefaultNetworks(options?: DefaultNetworkOptions): Record<string, NetworkConfig>`
-
-Creates default network configurations commonly used in e2e tests and templates. This function is used by `createHardhatConfig()` when default networks are enabled, but can also be called directly if you need to create networks separately or customize them.
-
-#### When to Use
-
-- **Directly**: When you want to create default networks and pass them explicitly to `createHardhatConfig()`
-- **Internally**: Automatically called by `createHardhatConfig()` when `networks` is not provided (default behavior)
-- **Customization**: Use with `defaultNetworkOptions` in `createHardhatConfig()` to customize default network parameters
-
-#### Parameters
-
-- `options.evmMainPort` (optional): Base port for evmMain (defaults to `8545`)
-- `options.evmParallelPort` (optional): Base port for evmParallel (defaults to `8546`)
-- `options.evmMainChainId` (optional): Chain ID for evmMain (defaults to `31337`)
-- `options.evmParallelChainId` (optional): Chain ID for evmParallel (defaults to `31338`)
-- `options.evmMainInterval` (optional): Mining interval for evmMain in ms (defaults to `250`)
-- `options.evmParallelInterval` (optional): Mining interval for evmParallel in ms (defaults to `1000`)
-
-#### Returns
-
-A network configuration object with:
-- `evmMain`: Fast network (250ms block interval) on chainId 31337, port 8545
-- `evmMainHttp`: HTTP wrapper for evmMain (used by Hardhat Ignition for deployments)
-- `evmParallel`: Slower network (1s block interval) on chainId 31338, port 8546
-- `evmParallelHttp`: HTTP wrapper for evmParallel (used by Hardhat Ignition for deployments)
-
-#### Example
+Import a compiled ABI:
 
 ```typescript
-import { createDefaultNetworks } from "@effectstream/evm-contracts";
+import EffectstreamL2 from "@effectstream/evm-contracts/artifacts/EffectstreamL2.json";
 
-// Create default networks with custom ports
-const networks = createDefaultNetworks({
-  evmMainPort: 8545,
-  evmParallelPort: 8546,
-  evmMainInterval: 500, // Slower than default
-});
-
-// Use in createHardhatConfig
-const config = createHardhatConfig({
-  sourcesDir: `${__dirname}/src/contracts`,
-  artifactsDir: `${__dirname}/build/artifacts/hardhat`,
-  cacheDir: `${__dirname}/build/cache/hardhat`,
-  networks, // Explicitly pass networks
-  useDefaultNetworks: false, // Disable auto-creation since we're passing networks
-});
+const abi = EffectstreamL2.abi;
+const bytecode = EffectstreamL2.bytecode;
 ```
 
-### `createHardhatConfig(options: HardhatConfigOptions): HardhatUserConfig`
+For the full list of contracts and their export paths, see [the docs](https://effectstream.github.io/docs/home/libraries/evm-contracts/introduction).
 
-Creates a unified Hardhat configuration.
+## Inside Effectstream
 
-#### Parameters
+The state machine and batcher read EVM events against ABIs exported here. Templates that target EVM include this package transitively through `@effectstream/evm-hardhat`'s deploy pipeline, so you usually don't import it by hand — you reference the contract names you want to deploy.
 
-- `options.sourcesDir` (required): Directory containing contract sources
-- `options.artifactsDir` (required): Directory for compiled artifacts
-- `options.cacheDir` (required): Directory for Hardhat cache
-- `options.networks` (optional): Networks configuration object. **If not provided, default networks (`evmMain`, `evmMainHttp`, `evmParallel`, `evmParallelHttp`) will be automatically used**
-- `options.useDefaultNetworks` (optional): Whether to use default networks (defaults to `true` if `networks` is not provided)
-- `options.defaultNetworkOptions` (optional): Options for customizing default networks (only used if `useDefaultNetworks` is `true`)
-- `options.tasks` (optional): Custom Hardhat tasks (e.g., from `createNodeTasks()`)
-- `options.solidityVersion` (optional): Solidity compiler version (defaults to `"0.8.30"`)
+## Building from source
 
-#### Returns
+For consumers modifying contracts locally:
 
-A complete `HardhatUserConfig` object ready to export.
-**Note:** The config will automatically include the default networks (`evmMain`, `evmMainHttp`, `evmParallel`, `evmParallelHttp`) when `networks` is not provided.
-
-### `createNodeTasks(deps: NodeTaskDependencies): HardhatUserConfig["tasks"]`
-
-Creates custom Hardhat tasks for running local blockchain nodes. These tasks enable:
-- Starting JSON-RPC servers for configured networks (`hardhat node`)
-- Waiting for servers to be ready (`hardhat node:wait`)
-
-#### Parameters
-
-- `deps.JsonRpcServer` (optional): Type placeholder, not actually used (kept for type compatibility). Can be omitted or set to `{} as unknown as never`
-- `deps.JsonRpcServerImplementation` (required): The JsonRpcServerImplementation class from `@effectstream/evm-hardhat/json-rpc-server` or `@paimaexample/evm-hardhat/json-rpc-server`
-- `deps.ComponentNames` (required): Component names from the log package
-- `deps.log` (required): Log utilities from the log package
-- `deps.SeverityNumber` (required): Severity number constants from the log package
-- `deps.waitOn` (required): The `wait-on` module for waiting on ports
-- `deps.fs` (required): Node.js `fs` module for checking Docker environment
-
-#### Returns
-
-An array of Hardhat tasks that can be passed to `createHardhatConfig()`.
-
-### `initTelemetry(logPackage: string, denoJsonPath?: string): void`
-
-Initializes OpenTelemetry for Hardhat. This should be called at the top level of your `hardhat.config.ts` file.
-
-#### Parameters
-
-- `logPackage` (required but ignored): Package name for log utilities - kept for backward compatibility but no longer used (uses static import instead)
-- `denoJsonPath` (optional): Path to `deno.json` file for version detection (defaults to `"./deno.json"`)
-
-## Package Names
-
-The unified config builder supports both package naming conventions:
-
-- **E2E tests**: Use `@effectstream/evm-hardhat/hardhat-config-builder`, `@effectstream/evm-hardhat/json-rpc-server`, `@effectstream/log`
-- **Templates**: Use `@paimaexample/evm-hardhat/hardhat-config-builder`, `@paimaexample/evm-hardhat/json-rpc-server`, `@paimaexample/log`
-
-Note: The functions are now exported from `evm-hardhat` package. The `evm-contracts` package re-exports them for backward compatibility, but new code should import directly from `evm-hardhat`.
-
-## Benefits
-
-1. **Centralized Configuration**: All common Hardhat setup logic in one place
-2. **Easier Maintenance**: Updates to Hardhat setup only need to be made once
-3. **Consistency**: All e2e tests and templates use the same configuration logic
-4. **Flexibility**: Still allows customization through parameters
-5. **Type Safety**: Full TypeScript support with proper types
-
-### Customizing Default Networks
-
-You can customize the default networks by passing `defaultNetworkOptions`:
-
-```typescript
-const config: HardhatUserConfig = createHardhatConfig({
-  sourcesDir: `${__dirname}/src/contracts`,
-  artifactsDir: `${__dirname}/build/artifacts/hardhat`,
-  cacheDir: `${__dirname}/build/cache/hardhat`,
-  defaultNetworkOptions: {
-    evmMainInterval: 500, // Customize main network interval
-    evmMainPort: 8545, // Customize port (defaults to 8545)
-    evmParallelPort: 8546, // Customize port (defaults to 8546)
-  },
-  tasks: nodeTasks,
-  solidityVersion: "0.8.30",
-});
+```bash
+# In a checkout of effectstream
+bun run --filter=@effectstream/evm-contracts build
 ```
 
-### Using Custom Networks
+The Hardhat config used during compilation is built by `@effectstream/evm-hardhat/hardhat-config-builder`. If you need a config in your own repo, import that builder directly; do not re-implement the Hardhat setup. See `@effectstream/evm-hardhat`'s README for the API.
 
-If you want to provide completely custom networks instead of using defaults:
+## Examples
 
-```typescript
-const customNetworks = {
-  myCustomNetwork: {
-    type: "edr-simulated",
-    chainType: "l1",
-    chainId: 1337,
-    // ... custom config
-  },
-};
+- [`templates/minimal/`](https://github.com/effectstream/effectstream/tree/main/templates/minimal) — smallest template that deploys an Effectstream contract.
+- [`templates/dice/`](https://github.com/effectstream/effectstream/tree/main/templates/dice) — full game-on-EVM example.
 
-const config: HardhatUserConfig = createHardhatConfig({
-  sourcesDir: `${__dirname}/src/contracts`,
-  artifactsDir: `${__dirname}/build/artifacts/hardhat`,
-  cacheDir: `${__dirname}/build/cache/hardhat`,
-  networks: customNetworks,
-  useDefaultNetworks: false, // Disable default networks
-  tasks: nodeTasks,
-  solidityVersion: "0.8.30",
-});
-```
+## Links
 
-## Migration Guide
-
-If you have an existing `hardhat.config.ts` file, follow these steps:
-
-1. Import the unified builder functions
-2. Replace your custom `initTelemetry()` function with `initTelemetry()` from the builder
-3. Replace your custom node tasks with `createNodeTasks()`
-4. Remove the network definitions (they're now provided by default)
-5. Replace your config object with `createHardhatConfig()` (without the `networks` parameter)
-6. Remove duplicate code (network list helpers, task definitions, etc.)
-
-See the examples in `e2e/shared/contracts/evm/hardhat.config.ts` and the template configs for reference implementations.
-
-## See Also
-
-- [Hardhat Documentation](https://hardhat.org/docs)
-- [Effectstream Documentation](https://effectstream.github.io/docs)
+- Docs: https://effectstream.github.io/docs/home/libraries/evm-contracts/introduction
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/chains/evm-contracts
+- Companion tooling: [`@effectstream/evm-hardhat`](https://www.npmjs.com/package/@effectstream/evm-hardhat)

--- a/docs/site/docs/home/500-packages/530-chains/evm-hardhat.md
+++ b/docs/site/docs/home/500-packages/530-chains/evm-hardhat.md
@@ -14,6 +14,11 @@ remappings every template uses to share contract paths. Pairs with
 [`@effectstream/evm-contracts`](https://www.npmjs.com/package/@effectstream/evm-contracts),
 which ships the actual Solidity sources.
 
+- Hardhat tooling for EVM-side Effectstream: JSON-RPC server, deploy + addresses, Solidity remappings.
+- Hardhat config builder with a Solidity 0.8.30 default.
+- Pairs with `@effectstream/evm-contracts` for the Solidity sources.
+- Used by every template's `deploy-contracts` step in the orchestrator.
+
 ## Install
 
 ```bash
@@ -71,19 +76,19 @@ The sync side then reads those addresses through `@effectstream/config`'s
 
 ## Key subpath exports
 
-- `@effectstream/evm-hardhat/json-rpc-server` — local JSON-RPC server.
-- `@effectstream/evm-hardhat/builder` — programmatic contract build entry point.
-- `@effectstream/evm-hardhat/hardhat-config-builder` — opinionated Hardhat config factory.
-- `@effectstream/evm-hardhat/deploy` — orchestrator-friendly deploy runner.
-- `@effectstream/evm-hardhat/addresses` — read/write the deployed-address file.
+- `@effectstream/evm-hardhat/json-rpc-server`: local JSON-RPC server.
+- `@effectstream/evm-hardhat/builder`: programmatic contract build entry point.
+- `@effectstream/evm-hardhat/hardhat-config-builder`: opinionated Hardhat config factory.
+- `@effectstream/evm-hardhat/deploy` runs Hardhat scripts and writes the deployed address into a deterministic file.
+- `@effectstream/evm-hardhat/addresses`: read/write the deployed-address file.
 - `@effectstream/evm-hardhat/remappings-hardhat`, `./remappings-forge` — Solidity import remappings.
 
 ## Examples
 
-- [`templates/minimal/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/minimal) — the smallest template that wires this package via the orchestrator.
-- [`templates/dice/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/dice) — full game with hardhat-deployed contracts.
+- [`templates/minimal/`](https://github.com/effectstream/effectstream/tree/main/templates/minimal) — the smallest template that wires this package via the orchestrator.
+- [`templates/dice/`](https://github.com/effectstream/effectstream/tree/main/templates/dice) — full game with hardhat-deployed contracts.
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/chains/evm-hardhat
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/chains/evm-hardhat
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/chains/evm-hardhat

--- a/docs/site/docs/home/500-packages/530-chains/midnight-contracts.md
+++ b/docs/site/docs/home/500-packages/530-chains/midnight-contracts.md
@@ -8,74 +8,54 @@ sidebar_label: "midnight-contracts"
 
 > Package: **[`@effectstream/midnight-contracts`](https://www.npmjs.com/package/@effectstream/midnight-contracts)** · [Source](https://github.com/PaimaStudios/paima-engine/tree/main/packages/chains/midnight-contracts)
 
-Utilities for working with Midnight contracts in EffectStream.
+Utilities for reading and deploying Midnight contracts from inside an Effectstream node or test. Two functions: `readMidnightContract` to load contract metadata + ABI by name, and `deployMidnightContract` to deploy and persist the resulting address.
 
-## read-contract
+- Reads contract files by name, searching from the current working directory upward.
+- Supports per-network files (`contract-counter.undeployed.json`, `contract-counter.testnet.json`) without hardcoded paths.
+- Deploys against the local Midnight stack by default; pass `NetworkUrls` to point at another environment.
+- Persists the deployed address to a JSON file so subsequent reads pick it up automatically.
 
-Provides a context-aware function to read Midnight contract information from JSON files.
+## Install
 
-### Usage
+```bash
+bun add @effectstream/midnight-contracts
+# or
+npm install @effectstream/midnight-contracts
+```
+
+Requires a reachable Midnight node, proof server, and indexer. The defaults match what `@effectstream/orchestrator`'s Midnight step boots locally.
+
+## Standalone usage
+
+### Read a contract
 
 ```typescript
 import { readMidnightContract } from "@effectstream/midnight-contracts/read-contract";
 
-// Read contract for the current network (defaults to contract-counter.<networkId>.json)
-const contractInfo = readMidnightContract("contract-counter");
+// Defaults to contract-counter.<networkId>.json, where networkId is "undeployed".
+const local = readMidnightContract("contract-counter");
 
-// Read contract for another network (e.g., preview)
-const previewInfo = readMidnightContract(
-  "contract-counter",
-  { networkId: "preview" },
-);
+// Read the same contract on a different network.
+const preview = readMidnightContract("contract-counter", { networkId: "preview" });
 
-// With explicit base directory (still respects network-specific files)
-const customDirInfo = readMidnightContract(
-  "contract-counter",
-  { baseDir: "/path/to/contracts", networkId: "undeployed" },
-);
+// Override the search base if your contracts live outside the CWD tree.
+const custom = readMidnightContract("contract-counter", {
+  baseDir: "/path/to/contracts",
+  networkId: "undeployed",
+});
 ```
 
-### Features
+Returns `{ contractAddress, contractInfo, zkConfigPath }`. Results are cached per `(location, name, filename)` tuple so repeated reads in the same process are free.
 
-- **Context-aware**: Automatically finds contract files by recursively searching from the current working directory upward through the directory tree
-- **Flexible directory structure**: Works with any directory structure - no hardcoded paths required
-- **Multiple contracts**: Supports reading multiple contracts with different filenames
-- **Caching**: Results are cached per contract location, name, and filename combination
-- **Dynamic compiler detection**: Automatically finds the compiler subdirectory in `src/managed/`
-
-### Function Signature
+### Deploy a contract
 
 ```typescript
-function readMidnightContract(
-  contractName: string,
-  contractFileName?: string,
-  options?: { baseDir?: string; networkId?: string }
-): MidnightContractInfo
-```
+import {
+  deployMidnightContract,
+  type DeployConfig,
+  type NetworkUrls,
+} from "@effectstream/midnight-contracts/deploy";
 
-### Parameters
-
-- `contractName`: The name of the contract directory (e.g., 'contract-counter', 'contract-eip-20')
-- `contractFileName`: Optional override. Defaults to `${contractName}.${networkId}.json`, so you can keep per-network files.
-- `options`: Optional configuration object. `baseDir` overrides the search location, and `networkId` selects the file (default: `undeployed`).
-
-### Returns
-
-`MidnightContractInfo` object containing:
-- `contractAddress`: The deployed contract address
-- `contractInfo`: Compiler-generated contract information (circuits, certificates, contracts)
-- `zkConfigPath`: Path to the zk configuration directory
-
-## deploy
-
-Deploys a Midnight contract using the provided configuration. This function is context-aware and automatically finds the contract directory and zkConfigPath.
-
-### Usage
-
-```typescript
-import { deployMidnightContract, type DeployConfig, type NetworkUrls } from "@effectstream/midnight-contracts/deploy";
-
-// Deploy with default network URLs (local undeployed endpoints)
 const config: DeployConfig = {
   contractName: "contract-counter",
   contractFileName: "contract-counter.json",
@@ -85,57 +65,48 @@ const config: DeployConfig = {
   initialPrivateState: { privateCounter: 0 },
 };
 
-const contractAddress = await deployMidnightContract(config);
+const address = await deployMidnightContract(config);
+```
 
-// Deploy with custom network URLs
-const networkUrls: NetworkUrls = {
+To deploy against a non-default stack, pass `NetworkUrls`:
+
+```typescript
+const network: NetworkUrls = {
   indexer: "http://localhost:8088/api/v3/graphql",
   indexerWS: "ws://localhost:8088/api/v3/graphql/ws",
   node: "http://localhost:9944",
   proofServer: "http://localhost:6300",
 };
 
-const contractAddress = await deployMidnightContract(config, networkUrls);
+const address = await deployMidnightContract(config, network);
 ```
 
-### Function Signature
+The deploy helper creates and funds a wallet from the genesis mint seed, runs the deployment, and writes the resulting address to `${contractName}.${networkId}.json` so the next `readMidnightContract` call picks it up.
 
-```typescript
-function deployMidnightContract(
-  config: DeployConfig,
-  networkUrls?: NetworkUrls
-): Promise<string>
-```
+## Inside Effectstream
 
-### Parameters
+`@effectstream/midnight-contracts` is the seam between Midnight contract artifacts on disk and the code that reads or deploys them. Templates that target Midnight call `readMidnightContract` from their node startup to resolve the on-chain address; the orchestrator's deploy step calls `deployMidnightContract` to put one there in the first place. On the sync side, `@effectstream/sync`'s `MidnightFetcher` consumes the node behind both calls.
 
-- `config`: Deployment configuration object containing:
-  - `contractName`: Name of the contract directory (e.g., "contract-counter", "contract-eip-20")
-  - `contractFileName`: Base filename for the contract address. The deployed file will append the network id (e.g., `contract-counter.undeployed.json`).
-  - `contractClass`: The Contract class to deploy
-  - `witnesses`: Witness definitions
-  - `privateStateId`: On-chain private state ID
-  - `initialPrivateState`: Initial private state object
-  - `deployArgs`: Optional deployment arguments array
-  - `privateStateStoreName`: Optional private state store name (defaults to contractName-based value)
-  - `baseDir`: Optional base directory override for finding contracts
-  - `logDir`: Optional log directory path
-  - `extractWalletAddress`: Optional flag to extract wallet address info (for contracts that need initialOwner)
+## Key exports
 
-- `networkUrls`: Optional network endpoint URLs. If not provided, defaults to local undeployed endpoints:
-  - `indexer`: GraphQL indexer HTTP endpoint (default: "http://127.0.0.1:8088/api/v3/graphql")
-  - `indexerWS`: GraphQL indexer WebSocket endpoint (default: "ws://127.0.0.1:8088/api/v3/graphql/ws")
-  - `node`: Midnight node RPC endpoint (default: "http://127.0.0.1:9944")
-  - `proofServer`: Proof server HTTP endpoint (default: "http://127.0.0.1:6300")
+`@effectstream/midnight-contracts/read-contract`:
 
-### Returns
+- `readMidnightContract(name, options?)`: returns `{ contractAddress, contractInfo, zkConfigPath }`. `options.networkId` selects per-network files; `options.baseDir` overrides the search base.
 
-A Promise that resolves to the deployed contract address as a string.
+`@effectstream/midnight-contracts/deploy`:
 
-### Features
+- `deployMidnightContract(config, networkUrls?)`: deploys and returns the address. Persists the address to a JSON file.
+- `DeployConfig`, `NetworkUrls`: input types.
 
-- **Context-aware**: Automatically finds contract directory by recursively searching from the current working directory
-- **Flexible network configuration**: Use default local endpoints or provide custom network URLs
-- **Automatic wallet setup**: Creates and funds a wallet automatically using the genesis mint seed
-- **Dynamic compiler detection**: Automatically finds the compiler subdirectory in `src/managed/`
-- **Contract address persistence**: Saves the deployed contract address to a JSON file
+## Examples
+
+End-to-end usage in templates:
+
+- [`templates/evm-midnight-v2/`](https://github.com/effectstream/effectstream/tree/main/templates/evm-midnight-v2)
+- [`templates/zswap-da/`](https://github.com/effectstream/effectstream/tree/main/templates/zswap-da)
+
+## Links
+
+- Docs: https://effectstream.github.io/docs/packages/chains/midnight-contracts
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/chains/midnight-contracts
+- Midnight: https://midnight.network

--- a/docs/site/docs/home/500-packages/540-binaries/avail-light-client.md
+++ b/docs/site/docs/home/500-packages/540-binaries/avail-light-client.md
@@ -13,6 +13,11 @@ CLI. Installs a pinned binary into `node_modules/.bin/npm-avail-light-client`
 so the EffectStream orchestrator and Avail-side E2E tests can spin up a
 light client without each developer fetching the binary by hand.
 
+- Pinned Avail light-client binary, dropped into `node_modules/.bin/`.
+- Linux / macOS, x64 and arm64.
+- Used by the orchestrator's Avail step; pairs with `@effectstream/npm-avail-node`.
+- Exercised by the [`e2e/avail/`](https://github.com/effectstream/effectstream/tree/main/e2e/avail) suite.
+
 ## Install
 
 ```bash
@@ -40,12 +45,11 @@ The orchestrator's Avail step boots this binary alongside the Avail node
 wrapper (`@effectstream/npm-avail-node`) so syncs against Avail-DA work
 locally. See:
 
-- [`templates/avail/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/avail) — full template using Avail.
-- [`e2e/avail/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e/avail) — E2E suite.
+- [`e2e/avail/`](https://github.com/effectstream/effectstream/tree/main/e2e/avail) — E2E suite.
 - `@effectstream/sync` — `AvailFetcher`, `AvailSyncState` on the runtime side.
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/avail-light-client
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/avail-light-client
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/avail-light-client
 - Avail Light Client: https://github.com/availproject/avail-light

--- a/docs/site/docs/home/500-packages/540-binaries/avail-node.md
+++ b/docs/site/docs/home/500-packages/540-binaries/avail-node.md
@@ -13,6 +13,11 @@ binary. Installs a pinned version into `node_modules/.bin/npm-avail-node`
 so the EffectStream orchestrator can run a local Avail node without each
 developer compiling or downloading it manually.
 
+- Pinned Avail node binary, dropped into `node_modules/.bin/`.
+- Spins up a local dev node with `--dev` in one command.
+- Paired with `@effectstream/npm-avail-light-client` for full local Avail-DA.
+- Exercised by the [`e2e/avail/`](https://github.com/effectstream/effectstream/tree/main/e2e/avail) suite.
+
 ## Install
 
 ```bash
@@ -39,12 +44,12 @@ for the full local Avail-DA setup.
 ## Inside EffectStream
 
 The orchestrator's Avail step starts this node alongside the light
-client. Templates and E2E suites that consume Avail data — see
-[`templates/avail/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/avail)
-— rely on it as their local source of truth.
+client. The Avail E2E suite at
+[`e2e/avail/`](https://github.com/effectstream/effectstream/tree/main/e2e/avail)
+exercises this binary as the local source of truth for Avail-DA data.
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/avail-node
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/avail-node
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/avail-node
 - Upstream Avail Node: https://github.com/availproject/avail

--- a/docs/site/docs/home/500-packages/540-binaries/bitcoin-core.md
+++ b/docs/site/docs/home/500-packages/540-binaries/bitcoin-core.md
@@ -13,6 +13,11 @@ versioned `bitcoind` and `bitcoin-cli` into `node_modules/.bin` so the
 EffectStream orchestrator and E2E tests can boot a local regtest
 without each developer running their own install script.
 
+- Pins Bitcoin Core 28.1 for local regtest.
+- Linux / macOS, x64 and arm64.
+- Pairs with `@effectstream/bitcoin-contracts` for `generate-blocks` and `wait-for-block`.
+- Used by the orchestrator's Bitcoin step.
+
 ## Install
 
 ```bash
@@ -50,11 +55,11 @@ for the `generate-blocks` and `wait-for-block` helpers.
 The orchestrator (`@effectstream/orchestrator`) declares this as a
 dependency of its `bitcoin-core` step, so `bun packages/build-tools/orchestrator/src/cli.ts start`
 brings up a regtest chain automatically. The Bitcoin E2E suite at
-[`e2e/bitcoin/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e/bitcoin)
+[`e2e/bitcoin/`](https://github.com/effectstream/effectstream/tree/main/e2e/bitcoin)
 runs against this same binary.
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/bitcoin-core
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/bitcoin-core
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/bitcoin-core
 - Upstream Bitcoin Core: https://bitcoincore.org/

--- a/docs/site/docs/home/500-packages/540-binaries/celestia.md
+++ b/docs/site/docs/home/500-packages/540-binaries/celestia.md
@@ -13,6 +13,11 @@ Installs a pinned version into `node_modules/.bin/celestia` so the
 EffectStream orchestrator can boot a local Celestia DA layer
 (node + bridge) for development and testing.
 
+- Pinned Celestia node + bridge binaries.
+- Ships `start-node` and `start-bridge` convenience scripts.
+- Consumed by `@effectstream/sync`'s `CelestiaFetcher`.
+- E2E: [`e2e/celestia/`](https://github.com/effectstream/effectstream/tree/main/e2e/celestia).
+
 ## Install
 
 ```bash
@@ -44,11 +49,11 @@ On install, the package fetches the pinned binary for your OS/arch.
 The orchestrator's Celestia step uses `start-node` to bring up a local
 chain, and the EffectStream runtime consumes it through
 `@effectstream/sync`'s `CelestiaFetcher`/`CelestiaSyncState`. See the
-[`e2e/celestia/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e/celestia)
+[`e2e/celestia/`](https://github.com/effectstream/effectstream/tree/main/e2e/celestia)
 suite.
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/celestia
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/celestia
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/celestia
 - Upstream Celestia: https://github.com/celestiaorg/celestia-node

--- a/docs/site/docs/home/500-packages/540-binaries/grafana-alloy.md
+++ b/docs/site/docs/home/500-packages/540-binaries/grafana-alloy.md
@@ -13,6 +13,11 @@ OpenTelemetry-compatible collector EffectStream nodes ship traces, logs,
 and metrics to during local development. Installs a pinned binary into
 `node_modules/.bin/grafana-alloy`.
 
+- Pinned Grafana Alloy binary, the OTel collector Effectstream nodes ship to in local dev.
+- One-command start via `bunx grafana-alloy run config.alloy`.
+- Pairs with `@effectstream/grafana-loki` for logs.
+- Drop-in: point your own collector at the same OTLP endpoint in production.
+
 ## Install
 
 ```bash
@@ -44,5 +49,5 @@ in production.
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/grafana-alloy
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/grafana-alloy
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/grafana-alloy
 - Upstream Grafana Alloy: https://grafana.com/oss/alloy/

--- a/docs/site/docs/home/500-packages/540-binaries/grafana-loki.md
+++ b/docs/site/docs/home/500-packages/540-binaries/grafana-loki.md
@@ -13,6 +13,11 @@ log-aggregation backend EffectStream nodes ship structured logs to in
 local development. Installs a pinned binary into
 `node_modules/.bin/grafana-loki`.
 
+- Pinned Grafana Loki binary, the local log backend for `@effectstream/log` output.
+- One-command start via `bunx grafana-loki -config.file=loki.yaml`.
+- Pairs with `@effectstream/grafana-alloy` so traces and logs land in one place.
+- Component-tagged logs queryable from a local Grafana out of the box.
+
 ## Install
 
 ```bash
@@ -44,5 +49,5 @@ config.
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/grafana-loki
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/grafana-loki
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/grafana-loki
 - Upstream Grafana Loki: https://grafana.com/oss/loki/

--- a/docs/site/docs/home/500-packages/540-binaries/midnight-indexer.md
+++ b/docs/site/docs/home/500-packages/540-binaries/midnight-indexer.md
@@ -8,27 +8,14 @@ sidebar_label: "midnight-indexer"
 
 > Package: **[`@effectstream/npm-midnight-indexer`](https://www.npmjs.com/package/@effectstream/npm-midnight-indexer)** · [Source](https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/midnight-indexer)
 
-A Node.js package that downloads and runs the
-[Midnight](https://midnight.network) Indexer. The indexer requires a running
-Midnight Node (see `@effectstream/npm-midnight-node`) to function properly.
+NPM wrapper that runs the [Midnight](https://midnight.network) Indexer either as a Docker container or as a native binary. Boots alongside `@effectstream/npm-midnight-node` and `@effectstream/npm-midnight-proof-server` to give Effectstream a local indexer to consume.
 
-## Overview
+- Docker or binary mode, with platform-aware defaults (macOS arm64 and Linux can use either; Windows is Docker-only).
+- One env var to set: `APP__INFRA__SECRET`. Everything else has a default that works against the local Midnight stack.
+- Used by the orchestrator's Midnight step; sits in front of `MidnightFetcher` on the sync side.
+- Maps port 8088 (Docker) or runs on localhost (binary) so the rest of the local stack reaches it the same way.
 
-This package provides flexible execution options for the Midnight Indexer:
-
-- **Docker mode**: Runs the indexer in a Docker container (recommended)
-- **Binary mode**: Downloads and runs the native binary locally (Linux, Windows,
-  macOS arm64)
-
-### Platform Support
-
-| Platform | Docker | Binary |
-| -------- | ------ | ------ |
-| macOS    | ✅ Yes | ✅ Yes |
-| Linux    | ✅ Yes | ✅ Yes |
-| Windows  | ❌ No  | ✅ Yes |
-
-## Installation
+## Install
 
 ```bash
 bun add @effectstream/npm-midnight-indexer
@@ -36,220 +23,74 @@ bun add @effectstream/npm-midnight-indexer
 npm install @effectstream/npm-midnight-indexer
 ```
 
-## Prerequisites
+Requires a running Midnight node (`@effectstream/npm-midnight-node`) and proof server (`@effectstream/npm-midnight-proof-server`) on their standard ports, or set the override env vars below.
 
-### For Docker Mode
+## Standalone usage
 
-- Docker installed and running
-- `APP__INFRA__SECRET` environment variable (required)
-
-### For Binary Mode
-
-- Supported platform (Linux/macOS ARM64)
-- Local Midnight Node and Proof Server running on standard ports. But they can
-  be set using env variables
-- `APP__INFRA__SECRET` environment variable (required)
-
-## Usage
-
-### Command Line Options
+Pick a mode and pass `APP__INFRA__SECRET`. Without a flag, the wrapper prompts interactively.
 
 ```bash
-node index.js [options] [args...]
+# Docker (recommended where available)
+APP__INFRA__SECRET=<secret> bunx npm-midnight-indexer --docker
+
+# Native binary (Linux, macOS arm64)
+APP__INFRA__SECRET=<secret> bunx npm-midnight-indexer --binary
+
+# Interactive: prompts for Docker vs binary
+APP__INFRA__SECRET=<secret> bunx npm-midnight-indexer
+
+# Help
+bunx npm-midnight-indexer --help
 ```
 
-**Options:**
+The Docker path pulls `midnightntwrk/indexer-standalone` and maps container port 8088 to host 8088. The binary path downloads a platform-specific binary on first run and points at localhost services.
 
-- `--docker` - Force Docker execution
-- `--binary` - Force binary execution (available on Linux, Windows, macOS arm64)
-- `--help` - Show help information
+### Environment variables
 
-**Examples:**
+| Variable | Required | Docker default | Binary default | Purpose |
+| --- | --- | --- | --- | --- |
+| `APP__INFRA__SECRET` | yes | — | — | Indexer secret. |
+| `LEDGER_NETWORK_ID` | no | `Undeployed` | `Undeployed` | Ledger network selector. |
+| `SUBSTRATE_NODE_WS_URL` | no | `ws://node:9944` | `ws://localhost:9944` | Substrate node WS. |
+| `FEATURES_WALLET_ENABLED` | no | `true` | `true` | Wallet features. |
+| `APP__INFRA__PROOF_SERVER__URL` | no | `http://proof-server:6300` | `http://localhost:6300` | Proof server. |
+| `APP__INFRA__NODE__URL` | no | `ws://node:9944` | `ws://localhost:9944` | Node URL. |
 
-```bash
-# Force Docker usage
-APP__INFRA__SECRET=mysecret node index.js --docker
+### Path resolution
 
-# Force binary usage (Linux/Windows/macOS arm64)
-APP__INFRA__SECRET=mysecret node index.js --binary
+`CONFIG_FILE` and `infra.storage.cnn_url` are both resolved relative to the process's current working directory when they are not absolute. Prefer absolute paths if your launch script's CWD is non-obvious. In binary mode this package sets the CWD to the bundled `indexer-standalone` folder, so a default `cnn_url: "./indexer.sqlite"` lands next to the binary. In Docker mode the image's `WORKDIR` is `/opt/indexer-standalone`; bind-mount accordingly.
 
-# Interactive mode - prompts for Docker vs binary choice
-APP__INFRA__SECRET=mysecret node index.js
+### Supported binary platforms
 
-# Show help
-node index.js --help
-```
+Linux arm64, Linux amd64, macOS arm64.
 
-## Environment Variables
+## Inside Effectstream
 
-The indexer supports several environment variables with different defaults based
-on execution mode:
-
-| Variable                        | Required | Docker Default             | Binary Default          | Description                    |
-| ------------------------------- | -------- | -------------------------- | ----------------------- | ------------------------------ |
-| `APP__INFRA__SECRET`            | Yes      | -                          | -                       | Secret key for the application |
-| `LEDGER_NETWORK_ID`             | No       | `Undeployed`               | `Undeployed`            | Ledger network identifier      |
-| `SUBSTRATE_NODE_WS_URL`         | No       | `ws://node:9944`           | `ws://localhost:9944`   | Substrate node WebSocket URL   |
-| `FEATURES_WALLET_ENABLED`       | No       | `true`                     | `true`                  | Enable wallet features         |
-| `APP__INFRA__PROOF_SERVER__URL` | No       | `http://proof-server:6300` | `http://localhost:6300` | Proof server URL               |
-| `APP__INFRA__NODE__URL`         | No       | `ws://node:9944`           | `ws://localhost:9944`   | Node WebSocket URL             |
-
-### Environment Variable Examples
-
-```bash
-# Minimal Docker setup
-APP__INFRA__SECRET=A5F07FCAC914A181EC0998CCCA68312DA5F07FCAC914A181EC0998CCCA68312D \
-node index.js --docker
-
-# Custom configuration
-APP__INFRA__SECRET=mysecret \
-LEDGER_NETWORK_ID=CustomNetwork \
-SUBSTRATE_NODE_WS_URL=ws://localhost:9944 \
-APP__INFRA__PROOF_SERVER__URL=http://localhost:6300 \
-node index.js --docker
-
-# Binary mode (uses localhost defaults automatically)
-APP__INFRA__SECRET=mysecret node index.js --binary
-```
-
-## Docker Mode Details
-
-When using Docker mode, the indexer:
-
-1. **Pulls the latest image**: `midnightntwrk/indexer-standalone`
-2. **Maps port 8088**: Container port 8088 → Host port 8088
-3. **Uses container networking**: Defaults work with Docker Compose setups
-4. **Auto-cleanup**: Removes existing containers before starting new ones
-
-### Docker Command Generated
-
-The package generates Docker commands similar to:
-
-```bash
-docker run --rm --name midnight-local-indexer \
-  -p 8088:8088 \
-  -e LEDGER_NETWORK_ID=Undeployed \
-  -e SUBSTRATE_NODE_WS_URL=ws://node:9944 \
-  -e APP__INFRA__SECRET=A5F07FCAC914A181EC0998CCCA68312DA5F07FCAC914A181EC0998CCCA68312D \
-  -e FEATURES_WALLET_ENABLED=true \
-  -e APP__INFRA__PROOF_SERVER__URL=http://proof-server:6300 \
-  -e APP__INFRA__NODE__URL=ws://node:9944 \
-  midnightntwrk/indexer-standalone
-```
-
-## Binary Mode Details
-
-When using binary mode, the indexer:
-
-1. **Downloads platform-specific binary** if not already present
-2. **Uses localhost URLs** for all service connections
-3. **Runs natively** on the host system
-
-## Path Resolution
-
-The indexer relies on two user-supplied file paths and **both are interpreted
-relative to the process’s current working directory (CWD)** when they are not
-absolute:
-
-| Configuration location             | Purpose                                      | If relative, resolved against                                             |
-| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------- |
-| `CONFIG_FILE` environment variable | Location of the YAML config file             | The directory you launch `node index.js …` from (or the Docker `WORKDIR`) |
-| `infra.storage.cnn_url` in YAML    | SQLite database used by the standalone build | The CWD at runtime of the indexer process                                 |
-
-### Practical tips
-
-1. Prefer absolute paths when you need to be explicit.
-2. In **binary mode** this package sets the CWD to the bundled
-   `indexer-standalone` folder, so a default `cnn_url: "./indexer.sqlite"` ends
-   up next to the binary.
-3. In **Docker mode** the image’s `WORKDIR` is `/opt/indexer-standalone`.
-   Bind-mount volumes accordingly if you want the database file somewhere else.
-
----
-
-### Supported Binary Platforms
-
-- Linux ARM64 (`linux-arm64`)
-- Linux AMD64 (`linux-amd64`)
-- macOS ARM64 (`macos-arm64`)
+The orchestrator's Midnight step starts this indexer behind `@effectstream/npm-midnight-node` + proof server. The runtime's `@effectstream/sync` `MidnightFetcher` queries it. You usually don't invoke this package by hand; you add it to your orchestrator config and the rest happens automatically.
 
 ## Troubleshooting
 
-### Common Issues
+A few common failures and where to look:
 
-**"Docker is not installed or not available"**
+- `Docker is not installed or not available` — install Docker Desktop / Engine and confirm `docker --version` from the same shell.
+- `APP__INFRA__SECRET environment variable is required` — required for both modes; export it or pass inline.
+- `Failed to start midnight-indexer` — check that ports 8088, 6300, and 9944 are free and that the Midnight node is reachable.
 
-- Install Docker Desktop or Docker Engine
-- Ensure Docker is running
-- Check Docker is accessible from command line: `docker --version`
+## Examples
 
-**"APP__INFRA__SECRET environment variable is required"**
+End-to-end Midnight startup is exercised by the templates that target Midnight:
 
-- Set the secret: `export APP__INFRA__SECRET=your_secret_here`
-- Or pass inline: `APP__INFRA__SECRET=your_secret node index.js --docker`
-- Required for both Docker and binary execution modes
+- [`templates/evm-midnight-v2/`](https://github.com/effectstream/effectstream/tree/main/templates/evm-midnight-v2)
+- [`templates/night-bitcoin/`](https://github.com/effectstream/effectstream/tree/main/templates/night-bitcoin)
+- [`templates/zswap-da/`](https://github.com/effectstream/effectstream/tree/main/templates/zswap-da)
 
-**"Binary execution is only supported on macOS ARM64"**
+## Links
 
-- Use `--docker` flag or run without flags to use Docker automatically
-- Install Docker if not already installed
-
-**"Failed to start midnight-indexer"**
-
-- Check if ports 8088, 6300, 9944 are available
-- Verify Midnight Node is running and accessible
-- Check environment variables are correctly set
-
-### Logs and Debugging
-
-The indexer outputs detailed logs including:
-
-- Download progress for binaries
-- Docker pull progress
-- Process IDs and status
-- Error messages with suggestions
-
-## Development
-
-### Package Structure
-
-```
-npm-midnight-indexer/
-├── index.js              # Main entry point
-├── binary.js             # Binary download logic
-├── docker.js             # Docker execution logic
-├── run_midnight_indexer.js # Binary execution logic
-├── package.json          # Package configuration
-└── README.md            # This file
-```
-
-### Testing
-
-```bash
-# Test Docker detection
-node -e "const { checkIfDockerExists } = require('./docker.js'); checkIfDockerExists().then(console.log)"
-
-# Test help
-node index.js --help
-
-# Test platform detection
-node -e "console.log('Platform:', require('os').platform())"
-```
+- Docs: https://effectstream.github.io/docs/packages/binaries/midnight-indexer
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/midnight-indexer
+- Midnight Network: https://midnight.network
+- Indexer image: https://hub.docker.com/r/midnightntwrk/indexer-standalone
 
 ## License
 
-ISC
-
-## Support
-
-For issues related to:
-
-- **This package**: Open an issue in the repository
-- **Midnight Protocol**: Visit [midnight.network](https://midnight.network)
-- **Docker**: Check [Docker documentation](https://docs.docker.com/)
-
-## Related Links
-
-- [Midnight Network](https://midnight.network)
-- [Docker Hub - Midnight Indexer](https://hub.docker.com/r/midnightntwrk/indexer-standalone)
-- [Node.js](https://nodejs.org/)
+ISC.

--- a/docs/site/docs/home/500-packages/540-binaries/midnight-node.md
+++ b/docs/site/docs/home/500-packages/540-binaries/midnight-node.md
@@ -13,6 +13,11 @@ NPM wrapper that downloads and runs the
 version on first invocation and exposes a `npm-midnight-node` CLI for
 the EffectStream orchestrator and templates.
 
+- Pinned Midnight node binary, downloaded on first run.
+- `--dev` for a local node; `--clean-binaries` / `--only-clean` to manage the cache.
+- Consumed by `@effectstream/sync`'s `MidnightFetcher`.
+- Templates: `evm-midnight-v2`, `night-bitcoin`, `zswap-da`, `zk-cardano`.
+
 ## Install
 
 ```bash
@@ -42,13 +47,13 @@ The orchestrator's Midnight step starts this binary, plus
 `MidnightFetcher` consumes the node's RPC. Templates that target
 Midnight:
 
-- [`templates/evm-midnight/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/evm-midnight)
-- [`templates/night-bitcoin/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/night-bitcoin)
-- [`templates/zswap-da/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/zswap-da)
-- [`templates/zk-cardano/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/zk-cardano)
+- [`templates/evm-midnight-v2/`](https://github.com/effectstream/effectstream/tree/main/templates/evm-midnight-v2)
+- [`templates/night-bitcoin/`](https://github.com/effectstream/effectstream/tree/main/templates/night-bitcoin)
+- [`templates/zswap-da/`](https://github.com/effectstream/effectstream/tree/main/templates/zswap-da)
+- [`templates/zk-cardano/`](https://github.com/effectstream/effectstream/tree/main/templates/zk-cardano)
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/midnight-node
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/midnight-node
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/midnight-node
 - Upstream Midnight: https://midnight.network/

--- a/docs/site/docs/home/500-packages/540-binaries/midnight-proof-server.md
+++ b/docs/site/docs/home/500-packages/540-binaries/midnight-proof-server.md
@@ -13,6 +13,11 @@ version into `node_modules/.bin/npm-midnight-proof-server` so the
 EffectStream orchestrator can boot the proving sidecar that the
 Midnight node depends on.
 
+- Pinned Midnight proof-server sidecar.
+- Boots alongside `@effectstream/npm-midnight-node`; no app-code import needed.
+- Cache management via `--clean-binaries` / `--only-clean`.
+- Required by ZK-heavy Midnight templates.
+
 ## Install
 
 ```bash
@@ -43,5 +48,5 @@ already do).
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/midnight-proof-server
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/midnight-proof-server
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/midnight-proof-server
 - Upstream Midnight: https://midnight.network/

--- a/docs/site/docs/home/500-packages/540-binaries/near-sandbox.md
+++ b/docs/site/docs/home/500-packages/540-binaries/near-sandbox.md
@@ -14,6 +14,11 @@ NEAR chain for local development. Installs a pinned version into
 `node_modules/.bin/near-sandbox` so the orchestrator can boot it
 without each developer fetching it separately.
 
+- Pinned NEAR sandbox binary, a single-node NEAR chain for local dev.
+- `init` then `run`, both via `bunx`.
+- Consumed by `@effectstream/sync`'s `NearFetcher`.
+- Used by the orchestrator's NEAR step for end-to-end local testing.
+
 ## Install
 
 ```bash
@@ -38,13 +43,12 @@ bun run --bun @effectstream/near-sandbox/start -- run
 ## Inside EffectStream
 
 The orchestrator's NEAR step starts the sandbox alongside the
-EffectStream sync layer so the
-[`templates/near/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates/near)
-template runs end-to-end locally. On the runtime side,
-`@effectstream/sync`'s `NearFetcher` consumes the sandbox's RPC.
+EffectStream sync layer for end-to-end local testing of NEAR-side
+integrations. On the runtime side, `@effectstream/sync`'s `NearFetcher`
+consumes the sandbox's RPC.
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/near-sandbox
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/near-sandbox
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/near-sandbox
 - Upstream NEAR sandbox: https://github.com/near/sandbox

--- a/docs/site/docs/home/500-packages/540-binaries/ord.md
+++ b/docs/site/docs/home/500-packages/540-binaries/ord.md
@@ -12,6 +12,11 @@ A pinned [`ord`](https://github.com/ordinals/ord) binary, packaged for
 npm. Installing this drops a versioned `ord` CLI into
 `node_modules/.bin` for EffectStream's Bitcoin / Ordinals dev workflows.
 
+- Pinned `ord` CLI for Bitcoin / Ordinals dev workflows.
+- Pairs with `@effectstream/bitcoin-core` for an `ord`-indexed view of local regtest.
+- Linux / macOS, x64 and arm64.
+- Used by Ordinals-aware templates and E2E tests.
+
 ## Install
 
 ```bash
@@ -44,5 +49,5 @@ Ordinals-aware templates and E2E tests.
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/binaries/ord
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/binaries/ord
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/binaries/ord
 - Upstream `ord`: https://github.com/ordinals/ord

--- a/docs/site/docs/home/500-packages/550-tools/batcher-sdk.md
+++ b/docs/site/docs/home/500-packages/550-tools/batcher-sdk.md
@@ -8,46 +8,42 @@ sidebar_label: "batcher-sdk"
 
 > Package: **[`@effectstream/batcher-sdk`](https://www.npmjs.com/package/@effectstream/batcher-sdk)** · [Source](https://github.com/PaimaStudios/paima-engine/tree/main/packages/batcher)
 
-A blockchain batching system for aggregating and submitting user inputs to
-multiple chains.
+Effectstream's cross-chain input batcher. Accepts signed user inputs over HTTP, batches them per adapter, and submits each batch as a single on-chain transaction. Persists every input to storage before it acks, so a crashed batcher recovers without losing inputs.
 
-## Features
+- Storage is the source of truth. No in-memory pool; the batcher recovers from a restart by reading the same files (or DB rows) it wrote on accept.
+- Per-adapter batching criteria: time window, size, value threshold, hybrid, or a function you provide.
+- Pluggable everywhere: storage backend, blockchain adapter, batch builder, lifecycle listeners.
+- Default chain adapters for Effectstream's L2, generic EVM (viem + Hardhat artifacts), Midnight, and Bitcoin regtest.
+- Optional REST API on Fastify; bypassable if you want to drive the batcher from your own runtime.
 
-- **Crash-safe batching** - Storage is the single source of truth; no in-memory
-  pools that can be lost on restart
-- **Pluggable storage** - Use files, PostgreSQL, Redis, or any backend by
-  implementing `BatcherStorage`
-- **Multi-chain support** - Abstract away blockchain differences through custom
-  adapters
-- **Flexible batching strategies** - Configure when to submit batches (time,
-  size, value, or custom logic)
-- **Structured concurrency** - Uses Effection for automatic resource cleanup and
-  graceful cancellation
-- **Event-driven observability** - Hook into batch lifecycle events for logging,
-  monitoring, and custom behavior
+## Install
 
-## Quick Start
+```bash
+bun add @effectstream/batcher-sdk
+# or
+npm install @effectstream/batcher-sdk
+```
 
-Here's a minimal example based on the E2E test setup:
+## Standalone usage
 
-### 1. Configure the Batcher
+A minimal end-to-end example using `FileStorage`, the EffectstreamL2 adapter, and the bundled HTTP server.
 
 ```typescript
+import { main, suspend } from "effection";
 import {
-  FileStorage,
   BatcherConfig,
+  createNewBatcher,
   EffectstreamL2DefaultAdapter,
-} from "@effectstream/batcher";
+  FileStorage,
+} from "@effectstream/batcher-sdk";
 
-// Create an adapter for your blockchain
-const effectstreamL2 = new EffectstreamL2DefaultAdapter(
-  "0x...", // Contract address
-  "0x...", // Private key
-  0n, // Fee
-  "parallelEvmRPC_fast", // Sync protocol name
+const adapter = new EffectstreamL2DefaultAdapter(
+  "0x...",            // contract address
+  "0x...",            // submitter private key
+  0n,                  // fee
+  "parallelEvmRPC_fast",
 );
 
-// Configure the batcher
 const config: BatcherConfig = {
   pollingIntervalMs: 1000,
   enableHttpServer: true,
@@ -57,322 +53,27 @@ const config: BatcherConfig = {
 };
 
 const storage = new FileStorage("./batcher-data");
-```
-
-### 2. Run with Effection
-
-```typescript
-import { main, suspend } from "effection";
-import { createNewBatcher } from "@effectstream/batcher";
-
-const batcher = createNewBatcher(config, storage);
-
-batcher
-  .addBlockchainAdapter("effectstream-l2", effectstreamL2Adapter, { criteriaType: "time", timeWindowMs: 1000 })
-// Add custom startup logging
-batcher.addStateTransition("startup", ({ publicConfig }) => {
-  console.log(
-    `🚀 Batcher started - polling every ${publicConfig.pollingIntervalMs}ms`,
-  );
-  console.log(`📍 Default Target: ${publicConfig.defaultTarget}`);
-});
-
-// Add HTTP server logging
-batcher.addStateTransition("http:start", ({ port }) => {
-  console.log(`🌐 HTTP Server: http://localhost:${port}`);
-});
 
 main(function* () {
+  const batcher = createNewBatcher(config, storage);
 
+  batcher.addBlockchainAdapter("effectstream-l2", adapter, {
+    criteriaType: "time",
+    timeWindowMs: 1000,
+  });
 
-  // Run the batcher (handles HTTP server and polling automatically)
+  batcher.addStateTransition("startup", ({ publicConfig }) => {
+    console.log(`batcher up, polling every ${publicConfig.pollingIntervalMs}ms`);
+  });
+
   yield* batcher.runBatcher();
   yield* suspend();
 });
 ```
 
-The batcher is now running and will:
+That accepts inputs on `http://localhost:3334`, batches them on a 1s window, submits via the adapter, and stays up until you cancel the operation.
 
-- Accept inputs via HTTP API on port 3334
-- Process batches every 1000ms
-- Submit to the blockchain via the adapter
-- Emit state transition events for observability
-
-## Core Concepts
-
-### Storage as Single Source of Truth
-
-All inputs are immediately persisted to storage. There's no in-memory pool,
-eliminating consistency issues on crashes or restarts.
-
-**Storage is fully pluggable** - implement the `BatcherStorage` interface to use
-any backend (PostgreSQL, Redis, S3, etc.). The default `FileStorage` uses JSONL
-files for simplicity.
-
-### Adapters
-
-Adapters abstract blockchain-specific logic. Each adapter implements
-`BlockchainAdapter`:
-
-```typescript
-interface BlockchainAdapter {
-  submitBatch(data: string, fee: string | bigint): Promise<BlockchainHash>;
-  waitForTransactionReceipt(
-    hash: BlockchainHash,
-  ): Promise<BlockchainTransactionReceipt>;
-  getAccountAddress(): string;
-  getChainName(): string;
-  estimateBatchFee(data: string): Promise<string | bigint> | string | bigint;
-  isReady(): boolean;
-  getBlockNumber(): Promise<bigint>;
-}
-```
-
-Out of the box we ship adapters for the most common targets:
-
-- `EffectstreamL2DefaultAdapter` – Effectstream's default L2 contract entrypoint.
-- `EvmContractAdapter` – generic viem-powered adapter that loads any Hardhat artifact and validates `{ method, args, value }` inputs.
-- `MidnightAdapter` – circuit-based submission flow for the Midnight chain.
-- `BitcoinAdapter` – UTXO batching + signature validation for regtest/local setups.
-
-### Batching Criteria
-
-Configure when batches are submitted per adapter:
-
-- **`time`** - Submit every N milliseconds
-- **`size`** - Submit when N inputs accumulate
-- **`value`** - Submit when accumulated value reaches threshold
-- **`hybrid`** - Submit when time OR size criteria met
-- **`custom`** - Provide your own `isBatchReadyFn`
-
-### State Transitions
-
-Hook into batch lifecycle for logging, metrics, or custom behavior:
-
-```typescript
-batcher.addStateTransition("startup", (payload) => {
-  // Batcher initialized
-});
-
-batcher.addStateTransition("batch:process:start", ({ target, inputCount }) => {
-  console.log(`Processing ${inputCount} inputs for ${target}`);
-});
-
-batcher.addStateTransition("error", ({ phase, error }) => {
-  // Handle errors
-});
-```
-
-## Configuration
-
-Key configuration options:
-
-```typescript
-type BatcherConfig = {
-  // Polling interval for checking batch criteria
-  pollingIntervalMs: number;
-
-  // Blockchain adapters keyed by name
-  adapters: Record<string, BlockchainAdapter>;
-
-  // Default adapter when input.target not specified
-  defaultTarget: string;
-
-  // Per-adapter batching rules
-  batchingCriteria?: {
-    [adapterName: string]: {
-      criteriaType: "time" | "size" | "value" | "hybrid" | "custom";
-      timeWindowMs?: number;
-      maxBatchSize?: number;
-      targetValue?: number;
-      valueAccumulatorFn?: (input: T) => number;
-      isBatchReadyFn?: (
-        inputs: T[],
-        lastProcessTime: number,
-      ) => boolean | Promise<boolean>;
-    };
-  };
-
-  // Wait behavior: "no-wait" | "wait-receipt" | "wait-effectstream-processed"
-  confirmationLevel?: string | Record<string, string>;
-
-  // Enable HTTP REST API
-  enableHttpServer?: boolean;
-  port?: number;
-
-  // Enable state transition events
-  enableEventSystem?: boolean;
-
-  // Signature verification namespace
-  namespace?: string;
-
-  // Batch building configuration
-  batchBuilding?: {
-    maxSize?: number;
-    defaultBuilder?: BatchDataBuilder<T>;
-    targetBuilders?: Record<string, BatchDataBuilder<T>>;
-  };
-};
-```
-
-## Customization
-
-### Custom Batching Criteria
-
-Define your own logic for when to submit batches:
-
-```typescript
-batchingCriteria: {
-  myAdapter: {
-    criteriaType: "custom",
-    isBatchReadyFn: async (inputs, lastProcessTime) => {
-      // Custom logic: batch when we have priority inputs
-      const hasPriority = inputs.some(input => input.priority === "high");
-      const timePassed = Date.now() - lastProcessTime > 5000;
-      return hasPriority || timePassed;
-    }
-  }
-}
-```
-
-### Custom Adapters
-
-Implement `BlockchainAdapter` for new chains:
-
-```typescript
-class MyChainAdapter implements BlockchainAdapter {
-  async submitBatch(
-    data: string,
-    fee: string | bigint,
-  ): Promise<BlockchainHash> {
-    // Submit to your blockchain
-    return txHash;
-  }
-
-  // Implement other required methods...
-}
-```
-
-### Custom Batch Builders
-
-Control how inputs are serialized into batch data:
-
-```typescript
-class MyBatchBuilder implements BatchDataBuilder<MyInput> {
-  buildBatchData(
-    inputs: MyInput[],
-    options: any,
-  ): BatchBuildingResult<MyInput> {
-    // Custom serialization logic
-    const data = myCustomEncoding(inputs);
-    return { data, includedInputs: inputs, excludedInputs: [] };
-  }
-}
-
-const config = {
-  // ...
-  batchBuilding: {
-    defaultBuilder: new MyBatchBuilder(),
-  },
-};
-```
-
-### State Transition Listeners
-
-Add custom behavior at any point in the batch lifecycle:
-
-```typescript
-// Log all batch submissions
-batcher.addStateTransition("batch:submit", ({ target, hash, inputCount }) => {
-  console.log(`Submitted batch ${hash} with ${inputCount} inputs to ${target}`);
-});
-
-// Track confirmation times
-batcher.addStateTransition(
-  "batch:confirmed",
-  ({ target, hash, blockNumber }) => {
-    metrics.recordConfirmation(target, Date.now() - startTime);
-  },
-);
-
-// Handle errors
-batcher.addStateTransition("error", ({ phase, error }) => {
-  errorReporter.report(phase, error);
-});
-```
-
-## API Overview
-
-### Main Operations
-
-- **`runBatcher(): Operation<void>`** - Effection operation that runs HTTP
-  server and polling loop
-- **`batchInput(input: T, confirmationLevel?, timeout?): Promise<Receipt | null>`** -
-  Submit an input for batching
-- **`addStateTransition(prefix, listener): void`** - Register event listener for
-  batch lifecycle
-- **`gracefulShutdownOp(): Operation<void>`** - Gracefully shutdown with cleanup
-- **`getPublicConfig()`** - Get public configuration information
-- **`getBatchingStatus()`** - Get current queue statistics
-
-### Confirmation Levels
-
-When calling `batchInput()`, choose how long to wait:
-
-- **`no-wait`** - Return immediately after queuing
-- **`wait-receipt`** - Wait for blockchain transaction receipt
-- **`wait-effectstream-processed`** - Wait until EffectStream has processed the batch
-
-```typescript
-// Don't wait
-await batcher.batchInput(input, "no-wait");
-
-// Wait for receipt (default)
-const receipt = await batcher.batchInput(input, "wait-receipt");
-
-// Wait for full processing
-const result = await batcher.batchInput(input, "wait-effectstream-processed");
-console.log(`Processed in rollup block ${result.rollup}`);
-```
-
-## Folder Structure
-
-```
-packages/batcher/
-├── core/                          # Core batcher functionality
-│   ├── batcher.ts                 # Main Batcher class
-│   ├── types.ts                   # Core types and interfaces
-│   ├── config.ts                  # Configuration types
-│   ├── storage.ts                 # Storage interface + FileStorage (✨ pluggable)
-│   ├── batch-processor.ts         # Batch processing logic
-│   ├── shutdown-manager.ts        # Graceful shutdown handling
-│   └── batcher-events.ts          # Event system types
-│
-├── batch-data-builder/            # Batch serialization (✨ pluggable)
-│   ├── batch-data-builder.ts      # Interface and types
-│   └── default-batch-builder.ts   # Default implementation
-│
-├── adapters/                      # Blockchain adapters (✨ pluggable)
-│   ├── adapter.ts                 # Base adapter interface
-│   ├── effectstream-l2-adapter.ts  # EffectstreamL2 EVM implementation
-│   ├── evm-contract-adapter.ts    # Generic ABI-driven EVM adapter
-│   ├── midnight-adapter.ts        # Midnight circuit adapter
-│   └── bitcoin-adapter.ts         # Bitcoin regtest adapter
-│
-└── server/                        # HTTP API
-    └── batcher-server.ts          # Fastify server implementation
-```
-
-## HTTP API
-
-When `enableHttpServer: true`, the batcher exposes a REST API:
-
-- **`POST /batch-input`** - Submit an input for batching
-- **`GET /status`** - Get batching status and statistics
-- **`GET /health`** - Health check endpoint
-- **`POST /force-process`** - Manually trigger batch processing
-
-Example:
+### Submitting an input
 
 ```bash
 curl -X POST http://localhost:3334/batch-input \
@@ -385,4 +86,55 @@ curl -X POST http://localhost:3334/batch-input \
   }'
 ```
 
-`signature` is optional for chains/adapters that override `verifySignature` (for example Midnight). When omitted, the adapter must implement its own verification semantics.
+`signature` is required for the EVM and Cardano adapters. Adapters that override `verifySignature` (Midnight, for example) accept inputs without it but must implement their own check.
+
+### Batching criteria
+
+Per-adapter, you choose how `runBatcher` decides to submit:
+
+- `time`: every `timeWindowMs` milliseconds.
+- `size`: when `maxBatchSize` inputs are queued.
+- `value`: when accumulated value (via `valueAccumulatorFn`) reaches `targetValue`.
+- `hybrid`: time OR size, whichever comes first.
+- `custom`: your `isBatchReadyFn(inputs, lastProcessTime)` returns `true`.
+
+### Confirmation levels
+
+`batcher.batchInput(input, level?)` returns when the chosen level is reached:
+
+- `no-wait`: returns once the input is queued.
+- `wait-receipt`: waits for the blockchain transaction receipt.
+- `wait-effectstream-processed`: waits until Effectstream has processed the resulting rollup block.
+
+## Customising the batcher
+
+The four interfaces you'd implement, in order of frequency:
+
+- `BlockchainAdapter`: submit, wait for receipt, estimate fee, report chain name. New chains plug in here.
+- `BatcherStorage`: persist + load inputs. The default is `FileStorage` (JSONL on disk); Postgres / Redis / S3 implementations are straightforward.
+- `BatchDataBuilder<T>`: control how inputs are serialised into the bytes the adapter submits.
+- State-transition listeners: hook into `startup`, `batch:process:start`, `batch:submit`, `batch:confirmed`, `error`, and others for metrics or custom behaviour.
+
+## Inside Effectstream
+
+The batcher is the on-ramp between user wallets and Effectstream's state machine. Frontends sign inputs through `@effectstream/wallets`, POST them here, and wait on the confirmation level they need. On submission, `@effectstream/sync`'s fetchers pick up the resulting on-chain transaction and the state machine (`@effectstream/sm`) processes the contained subunits in a per-block transaction.
+
+## Key exports
+
+- `createNewBatcher(config, storage)`: build a batcher instance.
+- `BatcherConfig`: configuration type. See `pollingIntervalMs`, `adapters`, `defaultTarget`, `batchingCriteria`, `confirmationLevel`, `enableHttpServer`, `port`, `enableEventSystem`, `namespace`, `batchBuilding`.
+- `FileStorage(dir)`: default JSONL storage.
+- Adapters: `EffectstreamL2DefaultAdapter`, `EvmContractAdapter`, `MidnightAdapter`, `BitcoinAdapter`.
+- Batcher operations: `runBatcher`, `batchInput`, `addStateTransition`, `gracefulShutdownOp`, `getPublicConfig`, `getBatchingStatus`.
+- HTTP endpoints (when enabled): `POST /batch-input`, `GET /status`, `GET /health`, `POST /force-process`.
+
+## Examples
+
+End-to-end batcher flow:
+[`e2e/evm/sync/batcher.test.ts`](https://github.com/effectstream/effectstream/blob/main/e2e/evm/sync/batcher.test.ts).
+
+## Links
+
+- Docs: https://effectstream.github.io/docs/packages/batcher
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/batcher
+- Companion: [`@effectstream/wallets`](https://www.npmjs.com/package/@effectstream/wallets) for the signing side.

--- a/docs/site/docs/home/500-packages/550-tools/orchestrator.md
+++ b/docs/site/docs/home/500-packages/550-tools/orchestrator.md
@@ -15,6 +15,11 @@ Cardano-side services, Avail node + light client, NEAR sandbox,
 Celestia, plus the EffectStream sync + runtime + batcher — in the right
 order, with health checks.
 
+- One CLI that starts every dependency a template needs: DB, chains, sync, runtime, batcher.
+- Dependency-graph aware: runs in parallel where it can, sequential where it must.
+- Disable any chain with `DISABLE_EVM=true`, `DISABLE_BITCOIN=true`, ...
+- Used by every template in this repo and by the E2E runner.
+
 ## Install
 
 ```bash
@@ -98,10 +103,10 @@ Global flags:
 ## Inside EffectStream
 
 Every template under
-[`templates/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates)
+[`templates/`](https://github.com/effectstream/effectstream/tree/main/templates)
 defines an `orchestrator.config.ts` (or `.json`) and starts dev with one
 command. The E2E runner at
-[`e2e/runner.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/e2e/runner.ts)
+[`e2e/runner.ts`](https://github.com/effectstream/effectstream/blob/main/e2e/runner.ts)
 is the same machinery, serialised across nine chain suites.
 
 ## Key subpath exports
@@ -113,12 +118,12 @@ is the same machinery, serialised across nine chain suites.
 
 ## Examples
 
-- Templates: every directory under [`templates/`](https://github.com/PaimaStudios/paima-engine/tree/main/templates) ships a working orchestrator config.
-- E2E: [`e2e/`](https://github.com/PaimaStudios/paima-engine/tree/main/e2e) drives the orchestrator under the hood.
+- Templates: every directory under [`templates/`](https://github.com/effectstream/effectstream/tree/main/templates) ships a working orchestrator config.
+- E2E: [`e2e/`](https://github.com/effectstream/effectstream/tree/main/e2e) drives the orchestrator under the hood.
 
 Runnable: [`test/examples.test.ts`](https://github.com/PaimaStudios/paima-engine/blob/main/packages/build-tools/orchestrator/test/examples.test.ts).
 
 ## Links
 
 - Docs: https://effectstream.github.io/docs/packages/tools/orchestrator
-- Source: https://github.com/PaimaStudios/paima-engine/tree/main/packages/build-tools/orchestrator
+- Source: https://github.com/effectstream/effectstream/tree/main/packages/build-tools/orchestrator


### PR DESCRIPTION
## Summary

- Replaces all `deno install` / `deno task` / `deno run` invocations across the docs with the bun equivalents the repo actually uses: `bun i`, `bun run dev`, `bun run --cwd <path>`, and `bun ./node_modules/.bin/<binary>` for the chain process scripts in the chain pages.
- Collapses the template install/run flow to `clone; cd; bun i; bun run dev` everywhere (intro, quickstart, all 8 template pages).
- Drops JSR mentions ("EffectStream is distributed for `deno` through `NPM` and `JSR`" → "through `NPM`") since the engine ships only on NPM now.
- Rewrites the `deno.json` `tasks` example in `199-environment-variables.md` as a `package.json` `scripts` block, and converts `Deno.env.get(...)` / `Deno.exit(1)` code samples in the batcher pages to `process.env[...]` / `process.exit(1)`.
- Regenerates `docs/site/docs/home/500-packages/**` via `bun run scripts/sync-package-readmes.ts` — needed to strip the stale `initTelemetry` / `deno.json` section from `evm-contracts.md`, and incidentally picks up source-README updates (simpler descriptions, `PaimaStudios/paima-engine` → `effectstream/effectstream` source URLs) that had been lagging on the docs site.

## Test plan

- [ ] `cd docs/site && bun i && bun run start` — verify dev server boots and the regenerated package pages render.
- [ ] Spot-check the intro, quickstart, and one template page (e.g. `1201-evm-midnight`) — the only install/run commands should be `bun i` / `bun run dev`.
- [ ] `grep -rni "deno" docs/site/docs docs/site/README.md` returns only the English word "denoted" in `102-state-machine.md` L227.
- [ ] Skim the regenerated `evm-contracts.md` — no `initTelemetry` section, no `deno.json` references.