### PR TITLE
docs: align symbol/package names with code

### DIFF
--- a/docs/site/docs/home/100-components/104-l2-contract.md
+++ b/docs/site/docs/home/100-components/104-l2-contract.md
@@ -1,6 +1,6 @@
 # EffectStream L2 Contract
 
-The `EffectStreamL2Contract` is a specialized, gas-efficient smart contract that serves as the primary "mailbox" or data entry point for your EffectStream application. While EffectStream can monitor any contract, the `EffectStreamL2Contract` is optimized for submitting user actions and game moves directly to your state machine.
+The `EffectstreamL2Contract` is a specialized, gas-efficient smart contract that serves as the primary "mailbox" or data entry point for your EffectStream application. While EffectStream can monitor any contract, the `EffectstreamL2Contract` is optimized for submitting user actions and game moves directly to your state machine.
 
 Its design is intentionally simple: its main job is to accept arbitrary data from a user, wrap it in an event, and securely log that event on the blockchain for the EffectStream to process.
 
@@ -11,7 +11,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/utils/Address.sol";
 
 /// @dev The main L2 contract for an EffectStream L2.
-contract EffectStreamL2Contract {
+contract EffectstreamL2Contract {
     // ... (events and state variables)
 
     /// @dev Emits the `EffectStreamGameInteraction` event, logging the `msg.sender`, `data`, and `msg.value`.
@@ -38,9 +38,9 @@ The contract's logic centers around a single function and a single event.
 
 ### How it Connects to the Grammar and State Machine
 
-The `EffectStreamL2Contract` is the critical on-chain starting point that triggers your off-chain logic. The connection happens through a precise sequence of steps orchestrated by the EffectStream:
+The `EffectstreamL2Contract` is the critical on-chain starting point that triggers your off-chain logic. The connection happens through a precise sequence of steps orchestrated by the EffectStream:
 
-1.  **User Action**: A user on your frontend initiates an action, which calls `effectstreamSubmitGameInput` on the deployed `EffectStreamL2Contract` with a formatted string (e.g., `["attack","player1","monster7"]`).
+1.  **User Action**: A user on your frontend initiates an action, which calls `effectstreamSubmitGameInput` on the deployed `EffectstreamL2Contract` with a formatted string (e.g., `["attack","player1","monster7"]`).
 2.  **Event Emission**: The contract executes and emits the `EffectStreamGameInteraction` event onto the blockchain.
 3.  **Sync Service Detection**: The EffectStream's **Sync Service**, which is constantly monitoring the blockchain, has a **Primitive** configured to listen specifically for the `EffectStreamGameInteraction` event from your contract's address.
 4.  **Grammar Parsing**: When the Sync Service detects a new event, it takes the `data` payload and passes it to the **Grammar Parser**. The parser checks the prefix (`["attack",...`) to identify which rule to apply. It then validates and parses the rest of the string into a structured, type-safe object.
@@ -51,14 +51,14 @@ This flow creates a secure and deterministic bridge from an on-chain event to yo
 ```mermaid
 sequenceDiagram
     participant User/Frontend
-    participant EVM Blockchain (EffectStreamL2Contract)
+    participant EVM Blockchain (EffectstreamL2Contract)
     participant EffectStream (Sync Service)
     participant EffectStream (Grammar Parser)
     participant EffectStream (State Machine)
 
-    User/Frontend->>EVM Blockchain (EffectStreamL2Contract): Calls `effectstreamSubmitGameInput("attack|p1|m7")`
-    EVM Blockchain (EffectStreamL2Contract)->>EVM Blockchain (EffectStreamL2Contract): Emits `EffectStreamGameInteraction` event
-    EffectStream (Sync Service)->>EVM Blockchain (EffectStreamL2Contract): [Primitive] Detects Event
+    User/Frontend->>EVM Blockchain (EffectstreamL2Contract): Calls `effectstreamSubmitGameInput("attack|p1|m7")`
+    EVM Blockchain (EffectstreamL2Contract)->>EVM Blockchain (EffectstreamL2Contract): Emits `EffectStreamGameInteraction` event
+    EffectStream (Sync Service)->>EVM Blockchain (EffectstreamL2Contract): [Primitive] Detects Event
     EffectStream (Sync Service)->>EffectStream (Grammar Parser): Passes raw data: ["attack","p1","m7"]
     EffectStream (Grammar Parser)->>EffectStream (State Machine): Parses input and identifies 'attack' prefix
     EffectStream (State Machine)->>EffectStream (State Machine): Executes 'attack' STF with parsed data
@@ -66,7 +66,7 @@ sequenceDiagram
 
 ### Ownership and Monetization
 
-The `EffectStreamL2Contract` also includes administrative functions that allow the contract owner to manage it and optionally generate revenue.
+The `EffectstreamL2Contract` also includes administrative functions that allow the contract owner to manage it and optionally generate revenue.
 
 *   **`setOwner(address newOwner)`**: Transfers ownership of the contract to a new address.
 *   **`setFee(uint256 newFee)`**: Sets a fee (in wei) that users must pay to call `effectstreamSubmitGameInput`. This is a simple way to monetize your dApp, as every action can contribute to a fee pool.
@@ -113,7 +113,7 @@ Typically, you will not construct this `&B` string manually. The Batcher service
 
 EffectStream includes a flexible, L2-native account system that goes beyond simple wallet addresses. A single "EffectStream Account" can be controlled by multiple wallets (e.g., a hot wallet on a mobile device and a hardware wallet for security), and the primary controlling wallet can be changed. This provides a form of L2 Account Abstraction.
 
-These commands allow users to manage their EffectStream Account directly through the `EffectStreamL2Contract`.
+These commands allow users to manage their EffectStream Account directly through the `EffectstreamL2Contract`.
 
 *   **`&createAccount`**
     *   **Description**: Creates a new, empty EffectStream Account. The wallet that sends this transaction (`msg.sender`) automatically becomes the first and primary address for this new account.

--- a/docs/site/docs/home/100-components/105-contracts.md
+++ b/docs/site/docs/home/100-components/105-contracts.md
@@ -70,11 +70,11 @@ bun run --cwd packages/contracts-midnight build
 ```
 The templates also include scripts for deploying these contracts to local development chains or public testnets/mainnets.
 
-## The `EffectStreamL2Contract`
+## The `EffectstreamL2Contract`
 
-While EffectStream can listen to any contract, it also provides a specialized contract called `EffectStreamL2Contract`. This contract serves as a highly efficient, generic "mailbox" for submitting game-specific inputs directly to the state machine.
+While EffectStream can listen to any contract, it also provides a specialized contract called `EffectstreamL2Contract`. This contract serves as a highly efficient, generic "mailbox" for submitting game-specific inputs directly to the state machine.
 
-Instead of defining dozens of specific functions on-chain (e.g., `attack(uint monsterId)`, `useItem(uint itemId)`), you send a single transaction to the `EffectStreamL2Contract`'s `submitInput` function with a concise, string-based payload.
+Instead of defining dozens of specific functions on-chain (e.g., `attack(uint monsterId)`, `useItem(uint itemId)`), you send a single transaction to the `EffectstreamL2Contract`'s `submitInput` function with a concise, string-based payload.
 
 **Example:**
 *   **Without L2 Contract:** `myGameContract.attack(123)`
@@ -88,11 +88,11 @@ This approach has significant advantages:
 More in the [EffectStream L2 Contract Section](./104-l2-contract.md)
 
 ### EffectStream-Provided Contracts
-The `@effectstream/evm-contracts` package includes a variety of useful contracts, including implementations of common standards and the core `EffectStreamL2Contract`.
+The `@effectstream/evm-contracts` package includes a variety of useful contracts, including implementations of common standards and the core `EffectstreamL2Contract`.
 
 | Contract | Description |
 | :--- | :--- |
-| **`EffectStreamL2Contract`** | The core contract for submitting game inputs. |
+| **`EffectstreamL2Contract`** | The core contract for submitting game inputs. |
 | `erc20`, `erc721` | Standard OpenZeppelin implementations. |
 | `Erc20Dev`, `Erc721Dev`| Simple mintable versions for development and testing. |
 | *Interfaces* | `IERC20`, `IERC721`, etc., for interacting with other contracts. |
@@ -129,7 +129,7 @@ This is the most important contract for interacting with the EffectStream's stat
 
 | Contract | Description |
 | :--- | :--- |
-| **`EffectStreamL2Contract`** | The central "mailbox" for your application. This contract provides the `submitInput` function, which is the most gas-efficient and flexible way to send game moves and actions from the on-chain world to your state machine. It serves as the primary entry point for user interactions and the Batcher service. |
+| **`EffectstreamL2Contract`** | The central "mailbox" for your application. This contract provides the `submitInput` function, which is the most gas-efficient and flexible way to send game moves and actions from the on-chain world to your state machine. It serves as the primary entry point for user interactions and the Batcher service. |
 
 #### Standard Token Contracts
 These are standard implementations of the most common token types, based on the battle-tested OpenZeppelin library.

--- a/docs/site/docs/home/100-components/108-batcher/1200-overview.md
+++ b/docs/site/docs/home/100-components/108-batcher/1200-overview.md
@@ -119,10 +119,10 @@ batcher.addBlockchainAdapter("nft", nftAdapter, {
 
 ```typescript
 import { main, suspend } from "effection";
-import { Batcher, FileStorage, EffectStreamL2DefaultAdapter } from "@effectstream/batcher";
+import { Batcher, FileStorage, EffectstreamL2DefaultAdapter } from "@effectstream/batcher-sdk";
 
 // 1. Create adapter
-const adapter = new EffectStreamL2DefaultAdapter(
+const adapter = new EffectstreamL2DefaultAdapter(
   "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",  // Contract address
   process.env.PRIVATE_KEY!,                       // Private key
   0n,                                              // Fee

--- a/docs/site/docs/home/100-components/108-batcher/1220-core-concepts.md
+++ b/docs/site/docs/home/100-components/108-batcher/1220-core-concepts.md
@@ -25,7 +25,7 @@ The generic type parameter `T` allows you to extend `DefaultBatcherInput` with c
 
 **Example:**
 ```typescript
-import { createNewBatcher, FileStorage } from "@effectstream/batcher";
+import { createNewBatcher, FileStorage } from "@effectstream/batcher-sdk";
 
 const batcher = createNewBatcher(
   {
@@ -181,13 +181,13 @@ const config: BatcherConfig = {
   
   // Configure multiple adapters for multi-chain support
   adapters: {
-    ethereum: new EffectStreamL2DefaultAdapter(
+    ethereum: new EffectstreamL2DefaultAdapter(
       "0x...", // Contract address
       "0x...", // Private key
       0n,      // Fee
       "eth-mainnet" // Sync protocol name
     ),
-    polygon: new EffectStreamL2DefaultAdapter(
+    polygon: new EffectstreamL2DefaultAdapter(
       "0x...",
       "0x...",
       0n,
@@ -233,7 +233,7 @@ There are **two different `maxBatchSize` settings** that serve different purpose
 
 **Example showing both:**
 ```typescript
-const ethereumAdapter = new EffectStreamL2DefaultAdapter(
+const ethereumAdapter = new EffectstreamL2DefaultAdapter(
   "0x...",
   "0x...",
   0n,
@@ -332,12 +332,12 @@ interface BlockchainAdapter<TOutput> {
 }
 ```
 
-### Example: EffectStreamL2DefaultAdapter
+### Example: EffectstreamL2DefaultAdapter
 
-The built-in `EffectStreamL2DefaultAdapter` provides a complete EVM implementation:
+The built-in `EffectstreamL2DefaultAdapter` provides a complete EVM implementation:
 
 ```typescript
-export class EffectStreamL2DefaultAdapter implements BlockchainAdapter<string> {
+export class EffectstreamL2DefaultAdapter implements BlockchainAdapter<string> {
   constructor(
     effectstreamL2Address: EvmAddress,
     batcherPrivateKey: EvmPrivateKey,
@@ -358,7 +358,7 @@ export class EffectStreamL2DefaultAdapter implements BlockchainAdapter<string> {
   }
 
   async submitBatch(data: string, fee?: string | bigint): Promise<BlockchainHash> {
-    // Submits to EffectStreamL2 contract via viem
+    // Submits to EffectstreamL2 contract via viem
     const hexData = encodeHexFromString(data);
     const hash = await this.walletClient.writeContract({
       address: this.effectstreamL2Address,
@@ -530,11 +530,11 @@ Here's a complete flow showing how all core concepts interact, including **exten
 import { 
   createNewBatcher, 
   BatcherConfig,
-  EffectStreamL2DefaultAdapter,
+  EffectstreamL2DefaultAdapter,
   FileStorage,
   DefaultBatcherInput,
   AddressType 
-} from "@effectstream/batcher";
+} from "@effectstream/batcher-sdk";
 
 // 1. Define custom input type with additional fields
 interface GameBatcherInput extends DefaultBatcherInput {
@@ -558,8 +558,8 @@ const batcher = createNewBatcher<GameBatcherInput>(config, new FileStorage("./da
 
 // 4. Create and add blockchain adapter dynamically
 // This must be done BEFORE init() or runBatcher()
-const ethereumAdapter = new EffectStreamL2DefaultAdapter(
-  "0x1234...",  // EffectStreamL2 contract address
+const ethereumAdapter = new EffectstreamL2DefaultAdapter(
+  "0x1234...",  // EffectstreamL2 contract address
   "0xabcd...",  // Batcher private key
   0n,           // Transaction fee
   "eth-mainnet" // Sync protocol name (target can differ from this)

--- a/docs/site/docs/home/100-components/108-batcher/1240-configuration.md
+++ b/docs/site/docs/home/100-components/108-batcher/1240-configuration.md
@@ -117,7 +117,7 @@ The dynamic configuration approach follows these steps:
 Create the base configuration object with global settings. **Adapters are not included here**—they'll be added dynamically in Step 3:
 
 ```typescript
-import { type BatcherConfig } from "@effectstream/batcher";
+import { type BatcherConfig } from "@effectstream/batcher-sdk";
 
 const baseConfig: BatcherConfig = {
   // Polling frequency (how often to check if batching criteria are met)
@@ -159,9 +159,9 @@ Set `pollingIntervalMs` to match your shortest batching time window. For example
 Instantiate each blockchain adapter you want to use:
 
 ```typescript
-import { EffectStreamL2DefaultAdapter } from "@effectstream/batcher";
+import { EffectstreamL2DefaultAdapter } from "@effectstream/batcher-sdk";
 
-const evmAdapter = new EffectStreamL2DefaultAdapter(
+const evmAdapter = new EffectstreamL2DefaultAdapter(
   "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
   "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
   0n,
@@ -178,7 +178,7 @@ For comprehensive information about adapters, their responsibilities, and exampl
 Now create the batcher instance and use the **builder pattern** to wire adapters:
 
 ```typescript
-import { createNewBatcher, FileStorage } from "@effectstream/batcher";
+import { createNewBatcher, FileStorage } from "@effectstream/batcher-sdk";
 
 // Create storage
 const storage = new FileStorage("./batcher-data");
@@ -344,12 +344,12 @@ Here's a complete example using the dynamic approach:
 import {
   createNewBatcher,
   FileStorage,
-  EffectStreamL2DefaultAdapter,
+  EffectstreamL2DefaultAdapter,
   MidnightAdapter
-} from "@effectstream/batcher";
+} from "@effectstream/batcher-sdk";
 
 // 1. Instantiate adapters
-const evmAdapter = new EffectStreamL2DefaultAdapter(
+const evmAdapter = new EffectstreamL2DefaultAdapter(
   "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
   process.env["EVM_PRIVATE_KEY"]!,
   0n,
@@ -418,11 +418,11 @@ import {
   createNewBatcher,
   FileStorage,
   type BatcherConfig,
-  EffectStreamL2DefaultAdapter
-} from "@effectstream/batcher";
+  EffectstreamL2DefaultAdapter
+} from "@effectstream/batcher-sdk";
 
 // Instantiate adapters first
-const evmAdapter = new EffectStreamL2DefaultAdapter(/* ... */);
+const evmAdapter = new EffectstreamL2DefaultAdapter(/* ... */);
 const midnightAdapter = new MidnightAdapter(/* ... */);
 
 // Create unified configuration
@@ -492,7 +492,7 @@ For detailed information about confirmation levels, their behavior in the pipeli
 Choose a storage backend for persisting pending inputs:
 
 ```typescript
-import { FileStorage } from "@effectstream/batcher";
+import { FileStorage } from "@effectstream/batcher-sdk";
 
 const storage = new FileStorage("./batcher-data");
 ```
@@ -513,7 +513,7 @@ The batcher supports graceful shutdown with customizable hooks that execute at s
 ### Shutdown Configuration
 
 ```typescript
-import { createNewBatcher } from "@effectstream/batcher";
+import { createNewBatcher } from "@effectstream/batcher-sdk";
 
 const batcher = createNewBatcher({
   pollingIntervalMs: 1000,

--- a/docs/site/docs/home/100-components/108-batcher/1250-adapter.md
+++ b/docs/site/docs/home/100-components/108-batcher/1250-adapter.md
@@ -55,7 +55,7 @@ The `TOutput` parameter defines what `buildBatchData()` produces and what `submi
 
 | Blockchain Type | `TOutput` Example | Description |
 |----------------|-------------------|-------------|
-| **EVM (EffectStreamL2)** | `string` | JSON string like `["&B", [...]]` |
+| **EVM (EffectstreamL2)** | `string` | JSON string like `["&B", [...]]` |
 | **Midnight** | `MidnightBatchPayload` | Structured object with circuit args |
 | **Custom Chain** | `Uint8Array` | Raw bytes for binary protocols |
 | **Solana** | `Transaction` | Native transaction object |
@@ -276,10 +276,10 @@ interface BatchBuildingResult<TOutput> {
 
 If your blockchain uses a standard format (like EffectStream's JSON batching format), use a helper class:
 
-**Example: EffectStreamL2DefaultAdapter (EVM)**
+**Example: EffectstreamL2DefaultAdapter (EVM)**
 
 ```typescript
-export class EffectStreamL2DefaultAdapter implements BlockchainAdapter<string> {
+export class EffectstreamL2DefaultAdapter implements BlockchainAdapter<string> {
   private readonly batchBuilderLogic = new DefaultBatchBuilderLogic();
   
   buildBatchData(
@@ -414,7 +414,7 @@ submitBatch(data: TOutput, fee: string | bigint): Promise<BlockchainHash>
 3. **Sign and submit** the transaction
 4. **Return** the transaction hash
 
-**Example: EffectStreamL2DefaultAdapter (EVM)**
+**Example: EffectstreamL2DefaultAdapter (EVM)**
 
 ```typescript
 async submitBatch(data: string, fee?: string | bigint): Promise<BlockchainHash> {
@@ -426,7 +426,7 @@ async submitBatch(data: string, fee?: string | bigint): Promise<BlockchainHash> 
   // Convert JSON string to hex bytes
   const hexData = encodeHexFromString(data);
   
-  // Submit to EffectStreamL2 contract
+  // Submit to EffectstreamL2 contract
   const hash = await this.walletClient.writeContract({
     account: this.account,
     chain: this.walletClient.chain,
@@ -911,7 +911,7 @@ The batcher provides two helper classes for common serialization patterns. These
 
 ### `DefaultBatchBuilderLogic`
 
-**Purpose:** Create the standard EffectStream JSON batch format used by the EffectStreamL2 contract.
+**Purpose:** Create the standard EffectStream JSON batch format used by the EffectstreamL2 contract.
 
 **Output Format:**
 ```json
@@ -924,7 +924,7 @@ The batcher provides two helper classes for common serialization patterns. These
 
 **Usage:**
 ```typescript
-import { DefaultBatchBuilderLogic } from "@effectstream/batcher";
+import { DefaultBatchBuilderLogic } from "@effectstream/batcher-sdk";
 
 export class MyEVMAdapter implements BlockchainAdapter<string> {
   private readonly batchBuilderLogic = new DefaultBatchBuilderLogic();
@@ -973,7 +973,7 @@ The helper:
 
 **Usage:**
 ```typescript
-import { MidnightBatchBuilderLogic, type MidnightBatchPayload } from "@effectstream/batcher";
+import { MidnightBatchBuilderLogic, type MidnightBatchPayload } from "@effectstream/batcher-sdk";
 
 export class MyMidnightAdapter implements BlockchainAdapter<MidnightBatchPayload | null> {
   private readonly batchBuilderLogic = new MidnightBatchBuilderLogic();
@@ -1012,8 +1012,8 @@ This adapter uses `DefaultBatchBuilderLogic` for serialization but implements cu
 - ✅ Pre-validates function names and argument counts
 
 ```typescript
-import { DefaultBatchBuilderLogic } from "@effectstream/batcher";
-import type { BlockchainAdapter, DefaultBatcherInput } from "@effectstream/batcher";
+import { DefaultBatchBuilderLogic } from "@effectstream/batcher-sdk";
+import type { BlockchainAdapter, DefaultBatcherInput } from "@effectstream/batcher-sdk";
 
 export class ERC1155CustomAdapter implements BlockchainAdapter<string | null> {
   private readonly batchBuilderLogic = new DefaultBatchBuilderLogic();
@@ -1133,8 +1133,8 @@ This adapter uses `MidnightBatchBuilderLogic` for serialization and implements c
 - ✅ Queries Midnight indexer GraphQL API for transaction confirmation
 
 ```typescript
-import { MidnightBatchBuilderLogic, type MidnightBatchPayload } from "@effectstream/batcher";
-import type { BlockchainAdapter, DefaultBatcherInput } from "@effectstream/batcher";
+import { MidnightBatchBuilderLogic, type MidnightBatchPayload } from "@effectstream/batcher-sdk";
+import type { BlockchainAdapter, DefaultBatcherInput } from "@effectstream/batcher-sdk";
 
 export class MidnightAdapter implements BlockchainAdapter<MidnightBatchPayload | null> {
   private readonly batchBuilderLogic = new MidnightBatchBuilderLogic();

--- a/docs/site/docs/home/100-components/108-batcher/1290-advanced-topics.md
+++ b/docs/site/docs/home/100-components/108-batcher/1290-advanced-topics.md
@@ -1002,7 +1002,7 @@ The default storage backend uses JSONL (JSON Lines) files for simplicity and hum
 
 **Usage:**
 ```typescript
-import { FileStorage } from "@effectstream/batcher";
+import { FileStorage } from "@effectstream/batcher-sdk";
 
 const storage = new FileStorage("./batcher-data");
 const batcher = createNewBatcher(config, storage);
@@ -1042,7 +1042,7 @@ Implement `BatcherStorage` to use any backend:
 
 ```typescript
 import { Pool } from "pg";
-import type { BatcherStorage, DefaultBatcherInput } from "@effectstream/batcher";
+import type { BatcherStorage, DefaultBatcherInput } from "@effectstream/batcher-sdk";
 
 export class PostgreSQLStorage<T extends DefaultBatcherInput>
   implements BatcherStorage<T> {
@@ -1156,7 +1156,7 @@ const batcher = createNewBatcher(config, storage);
 
 ```typescript
 import Redis from "ioredis";
-import type { BatcherStorage, DefaultBatcherInput } from "@effectstream/batcher";
+import type { BatcherStorage, DefaultBatcherInput } from "@effectstream/batcher-sdk";
 
 export class RedisStorage<T extends DefaultBatcherInput>
   implements BatcherStorage<T> {
@@ -1327,7 +1327,7 @@ The batcher provides a `runBatcher()` operation that:
 
 ```typescript
 import { main, suspend } from "effection";
-import { Batcher } from "@effectstream/batcher";
+import { Batcher } from "@effectstream/batcher-sdk";
 
 const batcher = new Batcher(config, storage);
 
@@ -1354,7 +1354,7 @@ Here's a production-ready example from the E2E tests:
 
 ```typescript
 import { main, suspend } from "effection";
-import { Batcher } from "@effectstream/batcher";
+import { Batcher } from "@effectstream/batcher-sdk";
 import { config, storage } from "./config.ts";
 
 const batcher = new Batcher(config, storage);

--- a/docs/site/docs/home/100-components/111-grammar.md
+++ b/docs/site/docs/home/100-components/111-grammar.md
@@ -49,7 +49,7 @@ Each argument is defined as a tuple `[name, type]`:
 
 The grammar is the central piece that links an on-chain event to your application logic. Here’s the flow:
 
-1.  **On-Chain Input**: A transaction is sent to the `EffectStreamL2Contract` with a payload that is a JSON-stringified array, e.g., `"[\"attack\",1,42]"`.
+1.  **On-Chain Input**: A transaction is sent to the `EffectstreamL2Contract` with a payload that is a JSON-stringified array, e.g., `"[\"attack\",1,42]"`.
 2.  **Prefix Matching**: The EffectStream parses the JSON and inspects the first element (`"attack"`) to find the matching rule in your `grammar.ts` file.
 3.  **Parsing & Validation**: It then uses the TypeBox schemas defined in that rule (`Type.Integer()`, `Type.Integer()`) to validate and parse the remaining elements (`1`, `42`).
 4.  **STF Execution**: Finally, the engine calls the STF registered with the prefix `"attack"`, passing it a `data` object containing the fully typed and parsed input:
@@ -93,7 +93,7 @@ const move = ["attack", 1, 42];
 // 2. Stringify it to create the payload
 const payload = JSON.stringify(move);
 
-// 3. Submit the payload to the EffectStreamL2Contract
+// 3. Submit the payload to the EffectstreamL2Contract
 // (The frontend SDKs will handle this for you)
 await effectstreamL2Contract.submitInput(payload);
 ```

--- a/docs/site/docs/home/100-components/112-wallets.md
+++ b/docs/site/docs/home/100-components/112-wallets.md
@@ -7,9 +7,9 @@ In any decentralized application, the user's wallet is their identity, their key
 
 A major challenge in building multi-chain dApps is that every blockchain ecosystem has its own wallet standards and connection methods. EffectStream solves this problem by providing a single, unified interface that handles the complexity for you.
 
-## The `@effectstream/wallet` Package
+## The `@effectstream/wallets` Package
 
-The `@effectstream/wallet` package is the core frontend library for managing user identity. It provides a single, easy-to-use API for connecting to and interacting with a wide variety of blockchain wallets, abstracting away the chain-specific implementation details.
+The `@effectstream/wallets` package is the core frontend library for managing user identity. It provides a single, easy-to-use API for connecting to and interacting with a wide variety of blockchain wallets, abstracting away the chain-specific implementation details.
 
 ## AddressType
 
@@ -31,7 +31,7 @@ This table is a EffectStream numeric representation of wallet address type. Norm
 Integrating wallet connectivity into your dApp is streamlined with a single `login` function. You simply specify which type of wallet you want to connect to using the `WalletMode` enum, and the library handles the rest.
 
 ```ts
-import { WalletMode, login } from '@effectstream/wallet';
+import { WalletMode, login } from '@effectstream/wallets';
 
 const effectstreamConfig = new EffectStreamConfig(...); // see EffectStreamConfig in the @effectstream/wallets package
 
@@ -120,7 +120,7 @@ const result = await sendBatcherTransaction(walletClient, conciseInput, effectst
 
 For specific, high-stakes actions, or if your dApp doesn't use a Batcher, you can use the wallet to send traditional on-chain transactions.
 
-*   **Direct EffectStream L2 Contract Interaction**: Call the `submitInput` function on the `EffectStreamL2Contract` to send a game move directly.
+*   **Direct EffectStream L2 Contract Interaction**: Call the `submitInput` function on the `EffectstreamL2Contract` to send a game move directly.
 This can be done using the `sendSelfSequencedTransaction` function.
 ```ts
 const result = await sendSelfSequencedTransaction(walletClient, conciseInput, effectstreamConfig);
@@ -148,6 +148,6 @@ This allows for an "account abstraction" experience where:
 *   A single EffectStream Account can be controlled by multiple wallet addresses.
 *   The primary (controlling) wallet of an account can be changed.
 
-A user manages their account by sending built-in system commands (like `&linkAddress`) to the `EffectStreamL2Contract`, using their connected wallet to authorize the action with a signature.
+A user manages their account by sending built-in system commands (like `&linkAddress`) to the `EffectstreamL2Contract`, using their connected wallet to authorize the action with a signature.
 
 **[Learn more about the EffectStream Account System](./116-accounts.md)**

--- a/docs/site/docs/home/100-components/115-frontend.md
+++ b/docs/site/docs/home/100-components/115-frontend.md
@@ -35,10 +35,10 @@ Integration is possible with many popular game engines:
 To change the state of the application, the frontend must initiate a transaction or a signed message.
 
 ### Connecting a Wallet
-All write operations begin with connecting a user's wallet. The `@effectstream/wallet` package provides a unified interface for connecting to various blockchain ecosystems.
+All write operations begin with connecting a user's wallet. The `@effectstream/wallets` package provides a unified interface for connecting to various blockchain ecosystems.
 
 ```ts
-import { WalletMode, login } from '@effectstream/wallet';
+import { WalletMode, login } from '@effectstream/wallets';
 
 // Example for an injected EVM wallet like MetaMask
 const loginInfo = await login(WalletMode.EvmInjected);
@@ -47,7 +47,7 @@ Supported wallet modes include `EvmInjected`, `Cardano`, `Mina`, `AvailJs`, and 
 
 ### Submission Methods
 1.  **Direct Contract Interaction**: The standard Web3 approach where your frontend calls a function on a smart contract directly (e.g., minting an NFT).
-2.  **Direct EffectStream L2 Contract Interaction**: A specific direct interaction where your frontend calls the `submitInput` method on your game's `EffectStreamL2Contract` with a grammar-formatted payload. The user pays the gas for this transaction.
+2.  **Direct EffectStream L2 Contract Interaction**: A specific direct interaction where your frontend calls the `submitInput` method on your game's `EffectstreamL2Contract` with a grammar-formatted payload. The user pays the gas for this transaction.
 3.  **Batcher Interaction**: The recommended approach for the best UX. The user signs a message, and the frontend sends it to a **Batcher** service via an HTTP request. The Batcher then submits the input on-chain, often covering the gas fee and allowing users from different chains to interact.
 
 Here is an example of a frontend submitting an input to the batcher:

--- a/docs/site/docs/home/100-components/116-accounts.md
+++ b/docs/site/docs/home/100-components/116-accounts.md
@@ -30,7 +30,7 @@ erDiagram
 
 ### Managing Accounts via Built-in Commands
 
-You do not need to write any custom STFs to manage accounts. EffectStream provides a suite of built-in [Grammar](./111-grammar.md) commands that you can call directly through the `EffectStreamL2Contract`. All administrative actions are secured by cryptographic signatures.
+You do not need to write any custom STFs to manage accounts. EffectStream provides a suite of built-in [Grammar](./111-grammar.md) commands that you can call directly through the `EffectstreamL2Contract`. All administrative actions are secured by cryptographic signatures.
 
 #### `&createAccount`
 This is the entry point for creating a new EffectStream Account.

--- a/docs/site/docs/home/100-components/118-primitives.md
+++ b/docs/site/docs/home/100-components/118-primitives.md
@@ -12,7 +12,7 @@ This creates a deterministic and reliable pipeline from raw blockchain events to
 
 ## Built-in Primitives
 
-EffectStream provides a suite of pre-built primitives for the most common blockchain standards, such as ERC20, ERC721, and the `EffectStreamL2Contract`. Using these is the quickest and easiest way to integrate standard on-chain assets and actions into your application.
+EffectStream provides a suite of pre-built primitives for the most common blockchain standards, such as ERC20, ERC721, and the `EffectstreamL2Contract`. Using these is the quickest and easiest way to integrate standard on-chain assets and actions into your application.
 
 ### How to Use
 You configure built-in primitives within your `localhostConfig.ts` file using the `.buildPrimitives()` step of the `ConfigBuilder`. You simply need to provide the primitive's type, the contract address to monitor, and the `stateMachinePrefix` that will trigger the corresponding State Transition Function (STF).
@@ -44,7 +44,7 @@ A key advantage of built-in primitives is that many come with automatic database
 
 | Primitive Type | Chain | Description |
 | :--- | :--- | :--- |
-| **`PrimitiveTypeEVMEffectStreamL2`** | EVM | Listens for inputs submitted to a standard `EffectStreamL2Contract`. |
+| **`PrimitiveTypeEVMEffectstreamL2`** | EVM | Listens for inputs submitted to a standard `EffectstreamL2Contract`. |
 | **`PrimitiveTypeEVMERC20`** | EVM | Tracks `Transfer` events for an ERC20 token and maintains balance tables. |
 | **`PrimitiveTypeEVMERC721`** | EVM | Tracks `Transfer` events for an ERC721 NFT and maintains ownership tables. |
 | **`PrimitiveTypeEVMERC1155`**| EVM | Tracks `TransferSingle` and `TransferBatch` events for an ERC1155 token. |

--- a/docs/site/docs/home/1000-effectstream-engine/1000-effectstream-engine.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1000-effectstream-engine.md
@@ -30,9 +30,6 @@ EffectStream is distributed through `NPM` packages.
 *  @effectstream/chain-types  
     Common chain types and hashing helpers shared across modules.
 
-*  @effectstream/collector  
-    Lightweight OpenTelemetry collector gateway (Fastify) to receive and forward metrics/logs. Intended for development only.
-
 *  @effectstream/concise  
     Client SDK for submitting moves and interacting with the batcher; includes helpers and delegate wallet utilities.
 
@@ -71,9 +68,6 @@ EffectStream is distributed through `NPM` packages.
 
 *  @effectstream/sync  
     Chain synchronization protocols and factory; Processing of different chains as EVM, Cardano, Midnight and Avail to feed the main sync engine.
-
-*  @effectstream/tui  
-    Terminal UI for monitoring logs and services.
 
 *  @effectstream/utils  
     Shared utilities (config helpers, address/encoding, concurrency, decorators, constants, captcha, viem wrappers).

--- a/docs/site/docs/home/1000-effectstream-engine/1000-effectstream-engine.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1000-effectstream-engine.md
@@ -24,7 +24,7 @@ EffectStream is distributed through `NPM` packages.
 *  @effectstream/npm-midnight-proof-server  
     A wrapper for the Midnight proof server binary.
 
-*  @effectstream/batcher  
+*  @effectstream/batcher-sdk  
     HTTP service to collect and submit user inputs, replacing the need for manually sending input to the blockchain EffectStream L2 contract.
 
 *  @effectstream/chain-types  

--- a/docs/site/docs/home/1200-templates/1203-chess.md
+++ b/docs/site/docs/home/1200-templates/1203-chess.md
@@ -47,8 +47,8 @@ The chess template uses a `EffectStream L2 Contract` on the EVM chain. This cont
 EffectStream monitors the `EffectStreamGameInteraction` event from this contract to receive and process player inputs.
 
 ```solidity
-// Simplified example of what the EffectStreamL2Contract does
-contract EffectStreamL2 {
+// Simplified example of what the EffectstreamL2Contract does
+contract EffectstreamL2 {
     event EffectStreamGameInteraction(address indexed user, bytes input, uint256 indexed nonce);
 
     function submitInput(bytes calldata input) external payable {

--- a/docs/site/docs/home/1200-templates/1204-multi-chain-swap.md
+++ b/docs/site/docs/home/1200-templates/1204-multi-chain-swap.md
@@ -416,7 +416,7 @@ The `batchingCriteria` is set to `size` with a `maxBatchSize` of 1. This means t
 
 #### Custom EVM Adapter (`erc1155-adapter.ts`)
 
-A custom adapter is required because the Batcher isn't submitting generic inputs to a `EffectStreamL2Contract`. Instead, it needs to call specific functions (`mint` or `transferToMidnight`) on the `MCT_ERC1155` contract. The custom adapter parses a JSON payload from the State Machine's request to determine which function to call and with what arguments.
+A custom adapter is required because the Batcher isn't submitting generic inputs to a `EffectstreamL2Contract`. Instead, it needs to call specific functions (`mint` or `transferToMidnight`) on the `MCT_ERC1155` contract. The custom adapter parses a JSON payload from the State Machine's request to determine which function to call and with what arguments.
 
 ```ts
 // In packages/client/batcher/erc1155-adapter.ts

--- a/docs/site/docs/home/1200-templates/1206-world-map-2d.md
+++ b/docs/site/docs/home/1200-templates/1206-world-map-2d.md
@@ -140,8 +140,8 @@ The world-map-2d template uses a `EffectStream L2 Contract` deployed on the loca
 The contract is deployed at `0x5FbDB2315678afecb367f032d93F642f64180aa3` (local Hardhat deployment).
 
 ```solidity
-// Simplified example of what the EffectStreamL2Contract does
-contract EffectStreamL2 {
+// Simplified example of what the EffectstreamL2Contract does
+contract EffectstreamL2 {
     event EffectStreamGameInteraction(address indexed user, bytes input, uint256 indexed nonce);
 
     function submitInput(bytes calldata input) external payable {

--- a/docs/site/docs/home/1200-templates/1207-rock-paper-scissors.md
+++ b/docs/site/docs/home/1200-templates/1207-rock-paper-scissors.md
@@ -103,8 +103,8 @@ When you run `bun run dev`, the [Process Orchestrator](../100-components/106-pro
 The template uses a `EffectStream L2 Contract` deployed on the local EVM chain at `0x5FbDB2315678afecb367f032d93F642f64180aa3`. Players submit formatted input strings, and EffectStream processes them to update game state.
 
 ```solidity
-// The EffectStreamL2Contract acts as an input mailbox
-contract EffectStreamL2 {
+// The EffectstreamL2Contract acts as an input mailbox
+contract EffectstreamL2 {
     event EffectStreamGameInteraction(address indexed user, bytes input, uint256 indexed nonce);
 
     function submitInput(bytes calldata input) external payable {

--- a/docs/site/docs/home/1200-templates/1208-dice.md
+++ b/docs/site/docs/home/1200-templates/1208-dice.md
@@ -124,8 +124,8 @@ When a player's turn begins, they automatically roll dice until their score reac
 The template uses a `EffectStream L2 Contract` deployed on the local EVM chain at `0x5FbDB2315678afecb367f032d93F642f64180aa3`. Players submit formatted input strings, and EffectStream processes them to update game state.
 
 ```solidity
-// The EffectStreamL2Contract acts as an input mailbox
-contract EffectStreamL2 {
+// The EffectstreamL2Contract acts as an input mailbox
+contract EffectstreamL2 {
     event EffectStreamGameInteraction(address indexed user, bytes input, uint256 indexed nonce);
 
     function submitInput(bytes calldata input) external payable {

--- a/docs/site/docs/home/200-chains/201-evm.md
+++ b/docs/site/docs/home/200-chains/201-evm.md
@@ -39,7 +39,7 @@ The protocol type is `EVM_RPC_PARALLEL`. This connects to a JSON-RPC endpoint.
 ### Primitives
 Primitives define what events to listen for. EffectStream provides built-in primitives for common standards.
 
-*   **`PrimitiveTypeEVMEffectStreamL2`**: Listens for the `EffectStreamGameInteraction` event on the `EffectStreamL2Contract`.
+*   **`PrimitiveTypeEVMEffectstreamL2`**: Listens for the `EffectStreamGameInteraction` event on the `EffectstreamL2Contract`.
 *   **`PrimitiveTypeEVMERC20`**: Tracks `Transfer` events and maintains a dynamic table of token balances.
 *   **`PrimitiveTypeEVMERC721`**: Tracks NFT `Transfer` events and maintains ownership tables.
 *   **`PrimitiveTypeEVMERC1155`**: Tracks `TransferSingle` and `TransferBatch` events.
@@ -67,12 +67,12 @@ import { PrimitiveTypeEVMERC20 } from "@effectstream/sm/builtin";
 To write data to an EVM chain (e.g., submit game moves or mint tokens), you configure the **Batcher** with an Adapter.
 
 ### Standard: EffectStream L2 Adapter
-If you are using the `EffectStreamL2Contract` to submit generic game inputs, use the built-in `EffectStreamL2DefaultAdapter`.
+If you are using the `EffectstreamL2Contract` to submit generic game inputs, use the built-in `EffectstreamL2DefaultAdapter`.
 
 ```ts
-import { EffectStreamL2DefaultAdapter } from "@effectstream/batcher";
+import { EffectstreamL2DefaultAdapter } from "@effectstream/batcher-sdk";
 
-const evmAdapter = new EffectStreamL2DefaultAdapter(
+const evmAdapter = new EffectstreamL2DefaultAdapter(
   contractAddress,
   privateKey,
   fee,

--- a/docs/site/docs/home/200-chains/202-midnight.md
+++ b/docs/site/docs/home/200-chains/202-midnight.md
@@ -130,7 +130,7 @@ Writing to Midnight involves proving and submitting ZK circuits. EffectStream pr
 The `MidnightAdapter` manages the ZK proof generation (via a proof server) and transaction submission.
 
 ```ts
-import { MidnightAdapter } from "@effectstream/batcher";
+import { MidnightAdapter } from "@effectstream/batcher-sdk";
 
 const midnightAdapter = new MidnightAdapter(
   contractAddress,

--- a/docs/site/docs/home/200-chains/205-bitcoin.md
+++ b/docs/site/docs/home/200-chains/205-bitcoin.md
@@ -64,7 +64,7 @@ To submit transactions to Bitcoin (e.g., for settlement or payments), you use th
 This adapter manages UTXO selection, transaction building (PSBT), and signing using `bitcoinjs-lib`.
 
 ```ts
-import { BitcoinAdapter } from "@effectstream/batcher";
+import { BitcoinAdapter } from "@effectstream/batcher-sdk";
 
 const bitcoinAdapter = new BitcoinAdapter({
   rpcUrl: "http://127.0.0.1:18443",

--- a/docs/site/docs/home/500-packages/550-tools/orchestrator.md
+++ b/docs/site/docs/home/500-packages/550-tools/orchestrator.md
@@ -77,8 +77,10 @@ export const config: OrchestratorConfig = {
 
 Common chain launchers ship as subpath scripts you can compose: `./launch-pglite`,
 `./launch-evm`, `./launch-bitcoin`, `./launch-cardano`, `./launch-midnight`,
-`./launch-avail`, `./launch-near`. Each wraps a pinned binary from
-`@effectstream/binaries/*` with sensible defaults.
+`./launch-avail`, `./launch-near`. Each wraps a pinned binary from a
+package under `packages/binaries/` (e.g. `@effectstream/npm-midnight-node`,
+`@effectstream/bitcoin-core`, `@effectstream/near-sandbox`) with sensible
+defaults.
 
 > **Tip:** Disable chains you don't need with env vars: `DISABLE_EVM=true`,
 > `DISABLE_BITCOIN=true`, `DISABLE_MIDNIGHT=true`, etc. Same flags work for

--- a/packages/build-tools/orchestrator/README.md
+++ b/packages/build-tools/orchestrator/README.md
@@ -69,8 +69,10 @@ export const config: OrchestratorConfig = {
 
 Common chain launchers ship as subpath scripts you can compose: `./launch-pglite`,
 `./launch-evm`, `./launch-bitcoin`, `./launch-cardano`, `./launch-midnight`,
-`./launch-avail`, `./launch-near`. Each wraps a pinned binary from
-`@effectstream/binaries/*` with sensible defaults.
+`./launch-avail`, `./launch-near`. Each wraps a pinned binary from a
+package under `packages/binaries/` (e.g. `@effectstream/npm-midnight-node`,
+`@effectstream/bitcoin-core`, `@effectstream/near-sandbox`) with sensible
+defaults.
 
 > **Tip:** Disable chains you don't need with env vars: `DISABLE_EVM=true`,
 > `DISABLE_BITCOIN=true`, `DISABLE_MIDNIGHT=true`, etc. Same flags work for


### PR DESCRIPTION
## Summary

Three case/spelling fixes to match the actual exported symbols and published npm names:

- **`EffectStreamL2*` → `EffectstreamL2*`** (lowercase `s`). Code exports use the lowercase form: `EffectstreamL2DefaultAdapter`, `EffectstreamL2Primitive`, `PrimitiveTypeEVMEffectstreamL2`, `EffectstreamL2Contract.sol`.
- **`@effectstream/batcher` → `@effectstream/batcher-sdk`**. The published package is `batcher-sdk` (see `packages/batcher/package.json`); bare `@effectstream/batcher` is not registered.
- **`@effectstream/wallet` → `@effectstream/wallets`** (plural). Matches `packages/effectstream-sdk/wallets/package.json`.

21 files, 88 substitutions, all in the `home/` doc tree (no synced 500-packages READMEs touched).

Brand-prose "EffectStream L2" (with a space, used as a label/heading) is intentionally left alone — this PR only fixes code-symbol references.

## Test plan

- [ ] `bun run docs:check` passes (verified locally — `Check passed: all 37 package docs up to date`).
- [ ] `bun run build` succeeds in CI (Docusaurus build).
- [ ] Spot-check rendered pages: `108-batcher/1240-configuration`, `200-chains/201-evm`, `100-components/112-wallets`, `100-components/115-frontend`.
- [ ] No anchor slugs change (Docusaurus lowercases heading text); no broken in-page links expected.