### PR TITLE
feat(shinkai-v2): swap user wallet from EVM to Cardano-only

### DIFF
--- a/templates/shinkai-v2/CLAUDE.md
+++ b/templates/shinkai-v2/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-AI-powered RPG Effectstream template: EVM (Hardhat/Arbitrum) + Shinkai AI node. Players interact with four animal NPCs at the Panda King's court. Each NPC poses a challenge evaluated by the Shinkai AI, and the final NPC (Panda King) distributes tokens from a shared world pool based on cumulative scores.
+AI-powered RPG Effectstream template: Cardano-wallet login (any CIP-30 wallet — Nami, Lace, Eternl, Flint, …) over EVM L2 settlement (Hardhat/Arbitrum) + Shinkai AI node. Players sign in with their Cardano wallet (CIP-8 `signData`); the batcher accepts the signature and submits batched inputs to the on-chain L2. Players interact with four animal NPCs at the Panda King's court. Each NPC poses a challenge evaluated by the Shinkai AI, and the final NPC (Panda King) distributes tokens from a shared world pool based on cumulative scores.
 
 ## Commands
 
@@ -33,7 +33,7 @@ Bun monorepo with flat `packages/*` layout. All `@effectstream/*` deps are from 
 - **State machine AI calls**: `yield* World.promise(shinkai.askQuestion(...))` for async AI within STM transitions.
 - **Scheduled data**: `tick` command runs every ~60s via `createScheduledData`, adds 20 tokens to global pool.
 - **Token economy**: Global world pool starts at 10000. Panda King distributes tokens to players based on cumulative NPC scores.
-- **Frontend**: PixiJS 8 with `@pixi/ui` Input widget. Uses `@effectstream/wallets` for wallet connection and `sendTransaction` for game inputs.
+- **Frontend**: PixiJS 8 with `@pixi/ui` Input widget. Uses `@effectstream/wallets` (`WalletMode.Cardano` + `allInjectedWallets` for the CIP-30 picker) for wallet connection and `sendTransaction(..., preferBatchedMode: true)` for game inputs — routes Cardano CIP-8 signatures through the batcher.
 
 ## Ports
 

--- a/templates/shinkai-v2/README.md
+++ b/templates/shinkai-v2/README.md
@@ -1,6 +1,6 @@
 # Shinkai Quest Template
 
-AI-powered RPG demonstrating Shinkai AI node integration with Effectstream on EVM. Players navigate animal NPCs at the Panda King's court, each posing challenges evaluated by AI. Features a global token economy and PixiJS frontend.
+AI-powered RPG demonstrating Shinkai AI node integration with Effectstream. Players sign in with a **Cardano wallet** (any CIP-30 extension — Nami, Lace, Eternl, Flint, …) and navigate animal NPCs at the Panda King's court, each posing challenges evaluated by AI. Cardano CIP-8 signatures are verified by the batcher; batched inputs settle on an EVM L2 (Hardhat/Arbitrum). Features a global token economy and PixiJS frontend.
 
 ## Quick Start
 
@@ -84,7 +84,7 @@ Transaction batcher with EVM adapter factory.
 
 ### packages/frontend
 
-PixiJS game with Vite build. Players connect wallet, start a new game, and interact with four animal NPCs (Tiger, Monkey, Bison, Panda King).
+PixiJS game with Vite build. Players connect a Cardano wallet (CIP-30 picker if multiple are installed), start a new game, and interact with four animal NPCs (Tiger, Monkey, Bison, Panda King). Each in-game action is signed with CIP-8 `signData` and submitted through the batcher.
 
 ### packages/tests
 

--- a/templates/shinkai-v2/packages/batcher/batcher.dev.ts
+++ b/templates/shinkai-v2/packages/batcher/batcher.dev.ts
@@ -18,6 +18,9 @@ const config: BatcherConfig = {
   pollingIntervalMs: batchIntervalMs,
   adapters: { paimaL2 },
   defaultTarget: "paimaL2",
+  // Must match what the sync-side `EffectstreamL2Primitive` uses to re-verify
+  // signatures. The SDK currently hardcodes namespace = null there, so we sign
+  // and verify with an empty namespace end-to-end until the SDK exposes it.
   namespace: "",
   batchingCriteria: {
     paimaL2: { criteriaType: "time", timeWindowMs: batchIntervalMs },

--- a/templates/shinkai-v2/packages/frontend/client/src/config.ts
+++ b/templates/shinkai-v2/packages/frontend/client/src/config.ts
@@ -3,7 +3,10 @@ import { arbitrum, hardhat } from "viem/chains";
 
 const BATCHER_URL = import.meta.env.VITE_BATCHER_URL ?? "http://localhost:3334";
 const L2_ADDRESS = import.meta.env.VITE_L2_ADDRESS ?? "0x0000000000000000000000000000000000000000";
-const NAMESPACE = import.meta.env.VITE_NAMESPACE ?? "shinkai-v2";
+// Empty namespace — must match the batcher and the sync-side L2 primitive,
+// which currently hardcodes namespace = null when reconstructing the signed
+// message for verification.
+const NAMESPACE = import.meta.env.VITE_NAMESPACE ?? "";
 const CHAIN = import.meta.env.MODE === "mainnet" ? arbitrum : hardhat;
 
 export const paimaConfig = new EffectstreamConfig(

--- a/templates/shinkai-v2/packages/frontend/client/src/main.ts
+++ b/templates/shinkai-v2/packages/frontend/client/src/main.ts
@@ -1,8 +1,9 @@
-import { Application, Assets } from "pixi.js";
-import { walletLogin, WalletMode } from "@effectstream/wallets";
+import { Application, Assets, Sprite, Text } from "pixi.js";
+import { allInjectedWallets, walletLogin, WalletMode } from "@effectstream/wallets";
 import { paimaConfig } from "./config.ts";
 import { MainScreen } from "./screens.ts";
 import { GameState } from "./game-state.ts";
+import { createButton, loader } from "./graphics.ts";
 
 const fontAssets = [
   { alias: "oswald", src: "/assets/fonts/Oswald-VariableFont_wght.ttf", data: { family: "Oswald" } },
@@ -24,11 +25,75 @@ const postAssets = [
   "/assets/img/button/b2.png",
 ];
 
+async function pickCardanoWallet(
+  options: { metadata: { name: string; displayName: string } }[],
+): Promise<string> {
+  return await new Promise((resolve) => {
+    const overlay = loader(GameState.app);
+    const title = new Text({
+      text: "Choose a Cardano wallet",
+      style: { fontFamily: "oswald", fontSize: 48, fill: "#fff", align: "center", dropShadow: true },
+    });
+    title.anchor.set(0.5, 0.5);
+    title.x = 512;
+    title.y = 240;
+    GameState.app.stage.addChild(title);
+
+    const created: { sprite: Sprite; text: Text }[] = [];
+    const cleanup = () => {
+      title.destroy();
+      created.forEach(({ sprite, text }) => { sprite.destroy(); text.destroy(); });
+      overlay.forEach((o) => o.destroy());
+    };
+
+    options.forEach((opt, i) => {
+      const [sprite, text] = createButton(320, 340 + i * 120, opt.metadata.displayName, () => {
+        cleanup();
+        resolve(opt.metadata.name);
+      });
+      GameState.app.stage.addChild(sprite);
+      GameState.app.stage.addChild(text);
+      created.push({ sprite, text });
+    });
+  });
+}
+
+/**
+ * Re-enable the CIP-30 session for the currently-connected wallet and patch
+ * the fresh API into the cached `CardanoProvider`. The `@effectstream/wallets`
+ * `CardanoConnector` caches the provider per-wallet-name, so calling
+ * `walletLogin` again hands back the same provider with its now-dead
+ * `conn.api` reference — `signData` will keep failing with "No account found
+ * for origin" until the underlying api is replaced. Calling
+ * `window.cardano[<name>].enable()` returns a fresh CIP-30 API (and prompts
+ * the user to unlock / re-approve as needed). We swap that into the cached
+ * provider so subsequent `signMessage` calls use the live session.
+ */
+export async function refreshCardanoSession(): Promise<void> {
+  const w = GameState.walletObj;
+  if (!w) return;
+  const name: string | undefined = (w.provider as any)?.conn?.metadata?.name;
+  if (!name) return;
+  const ext = (window as any).cardano?.[name];
+  if (!ext?.enable) return;
+  const freshApi = await ext.enable();
+  (w.provider as any).conn.api = freshApi;
+}
+
 export async function connectWallet(): Promise<string> {
+  const injected = await allInjectedWallets();
+  const cardanoWallets = injected[WalletMode.Cardano] ?? [];
+  if (cardanoWallets.length === 0) {
+    throw new Error("No Cardano wallet detected. Install Nami, Lace, Eternl, or another CIP-30 wallet.");
+  }
+
+  const chosen = cardanoWallets.length === 1
+    ? cardanoWallets[0].metadata.name
+    : await pickCardanoWallet(cardanoWallets);
+
   const result = await walletLogin({
-    mode: WalletMode.EvmInjected,
-    preferBatchedMode: true,
-    checkChainId: false,
+    mode: WalletMode.Cardano,
+    preference: { name: chosen },
   });
   if (!result.success) throw new Error(`Wallet connection failed: ${result.errorMessage}`);
   GameState.walletObj = result.result;

--- a/templates/shinkai-v2/packages/frontend/client/src/screens.ts
+++ b/templates/shinkai-v2/packages/frontend/client/src/screens.ts
@@ -14,7 +14,7 @@ import { GameState } from "./game-state.ts";
 import { sendTransaction } from "@effectstream/wallets";
 import { paimaConfig } from "./config.ts";
 import { getGame, getGameRound, getNewGame, getTokens } from "./api.ts";
-import { connectWallet } from "./main.ts";
+import { connectWallet, refreshCardanoSession } from "./main.ts";
 
 export abstract class QFTScreen {
   public abstract assets: (Sprite | Text | Input | Graphics)[];
@@ -43,20 +43,38 @@ export abstract class QFTScreen {
       const l = loader(GameState.app);
       GameState.isLoading = true;
 
-      await sendTransaction(
+      const sendAi = () => sendTransaction(
         GameState.walletObj!,
         ["ai", animal, GameState.gameId, value],
         paimaConfig,
         "wait-effectstream-processed",
       );
 
-      const round = await getGameRound(GameState.gameId, animal);
-      GameState.isLoading = false;
-
-      if (!round) {
+      let round: Awaited<ReturnType<typeof getGameRound>> | undefined;
+      try {
+        await sendAi();
+        round = await getGameRound(GameState.gameId, animal);
+      } catch (e: any) {
+        console.error("ai action failed", e);
+        // Cardano CIP-30 wallets sometimes drop the dApp session between
+        // actions (auto-lock, origin permission rotated). Refreshing the
+        // underlying api via window.cardano[name].enable() prompts the user
+        // to unlock / re-approve, then we retry the action once.
+        if (e?.name === "APIError") {
+          try {
+            await refreshCardanoSession();
+            await sendAi();
+            round = await getGameRound(GameState.gameId, animal);
+          } catch (re) {
+            console.error("retry after reconnect failed", re);
+          }
+        }
+      } finally {
+        GameState.isLoading = false;
         l.forEach((o) => o.destroy());
-        return;
       }
+
+      if (!round) return;
 
       cleanup();
       await animalTalk(GameState.app, round.answer ?? "...");


### PR DESCRIPTION
## Summary

- Repoints the **shinkai-v2** template's user-facing wallet to **any CIP-30 Cardano wallet** (Nami, Lace, Eternl, Flint, …). The batcher + EVM L2 settlement layer are kept as-is — only the user wallet changes.
- No SDK changes: `EffectstreamL2DefaultAdapter` has no `verifySignature` override, so the batcher's default verifier already dispatches `AddressType.CARDANO` to `CryptoManager.Cardano().verifySignature` (CIP-8 via `@cardano-foundation/cardano-verify-datasignature`) transparently.
- 6 files touched: 3 frontend, 1 batcher config, 2 docs.

## What changed

**Frontend**
- `packages/frontend/client/src/main.ts` — swaps `WalletMode.EvmInjected` → `WalletMode.Cardano`. Enumerates CIP-30 wallets via `allInjectedWallets`, auto-connects when only one is present, renders a minimal PixiJS picker when multiple are. Adds `refreshCardanoSession()` to recover from CIP-30 session drops (auto-lock, origin permission rotated) by calling `window.cardano[<name>].enable()` and patching the fresh api into the cached `CardanoProvider`. Plain `walletLogin` retries return the stale cached provider after a drop, so the api ref has to be replaced directly.
- `packages/frontend/client/src/config.ts` — empty `NAMESPACE`. See "Namespace caveat" below.
- `packages/frontend/client/src/screens.ts` — wraps the in-game `sendTransaction` in try/catch/finally so the loader overlay + `isLoading` flag clean up on any wallet/batcher failure. On `APIError`, calls `refreshCardanoSession()` and retries once in the same click.

**Batcher**
- `packages/batcher/batcher.dev.ts` — `namespace: ""` (was `""` originally, briefly `"shinkai-v2"` during debugging, now back to `""` and aligned with sync). See caveat below.

**Docs**
- `CLAUDE.md` + `README.md` updated to describe Cardano-wallet login over EVM L2 settlement.

## Namespace caveat (worth a future cleanup)

The sync-side `EffectstreamL2Primitive.processEffectstreamL2SyncProtocolResponse` hardcodes the namespace to `null` when reconstructing the signed message for re-verification, with an explicit `// TODO: We need to setup & configure the namespace.` So end-to-end the only working setup today is **frontend, batcher, and sync all aligned on empty namespace**. That's what this PR does for dev. `batcher.mainnet.ts` still carries the original `namespace: "shinkai-v2"` value — same latent issue if/when someone runs that path. Leaving it out of this PR since the user explicitly scoped the change to "don't touch the backend or batcher; only if critical."

## Test plan

- [x] `bun install && bun run build` from `templates/shinkai-v2/packages/frontend` — clean.
- [x] `bunx orchestrator start --background` — pglite + hardhat + sync + batcher + frontend all healthy on their canonical ports.
- [x] Open `http://localhost:10599`, connect Lace or Eternl, click "Enter the Kingdom" → wallet picker → approve `signData` → `newGame` lands on-chain and the STM writes a `game` row with a bech32 wallet (`addr1…`).
- [x] Each of tiger/monkey/bison/panda triggers a `signData` prompt and an `ai` STM transition. With `SHINKAI_*` env vars set on the sync process the `question_answer` row gets populated.
- [x] Locking the wallet between rounds no longer deadlocks the UI: the loader cleans up, `refreshCardanoSession()` prompts to unlock, and the retry goes through in the same click cycle.
- [x] Negative path: submit an input to `/send-input` with a tampered Cardano signature → batcher rejects with 401 `InputValidationError`, confirming `CryptoManager.Cardano().verifySignature` is in the path.

## Follow-ups (out of scope here)

- Push the namespace fix down into `@effectstream/sm` so the L2 primitive can be configured with the security namespace instead of hardcoding `null`. Once that lands we can re-introduce `namespace: "shinkai-v2"` everywhere for app isolation.
- Replace the `(w.provider as any).conn.api = freshApi` monkey-patch in `refreshCardanoSession()` with a proper "invalidate cached provider" / "re-enable" API on `CardanoConnector` in `@effectstream/wallets`.
- Mainnet batcher (`batcher.mainnet.ts`) carries the same `namespace: "shinkai-v2"` mismatch — flag if anyone ships mainnet against the current SDK.
- Surface wallet errors as in-game text instead of console-only.