### PR TITLE
fix(sm): CardanoMintBurn primitive misses burn events

### DIFF
--- a/packages/node-sdk/sm/primitives/src/cardano-mint-burn/mint-burn-primitive.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-mint-burn/mint-burn-primitive.ts
@@ -63,14 +63,23 @@ export class CardanoMintBurnPrimitive extends Primitive<
   }
 
   override getConfig(): ProtocolPrimitiveMap[ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL] {
+    // UTxO-RPC's `mints_asset` predicate is interpreted by Dolos as
+    // "creates new supply" — it matches only positive-quantity mints and
+    // silently filters burns. To catch burns we also match `moves_asset`,
+    // which fires when the asset appears in any input/output of the tx
+    // (true for burns, since the asset is in the input UTxO being spent).
+    // Downstream consumers see both mint and burn payloads through the
+    // same primitive; sign-of-quantity discriminates.
+    const matchPolicy = (pid: string): UtxorpcTxPredicate => ({
+      any_of: [
+        { match: { cardano: { mints_asset: { policy_id: pid } } } },
+        { match: { cardano: { moves_asset: { policy_id: pid } } } },
+      ],
+    });
     const predicate: UtxorpcTxPredicate =
       this.policyIds.length === 1
-        ? { match: { cardano: { mints_asset: { policy_id: this.policyIds[0] } } } }
-        : {
-            any_of: this.policyIds.map((pid) => ({
-              match: { cardano: { mints_asset: { policy_id: pid } } },
-            })),
-          };
+        ? matchPolicy(this.policyIds[0])
+        : { any_of: this.policyIds.map(matchPolicy) };
 
     return {
       name: this.instanceName,


### PR DESCRIPTION
## Summary

- `CardanoMintBurnPrimitive` uses a UTxO-RPC `mints_asset` predicate that Dolos interprets as *"creates new supply"* and silently filters burn txs at the gRPC stream layer
- The primitive's `getPayload` is therefore never invoked for burns, so downstream STM transitions and `effectstream.primitive_accounting` see only mints
- Fix combines `mints_asset` with `moves_asset` per watched policy; `moves_asset` fires when the asset appears in any input/output, which is true for burns (asset is in the input UTxO being spent)

## Repro (before fix)

1. Spin up YACI+Dolos via `launchCardano` and a sync node configured with `PrimitiveTypeCardanoMintBurn { policyIds: [POLICY] }`
2. From a Cardano wallet (e.g. Lucid Evolution), mint an asset under `POLICY` → STM transition fires, row appears in `effectstream.primitive_accounting` with `amount: "1"`
3. From the same wallet, burn the asset (negative-quantity mint entry in a fresh tx) under the same `POLICY`
4. Blockfrost (`http://localhost:3000/assets/{unit}`) reports `quantity: "0"` and `mint_or_burn_count: 2` — the burn is on-chain
5. But `effectstream.primitive_accounting` still has only the original mint row — the primitive never sees the burn

## After fix

Same repro: the burn now flows through `getPayload` with `amount: "-1"`. Downstream STM transitions can discriminate by sign-of-quantity as before.

## Test plan

- [ ] Existing primitive unit tests still pass (`bun test packages/node-sdk/sm/primitives`)
- [ ] Manual e2e: mint then burn under a watched policy on a YACI/Dolos devnet; confirm both events land in `effectstream.primitive_accounting`
- [ ] Check that the `moves_asset` addition does not introduce extra events for non-mint/burn txs that merely *transfer* the asset — the primitive's `getPayload` only emits when `tx.mint` is non-empty under a matched policy, so transfer-only txs (no mint field activity) still produce zero events