### PR TITLE
Make pg_ivm optional via strategy pattern

### DIFF
--- a/docs/site/docs/home/1000-effectstream-engine/1002-database.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1002-database.md
@@ -56,6 +56,40 @@ bun run --cwd packages/database pgtyped:update
 ```
 This introspects your SQL files and database schema, then writes a `*.queries.ts` file next to each `*.sql` with fully-typed wrapper functions.
 
+### Required Extension: `pg_ivm`
+
+Effectstream relies on the [`pg_ivm`](https://github.com/sraoss/pg_ivm) PostgreSQL extension to maintain the read-side views over each Primitive's intermediate state (`primitives.<view>`). `pg_ivm` produces an *incrementally maintained materialized view* — a compact, up-to-date projection that the engine writes through synchronously on each accounting update, so reads from `primitives.<view>` hit a small physical table instead of scanning the full intermediate.
+
+This matters because the intermediate tables grow monotonically: when an ERC20 holder transfers their full balance out, their row stays (with `balance = 0`) so that future credits can find it. On a long-lived token with millions of historical addresses, the intermediate can be 10× to 100× the size of the currently-active set. `pg_ivm` filters that down at write time so reads stay fast forever.
+
+**The engine aborts at startup when `pg_ivm` is not installed.** You will see a multi-line error explaining the two ways forward. To install:
+
+```sh
+# From source — works on any self-hosted Postgres 14+
+git clone --depth 1 --branch v1.11 https://github.com/sraoss/pg_ivm
+cd pg_ivm && make && sudo make install
+
+# Then in your database (as a superuser):
+CREATE EXTENSION pg_ivm;
+```
+
+#### `ALLOW_NO_PG_IVM=true` — dev/test fallback
+
+If you cannot install `pg_ivm` (managed Postgres providers like RDS, Cloud SQL, or Neon don't allow custom extensions), you can opt into a fallback path by setting:
+
+```sh
+ALLOW_NO_PG_IVM=true
+```
+
+In this mode the engine creates plain SQL `VIEW`s over the intermediate tables instead of incrementally maintained ones. Correctness is identical — the underlying trigger that maintains the intermediate is the same in both modes, so reads always see a transactionally-consistent snapshot. **But performance is not.** Every read of `primitives.<view>` becomes a sequential scan over the full intermediate with the filter applied at read time. For high-cardinality contracts (popular tokens, long-running games) this becomes unusable past some scale.
+
+| Mode | Read cost | Suitable for |
+| :--- | :--- | :--- |
+| `pg_ivm` (default) | Index lookup on a compact materialized table | Production at any scale |
+| `ALLOW_NO_PG_IVM=true` | Seq scan + filter over the full intermediate | Dev / test / low-volume apps only |
+
+When running with `ALLOW_NO_PG_IVM=true`, the engine emits a prominent `[WARN]` log line on every startup so the degraded mode is visible.
+
 ### System Tables Overview
 
 The `effectstream` schema contains a number of tables essential for the engine's operation. Here are a few of the most important ones:

--- a/packages/build-tools/orchestrator/scripts/launch-pglite.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-pglite.ts
@@ -8,21 +8,43 @@ export const DbNames = {
   PGLITE_WAIT: "pglite-wait",
 } as const;
 
+/**
+ * Spawns the embedded PGlite database used by e2e suites — unless
+ * `PGLITE=false` is set in the environment, in which case it assumes an
+ * external Postgres is already running on `DB_PORT` (or `port`) and emits a
+ * single wait task that other processes can still depend on via
+ * `DbNames.PGLITE_WAIT`. This keeps the launcher.cli.ts call sites unchanged
+ * while letting e2e_postgres.sh exercise the engine against a real Postgres
+ * (e.g. to verify the pg_ivm-optional fallback path).
+ */
 export function launchPglite(opts?: { port?: number }): ProcessConfig[] {
-  const port = opts?.port ?? 5432;
+  const defaultPort = opts?.port ?? 5432;
+
+  if (process.env.PGLITE === "false") {
+    const externalPort = process.env.DB_PORT ?? String(defaultPort);
+    return [
+      {
+        name: DbNames.PGLITE_WAIT,
+        description: `Wait for external Postgres on port ${externalPort}`,
+        args: [waitTcpScript, String(externalPort)],
+        waitToExit: true,
+      },
+    ];
+  }
+
   return [
     {
       name: DbNames.PGLITE,
-      description: `PGLite embedded database (port ${port})`,
-      args: [startPgliteScript, "--port", String(port)],
-      stopProcessAtPort: [port],
+      description: `PGLite embedded database (port ${defaultPort})`,
+      args: [startPgliteScript, "--port", String(defaultPort)],
+      stopProcessAtPort: [defaultPort],
       waitToExit: false,
       critical: true,
     },
     {
       name: DbNames.PGLITE_WAIT,
-      description: `Wait for PGLite on port ${port}`,
-      args: [waitTcpScript, String(port)],
+      description: `Wait for PGLite on port ${defaultPort}`,
+      args: [waitTcpScript, String(defaultPort)],
       waitToExit: true,
       dependsOn: [DbNames.PGLITE],
     },

--- a/packages/effectstream-sdk/utils/src/config.ts
+++ b/packages/effectstream-sdk/utils/src/config.ts
@@ -239,6 +239,13 @@ const definitions: Record<string, ConfigDefinition> = {
     defaultValue: undefined,
     description: "Enable PGLite Debug/Verbose mode. Example: '1'",
   },
+  DISABLE_PG_IVM: {
+    key: "DISABLE_PG_IVM",
+    type: "boolean",
+    defaultValue: false,
+    description:
+      "Force the engine to skip the pg_ivm extension and fall back to plain SQL views over the trigger-maintained intermediate tables. Use on managed Postgres without custom extensions. ('true' or 'false')",
+  },
   OTEL_COLLECTOR_PORT: {
     key: "OTEL_COLLECTOR_PORT",
     type: "number",
@@ -404,6 +411,9 @@ export class ENV {
   }
   static get DEBUG_PGLITE(): number {
     return ENV.getConfig(definitions.DEBUG_PGLITE);
+  }
+  static get DISABLE_PG_IVM(): boolean {
+    return ENV.getConfig(definitions.DISABLE_PG_IVM);
   }
   static get OTEL_COLLECTOR_PORT(): number {
     return ENV.getConfig(definitions.OTEL_COLLECTOR_PORT);

--- a/packages/effectstream-sdk/utils/src/config.ts
+++ b/packages/effectstream-sdk/utils/src/config.ts
@@ -239,12 +239,12 @@ const definitions: Record<string, ConfigDefinition> = {
     defaultValue: undefined,
     description: "Enable PGLite Debug/Verbose mode. Example: '1'",
   },
-  DISABLE_PG_IVM: {
-    key: "DISABLE_PG_IVM",
+  ALLOW_NO_PG_IVM: {
+    key: "ALLOW_NO_PG_IVM",
     type: "boolean",
     defaultValue: false,
     description:
-      "Force the engine to skip the pg_ivm extension and fall back to plain SQL views over the trigger-maintained intermediate tables. Use on managed Postgres without custom extensions. ('true' or 'false')",
+      "Permits the engine to start when the pg_ivm extension is not installed, falling back to plain SQL views over the trigger-maintained intermediate tables. Intended for dev/test and low-volume apps only — the fallback degrades sharply on high-cardinality data. Production deployments should install pg_ivm. ('true' or 'false')",
   },
   OTEL_COLLECTOR_PORT: {
     key: "OTEL_COLLECTOR_PORT",
@@ -412,8 +412,8 @@ export class ENV {
   static get DEBUG_PGLITE(): number {
     return ENV.getConfig(definitions.DEBUG_PGLITE);
   }
-  static get DISABLE_PG_IVM(): boolean {
-    return ENV.getConfig(definitions.DISABLE_PG_IVM);
+  static get ALLOW_NO_PG_IVM(): boolean {
+    return ENV.getConfig(definitions.ALLOW_NO_PG_IVM);
   }
   static get OTEL_COLLECTOR_PORT(): number {
     return ENV.getConfig(definitions.OTEL_COLLECTOR_PORT);

--- a/packages/node-sdk/db-emulator/patch-emulator.ts
+++ b/packages/node-sdk/db-emulator/patch-emulator.ts
@@ -2,8 +2,7 @@ import { run } from "effection";
 import {
   createDynamicTables,
   detectCapabilities,
-  pgIvmStrategy,
-  plainViewStrategy,
+  selectViewStrategy,
 } from "@effectstream/db";
 import type { Client } from "pg";
 import { applyMigrations } from "@effectstream/db/version";
@@ -67,6 +66,7 @@ export async function standAloneApplyMigrations(
   );
 
   const capabilities = await detectCapabilities(db as any);
+  const viewStrategy = selectViewStrategy(capabilities);
 
   await run(function* () {
     return yield* createDynamicTables(
@@ -79,7 +79,7 @@ export async function standAloneApplyMigrations(
       0,
       db,
       config as any,
-      capabilities.pgIvm ? pgIvmStrategy : plainViewStrategy,
+      viewStrategy,
     );
   });
   const migrations = migrationTable;

--- a/packages/node-sdk/db-emulator/patch-emulator.ts
+++ b/packages/node-sdk/db-emulator/patch-emulator.ts
@@ -1,5 +1,10 @@
 import { run } from "effection";
-import { createDynamicTables } from "@effectstream/db";
+import {
+  createDynamicTables,
+  detectCapabilities,
+  pgIvmStrategy,
+  plainViewStrategy,
+} from "@effectstream/db";
 import type { Client } from "pg";
 import { applyMigrations } from "@effectstream/db/version";
 import type { SyncProtocolWithNetwork } from "@effectstream/config";
@@ -61,6 +66,8 @@ export async function standAloneApplyMigrations(
     },
   );
 
+  const capabilities = await detectCapabilities(db as any);
+
   await run(function* () {
     return yield* createDynamicTables(
       {
@@ -72,6 +79,7 @@ export async function standAloneApplyMigrations(
       0,
       db,
       config as any,
+      capabilities.pgIvm ? pgIvmStrategy : plainViewStrategy,
     );
   });
   const migrations = migrationTable;

--- a/packages/node-sdk/db/migrations/system-up-v-0.0.0.sql
+++ b/packages/node-sdk/db/migrations/system-up-v-0.0.0.sql
@@ -1,7 +1,5 @@
 CREATE SCHEMA IF NOT EXISTS effectstream;
 
-CREATE EXTENSION IF NOT EXISTS pg_ivm;
-
 CREATE TABLE effectstream.effectstream_expected_version (
   app_version_major INTEGER NOT NULL,
   app_version_minor INTEGER NOT NULL,

--- a/packages/node-sdk/db/src/MaterializedViewStrategy.ts
+++ b/packages/node-sdk/db/src/MaterializedViewStrategy.ts
@@ -1,0 +1,50 @@
+/**
+ * Strategy for publishing the read-side relation that primitives query
+ * (e.g. `primitives.erc20_balances_view_<name>`).
+ *
+ * The intermediate table and the maintenance trigger are identical in both
+ * modes — only how the view itself is created differs. The query API
+ * (`SELECT * FROM primitives.<viewName>`) is unchanged across strategies.
+ */
+export interface MaterializedViewStrategy {
+  /**
+   * Stable identifier used to namespace migration rows per strategy.
+   * Empty string for the legacy pg_ivm strategy, so its migration rows keep
+   * the same names that existing deployments already have in their
+   * `effectstream_migration_history`. Only the new fallback strategy uses a
+   * suffixed name. This avoids re-applying dynamic-table DDL (which would
+   * fail on already-existing triggers/IMMVs) when an existing app upgrades.
+   */
+  readonly migrationSuffix: "" | "-view";
+  /** Emit DDL that publishes `viewName` as a queryable relation backed by `selectSql`. */
+  createView(viewName: string, selectSql: string): string;
+}
+
+/**
+ * Uses the `pg_ivm` extension to create an incrementally maintained
+ * materialized view. Requires the extension to be installed in the database.
+ *
+ * Migration rows for this strategy use the historical unsuffixed name
+ * (`dynamic-tables-<type>-<name>`) so deployments that were already running
+ * the engine before the strategy pattern existed keep matching their
+ * previously-applied rows on upgrade — no re-application, no DDL conflicts.
+ */
+export const pgIvmStrategy: MaterializedViewStrategy = {
+  migrationSuffix: "",
+  createView: (viewName, selectSql) =>
+    `SELECT pgivm.create_immv('${viewName}', $IVM$${selectSql}$IVM$);`,
+};
+
+/**
+ * Fallback: a plain SQL view computed on read. The intermediate table is
+ * still trigger-maintained, so the only extra cost is re-applying the
+ * (typically cheap) WHERE filter at query time.
+ *
+ * Migration rows use a `-view` suffix to keep this strategy's history
+ * distinct from the pg_ivm strategy's.
+ */
+export const plainViewStrategy: MaterializedViewStrategy = {
+  migrationSuffix: "-view",
+  createView: (viewName, selectSql) =>
+    `CREATE OR REPLACE VIEW ${viewName} AS ${selectSql};`,
+};

--- a/packages/node-sdk/db/src/capabilities.ts
+++ b/packages/node-sdk/db/src/capabilities.ts
@@ -1,35 +1,37 @@
 import type { PoolClient } from "pg";
 import { ENV } from "@effectstream/utils/node-env";
+import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
+import {
+  type MaterializedViewStrategy,
+  pgIvmStrategy,
+  plainViewStrategy,
+} from "./MaterializedViewStrategy.ts";
 
 /**
  * Optional database features the engine probes for at startup.
  *
  * - `pgIvm`: the `pg_ivm` extension that provides incrementally maintained
- *   materialized views. When unavailable, the engine falls back to plain
- *   SQL views over the same trigger-maintained intermediate tables.
+ *   materialized views. When unavailable, the engine can fall back to plain
+ *   SQL views over the same trigger-maintained intermediate tables — but
+ *   only if the operator has explicitly opted in via `ENV.ALLOW_NO_PG_IVM`.
  */
 export interface DatabaseCapabilities {
   pgIvm: boolean;
 }
 
 /**
- * Probes the connected database for optional features.
+ * Probes the connected database for optional features. Pure detection —
+ * no policy decision is made here; the caller (typically via
+ * {@link selectViewStrategy}) decides whether the resulting capability set
+ * is acceptable.
  *
- * - If `ENV.DISABLE_PG_IVM` is set, `pg_ivm` is reported unavailable without
- *   probing — useful for tests and benchmarking against managed Postgres
- *   where the extension is not installable.
- * - Otherwise we best-effort `CREATE EXTENSION IF NOT EXISTS pg_ivm`. If the
- *   extension binary is missing (managed Postgres, fresh dev DB, etc.) the
- *   statement raises; we swallow the error and treat `pg_ivm` as absent.
- * - Finally we query `pg_extension` to confirm the real state.
+ * - Best-effort `CREATE EXTENSION IF NOT EXISTS pg_ivm` (no-op if already
+ *   installed, soft-fail if the binary is missing on the server).
+ * - Then queries `pg_extension` to confirm the real state.
  */
 export async function detectCapabilities(
   client: Pick<PoolClient, "query">,
 ): Promise<DatabaseCapabilities> {
-  if (ENV.DISABLE_PG_IVM) {
-    return { pgIvm: false };
-  }
-
   try {
     await client.query("CREATE EXTENSION IF NOT EXISTS pg_ivm");
   } catch {
@@ -41,4 +43,76 @@ export async function detectCapabilities(
     `SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_ivm') AS exists`,
   );
   return { pgIvm: rows[0]?.exists === true };
+}
+
+/**
+ * Decide which materialized-view strategy to use based on detected
+ * capabilities and operator policy.
+ *
+ * Behavior matrix:
+ *
+ * | pg_ivm available | ALLOW_NO_PG_IVM | Result                                   |
+ * | :--------------- | :-------------- | :--------------------------------------- |
+ * | yes              | any             | pgIvmStrategy (production path)          |
+ * | no               | false / unset   | **throws** — startup aborts loudly       |
+ * | no               | true            | plainViewStrategy + prominent startup WARN |
+ *
+ * The throw is intentional: silently degrading to a slower read path in
+ * production is much worse than failing early with a clear remediation
+ * message. Operators who genuinely need the dev/test fallback must opt in.
+ */
+export function selectViewStrategy(
+  capabilities: DatabaseCapabilities,
+): MaterializedViewStrategy {
+  if (capabilities.pgIvm) return pgIvmStrategy;
+
+  if (!ENV.ALLOW_NO_PG_IVM) {
+    throw new Error(formatMissingPgIvmError());
+  }
+
+  log.local(
+    ComponentNames.EFFECTSTREAM_RUNTIME,
+    "pg_ivm-fallback",
+    SeverityNumber.WARN,
+    (l) =>
+      l(
+        [
+          "─────────────────────────────────────────────────────────────",
+          "  effectstream: running WITHOUT pg_ivm (fallback mode)",
+          "  ALLOW_NO_PG_IVM=true is set; using plain SQL views over the",
+          "  trigger-maintained intermediate tables.",
+          "",
+          "  This path is intended for dev/test and low-volume apps only.",
+          "  Read-path performance degrades sharply on long-lived contracts",
+          "  with high address cardinality (intermediate tables grow",
+          "  monotonically; the plain view does a seq scan + filter per",
+          "  read). DO NOT run production on this configuration.",
+          "─────────────────────────────────────────────────────────────",
+        ].join("\n"),
+      ),
+  );
+  return plainViewStrategy;
+}
+
+function formatMissingPgIvmError(): string {
+  return [
+    "",
+    "Effectstream startup aborted: the `pg_ivm` PostgreSQL extension is not",
+    "available on this database.",
+    "",
+    "The engine uses `pg_ivm` for incrementally maintained materialized views,",
+    "which give compact, fast reads on long-lived contracts. Without it the",
+    "engine can fall back to plain SQL views over the trigger-maintained",
+    "intermediate tables — but that path degrades sharply on high-cardinality",
+    "data and is only suitable for dev/test and low-volume apps.",
+    "",
+    "To proceed:",
+    "  • Install pg_ivm in your PostgreSQL instance:",
+    "      https://github.com/sraoss/pg_ivm",
+    "  • OR explicitly accept the dev-mode fallback by setting:",
+    "      ALLOW_NO_PG_IVM=true",
+    "    (NOT recommended for production — see the database docs for the",
+    "     performance ceiling.)",
+    "",
+  ].join("\n");
 }

--- a/packages/node-sdk/db/src/capabilities.ts
+++ b/packages/node-sdk/db/src/capabilities.ts
@@ -1,0 +1,44 @@
+import type { PoolClient } from "pg";
+import { ENV } from "@effectstream/utils/node-env";
+
+/**
+ * Optional database features the engine probes for at startup.
+ *
+ * - `pgIvm`: the `pg_ivm` extension that provides incrementally maintained
+ *   materialized views. When unavailable, the engine falls back to plain
+ *   SQL views over the same trigger-maintained intermediate tables.
+ */
+export interface DatabaseCapabilities {
+  pgIvm: boolean;
+}
+
+/**
+ * Probes the connected database for optional features.
+ *
+ * - If `ENV.DISABLE_PG_IVM` is set, `pg_ivm` is reported unavailable without
+ *   probing — useful for tests and benchmarking against managed Postgres
+ *   where the extension is not installable.
+ * - Otherwise we best-effort `CREATE EXTENSION IF NOT EXISTS pg_ivm`. If the
+ *   extension binary is missing (managed Postgres, fresh dev DB, etc.) the
+ *   statement raises; we swallow the error and treat `pg_ivm` as absent.
+ * - Finally we query `pg_extension` to confirm the real state.
+ */
+export async function detectCapabilities(
+  client: Pick<PoolClient, "query">,
+): Promise<DatabaseCapabilities> {
+  if (ENV.DISABLE_PG_IVM) {
+    return { pgIvm: false };
+  }
+
+  try {
+    await client.query("CREATE EXTENSION IF NOT EXISTS pg_ivm");
+  } catch {
+    // Extension binary not installed on this server — fall through and let
+    // the pg_extension lookup confirm the absence.
+  }
+
+  const { rows } = await client.query<{ exists: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_ivm') AS exists`,
+  );
+  return { pgIvm: rows[0]?.exists === true };
+}

--- a/packages/node-sdk/db/src/dynamic-tables.ts
+++ b/packages/node-sdk/db/src/dynamic-tables.ts
@@ -6,26 +6,42 @@ import type { PoolClient } from "pg";
 import type { VersionInfo } from "../migrations/system-version.ts";
 import { applyMigrations } from "../scripts/apply-migrations.ts";
 import { findMigrationByName } from "./sql/system.queries.ts";
+import {
+  type MaterializedViewStrategy,
+  plainViewStrategy,
+} from "./MaterializedViewStrategy.ts";
 
 /**
  * Creates dynamic tables for the given sync protocols.
- * This is used to create the IVMs for the given sync protocols.
+ * This is used to create the read-side relations (incrementally maintained
+ * via pg_ivm when available, otherwise plain SQL views) for each primitive's
+ * intermediate state.
  *
  * For example for ERC20 it creates a table that holds the balance for each address.
  * For ERC721 it creates a table that holds the token id for each address.
  *
  * @param dbConn - The database connection.
  * @param syncProtocols - The sync protocols.
+ * @param strategy - How to publish the read-side view. Defaults to the plain
+ *   view fallback so callers that haven't probed capabilities yet stay safe
+ *   on managed Postgres without pg_ivm. The runtime detects the extension
+ *   and passes `pgIvmStrategy` explicitly when available.
  */
 export function* createDynamicTables(
   versionInfo: VersionInfo,
   lastBlockHeight: number,
   dbConn: PoolClient,
   syncProtocols: any[], // AllSyncProtocols[],
+  strategy: MaterializedViewStrategy = plainViewStrategy,
 ) {
   for (const syncProtocol of syncProtocols) {
     for (const primitive of syncProtocol.config.primitives) {
-      yield* createDynamicTableForPrimitive(primitive, lastBlockHeight, dbConn);
+      yield* createDynamicTableForPrimitive(
+        primitive,
+        lastBlockHeight,
+        dbConn,
+        strategy,
+      );
     }
   }
 }
@@ -39,6 +55,7 @@ function* createDynamicTableForPrimitive(
   },
   lastBlockHeight: number,
   dbConn: PoolClient,
+  strategy: MaterializedViewStrategy,
 ) {
   const type = p.primitive.type;
   const name = p.primitive.name;
@@ -54,10 +71,15 @@ function* createDynamicTableForPrimitive(
 
   // This primitive does not have dynamic tables.
   if (!sqlFunction) return;
-  const code = sqlFunction(name);
+  const code = sqlFunction(name, strategy);
   if (!code) return;
 
-  const migrationName = `dynamic-tables-${type}-${name}`;
+  // pgIvmStrategy uses the legacy unsuffixed name so existing deployments
+  // upgrading from a pre-strategy build keep matching their previously-
+  // applied migration rows. plainViewStrategy uses a `-view` suffix to keep
+  // its history distinct, so a deployment that later gains or loses pg_ivm
+  // re-applies the correct view-creation DDL.
+  const migrationName = `dynamic-tables-${type}-${name}${strategy.migrationSuffix}`;
   const [migration] = yield* until(findMigrationByName.run({
     name: migrationName,
     isSystemMigration: true,

--- a/packages/node-sdk/db/src/mod.ts
+++ b/packages/node-sdk/db/src/mod.ts
@@ -63,6 +63,13 @@ export {
   getPrimitiveIntermediatePrefix,
   getPrimitivePrefix,
 } from "./dynamic-tables.ts";
+export { detectCapabilities } from "./capabilities.ts";
+export type { DatabaseCapabilities } from "./capabilities.ts";
+export {
+  pgIvmStrategy,
+  plainViewStrategy,
+} from "./MaterializedViewStrategy.ts";
+export type { MaterializedViewStrategy } from "./MaterializedViewStrategy.ts";
 // export { startPGlite } from "./start-pglite.ts";
 
 export { getMigrationsForBlockHeight } from "./migrations.ts";

--- a/packages/node-sdk/db/src/mod.ts
+++ b/packages/node-sdk/db/src/mod.ts
@@ -63,7 +63,7 @@ export {
   getPrimitiveIntermediatePrefix,
   getPrimitivePrefix,
 } from "./dynamic-tables.ts";
-export { detectCapabilities } from "./capabilities.ts";
+export { detectCapabilities, selectViewStrategy } from "./capabilities.ts";
 export type { DatabaseCapabilities } from "./capabilities.ts";
 export {
   pgIvmStrategy,

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -6,8 +6,11 @@ import {
 import {
   acquireDBMutex,
   createDynamicTables,
+  detectCapabilities,
   getConnection,
   getLastNonEmptyBlockHash,
+  pgIvmStrategy,
+  plainViewStrategy,
   releaseDBMutex,
   resetPublicTables,
   runSnapshotLoop,
@@ -317,11 +320,15 @@ function* startup(
   const syncProtocols = yield* genSyncProtocols(dbConn as any, // Client,
     syncInfo);
 
+  const capabilities = yield* until(detectCapabilities(dbConn as any));
+  const viewStrategy = capabilities.pgIvm ? pgIvmStrategy : plainViewStrategy;
+
   yield* createDynamicTables(
     versionInfo,
     lastBlockHeight,
     dbConn as any, // Client,
     syncProtocols,
+    viewStrategy,
   );
 
   releaseDBMutex(`startup-node`);

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -9,11 +9,10 @@ import {
   detectCapabilities,
   getConnection,
   getLastNonEmptyBlockHash,
-  pgIvmStrategy,
-  plainViewStrategy,
   releaseDBMutex,
   resetPublicTables,
   runSnapshotLoop,
+  selectViewStrategy,
 } from "@effectstream/db";
 import { EventBroker } from "@effectstream/event-server";
 import { ENV } from "@effectstream/utils/node-env";
@@ -321,7 +320,7 @@ function* startup(
     syncInfo);
 
   const capabilities = yield* until(detectCapabilities(dbConn as any));
-  const viewStrategy = capabilities.pgIvm ? pgIvmStrategy : plainViewStrategy;
+  const viewStrategy = selectViewStrategy(capabilities);
 
   yield* createDynamicTables(
     versionInfo,

--- a/packages/node-sdk/sm/primitives/Primitive.ts
+++ b/packages/node-sdk/sm/primitives/Primitive.ts
@@ -9,6 +9,7 @@ import type {
   ProtocolPrimitiveMap,
 } from "@effectstream/config";
 import type { AnyPrimitiveType } from "./src/builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
 /**
  * Abstract Class for Effectstream Primitives
@@ -44,7 +45,15 @@ export abstract class Primitive<
   abstract grammar: TGrammar;
 
   // Dynamic/ivm Table Global definitions
-  dynamicTables: undefined | ((name: string) => string) = undefined;
+  //
+  // The `strategy` argument lets the engine pick between an incrementally
+  // maintained `pg_ivm` view (when the extension is available) and a plain
+  // SQL view fallback (when it isn't). All other DDL — intermediate table,
+  // trigger function, trigger — is identical across strategies.
+  dynamicTables:
+    | undefined
+    | ((name: string, strategy: MaterializedViewStrategy) => string) =
+      undefined;
   getIntermediatePrefix(): string[] {
     return [];
   }
@@ -56,8 +65,11 @@ export abstract class Primitive<
   abstract getConfig(): ProtocolPrimitiveMap[SyncProtocol];
 
   // Arrow function to bind 'this', as this function is passed as a reference
-  public getDynamicTables = (name: string): string | undefined => {
-    return this.dynamicTables?.(name);
+  public getDynamicTables = (
+    name: string,
+    strategy: MaterializedViewStrategy,
+  ): string | undefined => {
+    return this.dynamicTables?.(name, strategy);
   };
 
   // This returns the payload in the state machine format.

--- a/packages/node-sdk/sm/primitives/src/cardano-delayed-asset/delayed-asset-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-delayed-asset/delayed-asset-ivm.ts
@@ -1,6 +1,10 @@
 import { PrimitiveTypeCardanoDelayedAsset } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function delayedAssetIvm(name: string) {
+export function delayedAssetIvm(
+  name: string,
+  strategy: MaterializedViewStrategy,
+) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +12,9 @@ export function delayedAssetIvm(name: string) {
   }
 
   const intermediateTable = `primitives.cardano_asset_utxos_intermediate_${validSQLName}`;
+  const viewName = `primitives.cardano_asset_utxos_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, tx_id, output_index, address, cip14_fingerprint, policy_id, asset_name, amount, block_height FROM ${intermediateTable}`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${intermediateTable} (
@@ -69,19 +76,7 @@ export function delayedAssetIvm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_delayed_asset_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.cardano_asset_utxos_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            tx_id,
-            output_index,
-            address,
-            cip14_fingerprint,
-            policy_id,
-            asset_name,
-            amount,
-            block_height
-        FROM ${intermediateTable};
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/cardano-pool-delegation/pool-delegation-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-pool-delegation/pool-delegation-ivm.ts
@@ -1,6 +1,10 @@
 import { PrimitiveTypeCardanoPoolDelegation } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function poolDelegationIvm(name: string) {
+export function poolDelegationIvm(
+  name: string,
+  strategy: MaterializedViewStrategy,
+) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +12,9 @@ export function poolDelegationIvm(name: string) {
   }
 
   const intermediateTable = `primitives.cardano_pool_delegation_intermediate_${validSQLName}`;
+  const viewName = `primitives.cardano_pool_delegation_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, staking_credential, pool_keyhash FROM ${intermediateTable}`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${intermediateTable} (
@@ -51,13 +58,7 @@ export function poolDelegationIvm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_pool_delegation_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.cardano_pool_delegation_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            staking_credential,
-            pool_keyhash
-        FROM ${intermediateTable};
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/cardano-projected-nft/projected-nft-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-projected-nft/projected-nft-ivm.ts
@@ -1,6 +1,10 @@
 import { PrimitiveTypeCardanoProjectedNFT } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function projectedNftIvm(name: string) {
+export function projectedNftIvm(
+  name: string,
+  strategy: MaterializedViewStrategy,
+) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +12,9 @@ export function projectedNftIvm(name: string) {
   }
 
   const intermediateTable = `primitives.cardano_projected_nft_intermediate_${validSQLName}`;
+  const viewName = `primitives.cardano_projected_nft_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, owner_address, current_tx_id, current_output_index, previous_tx_id, previous_output_index, policy_id, asset_name, status, for_how_long FROM ${intermediateTable}`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${intermediateTable} (
@@ -87,20 +94,7 @@ export function projectedNftIvm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_projected_nft_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.cardano_projected_nft_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            owner_address,
-            current_tx_id,
-            current_output_index,
-            previous_tx_id,
-            previous_output_index,
-            policy_id,
-            asset_name,
-            status,
-            for_how_long
-        FROM ${intermediateTable};
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/evm-erc1155/erc1155-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/evm-erc1155/erc1155-ivm.ts
@@ -1,12 +1,14 @@
 import { PrimitiveTypeEVMERC1155 } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
 /**
  * Creates a new IVM for the ERC1155 token with the given name.
  * This will track the current owner of each token.
  * @param name - The name of the ERC1155 token.
+ * @param strategy - How to publish the read-side view (pg_ivm or plain VIEW).
  * @returns A string containing the SQL script to create the IVM.
  */
-export function erc1155Ivm(name: string) {
+export function erc1155Ivm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -15,6 +17,9 @@ export function erc1155Ivm(name: string) {
 
   const ownershipTable =
     `primitives.erc1155_ownership_intermediate_${validSQLName}`;
+  const viewName = `primitives.erc1155_ownership_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, token_id, owner_address, amount FROM ${ownershipTable} WHERE amount > 0`;
 
   return `
   -- Intermediate table for current ERC1155 ownership (maintained by triggers)
@@ -85,16 +90,8 @@ export function erc1155Ivm(name: string) {
       FOR EACH ROW
       EXECUTE FUNCTION update_erc1155_ownership_${validSQLName}();
 
-  -- Simple incrementally maintained view on the intermediate table
-  SELECT pgivm.create_immv('primitives.erc1155_ownership_view_${validSQLName}',
-      'SELECT
-          primitive_name,
-          token_id,
-          owner_address,
-          amount
-      FROM ${ownershipTable}
-      WHERE amount > 0;
-  ');
+  -- Publish the read-side view (incrementally maintained or plain, per strategy)
+  ${strategy.createView(viewName, selectSql)}
   `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/evm-erc20/erc20-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/evm-erc20/erc20-ivm.ts
@@ -2,6 +2,7 @@
 // This will allow to create new tables during migrations.
 
 import { PrimitiveTypeEVMERC20 } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
 // TODO The IVM here is not relevant, as the trigger does the work.
 
@@ -9,9 +10,10 @@ import { PrimitiveTypeEVMERC20 } from "../builtin.ts";
  * Creates a new IVM for the ERC20 token with the given name.
  * This will track the current balance of each address.
  * @param name - The name of the ERC20 token.
+ * @param strategy - How to publish the read-side view (pg_ivm or plain VIEW).
  * @returns A string containing the SQL script to create the IVM.
  */
-export function erc20Ivm(name: string) {
+export function erc20Ivm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -19,6 +21,9 @@ export function erc20Ivm(name: string) {
   }
 
   const balanceTable = `primitives.erc20_balances_intermediate_${validSQLName}`;
+  const viewName = `primitives.erc20_balances_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, address, balance FROM ${balanceTable} WHERE balance > 0`;
 
   return `
     -- Intermediate table for current ERC20 balances (maintained by triggers)
@@ -28,7 +33,7 @@ export function erc20Ivm(name: string) {
         balance numeric(78,0) DEFAULT 0,
         PRIMARY KEY (primitive_name, address)
     );
-    
+
     -- Trigger function to maintain ERC20 balances
     CREATE OR REPLACE FUNCTION update_erc20_balances_${validSQLName}() RETURNS TRIGGER AS $$
     DECLARE
@@ -37,25 +42,25 @@ export function erc20Ivm(name: string) {
         to_address TEXT;
     BEGIN
         -- Only process ERC20 transfers
-        IF NEW.payload_type = '${PrimitiveTypeEVMERC20}' 
+        IF NEW.payload_type = '${PrimitiveTypeEVMERC20}'
            AND NEW.primitive_name = '${name}'
            AND NEW.payload->>'value' IS NOT NULL THEN
-           
+
          transfer_value := (NEW.payload->>'value')::numeric(78,0);
          from_address := lower(NEW.payload->>'from');
          to_address := lower(NEW.payload->>'to');
-         
+
          -- Handle FROM address (subtract balance, but skip burn address)
-         IF from_address IS NOT NULL 
-            AND from_address != '' 
+         IF from_address IS NOT NULL
+            AND from_address != ''
             AND from_address != '0x0000000000000000000000000000000000000000' THEN
-             
+
              INSERT INTO ${balanceTable} (primitive_name, address, balance)
              VALUES (NEW.primitive_name, from_address, -transfer_value)
              ON CONFLICT (primitive_name, address) DO UPDATE SET
                  balance = ${balanceTable}.balance - transfer_value;
          END IF;
-         
+
          -- Handle TO address (add balance)
          IF to_address IS NOT NULL AND to_address != '' THEN
              INSERT INTO ${balanceTable} (primitive_name, address, balance)
@@ -64,26 +69,19 @@ export function erc20Ivm(name: string) {
                  balance = ${balanceTable}.balance + transfer_value;
          END IF;
         END IF;
-        
+
         RETURN NEW;
     END;
     $$ LANGUAGE plpgsql;
-    
+
     -- Create trigger on primitive_accounting for ERC20 balances
     CREATE TRIGGER trigger_update_erc20_balances_${validSQLName}
         AFTER INSERT ON effectstream.primitive_accounting  -- Note: Qualify with paima schema
         FOR EACH ROW
         EXECUTE FUNCTION update_erc20_balances_${validSQLName}();
-    
-    -- Simple incrementally maintained view on the intermediate table
-    SELECT pgivm.create_immv('primitives.erc20_balances_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            address,
-            balance
-        FROM ${balanceTable}
-        WHERE balance > 0;
-    ');
+
+    -- Publish the read-side view (incrementally maintained or plain, per strategy)
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/evm-erc721/erc721-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/evm-erc721/erc721-ivm.ts
@@ -1,12 +1,14 @@
 import { PrimitiveTypeEVMERC721 } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
 /**
  * Creates a new IVM for the ERC721 token with the given name.
  * This will track the current owner of each token.
  * @param name - The name of the ERC721 token.
+ * @param strategy - How to publish the read-side view (pg_ivm or plain VIEW).
  * @returns A string containing the SQL script to create the IVM.
  */
-export function erc721Ivm(name: string) {
+export function erc721Ivm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -15,6 +17,9 @@ export function erc721Ivm(name: string) {
 
   const ownershipTable =
     `primitives.erc721_ownership_intermediate_${validSQLName}`;
+  const viewName = `primitives.erc721_ownership_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, token_id, current_owner FROM ${ownershipTable}`;
 
   return `
   -- Intermediate table for current ERC721 ownership (maintained by triggers)
@@ -68,14 +73,8 @@ export function erc721Ivm(name: string) {
       FOR EACH ROW
       EXECUTE FUNCTION update_erc721_ownership_${validSQLName}();
 
-  -- Simple incrementally maintained view on the intermediate table
-  SELECT pgivm.create_immv('primitives.erc721_ownership_view_${validSQLName}',
-      'SELECT
-          primitive_name,
-          token_id,
-          current_owner
-      FROM ${ownershipTable};
-  ');
+  -- Publish the read-side view (incrementally maintained or plain, per strategy)
+  ${strategy.createView(viewName, selectSql)}
   `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/near-intent/near-intent-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/near-intent/near-intent-ivm.ts
@@ -1,6 +1,7 @@
 import { PrimitiveTypeNEARIntent } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function nearIntentIvm(name: string) {
+export function nearIntentIvm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +9,9 @@ export function nearIntentIvm(name: string) {
   }
 
   const settlementTable = `primitives.near_intent_settlement_intermediate_${validSQLName}`;
+  const viewName = `primitives.near_intent_settlement_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, intent_hash, account_id, token_id, amount, block_height FROM ${settlementTable}`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${settlementTable} (
@@ -54,16 +58,7 @@ export function nearIntentIvm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_near_intent_settlement_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.near_intent_settlement_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            intent_hash,
-            account_id,
-            token_id,
-            amount,
-            block_height
-        FROM ${settlementTable};
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/near-nep141/nep141-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/near-nep141/nep141-ivm.ts
@@ -1,6 +1,7 @@
 import { PrimitiveTypeNEARNEP141 } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function nep141Ivm(name: string) {
+export function nep141Ivm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +9,9 @@ export function nep141Ivm(name: string) {
   }
 
   const balanceTable = `primitives.nep141_balance_intermediate_${validSQLName}`;
+  const viewName = `primitives.nep141_balance_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, account_id, balance FROM ${balanceTable} WHERE balance > 0`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${balanceTable} (
@@ -55,14 +59,7 @@ export function nep141Ivm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_nep141_balance_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.nep141_balance_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            account_id,
-            balance
-        FROM ${balanceTable}
-        WHERE balance > 0;
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/near-nep171/nep171-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/near-nep171/nep171-ivm.ts
@@ -1,6 +1,7 @@
 import { PrimitiveTypeNEARNEP171 } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function nep171Ivm(name: string) {
+export function nep171Ivm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +9,9 @@ export function nep171Ivm(name: string) {
   }
 
   const ownerTable = `primitives.nep171_owner_intermediate_${validSQLName}`;
+  const viewName = `primitives.nep171_owner_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, token_id, current_owner FROM ${ownerTable}`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${ownerTable} (
@@ -57,13 +61,7 @@ export function nep171Ivm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_nep171_owner_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.nep171_owner_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            token_id,
-            current_owner
-        FROM ${ownerTable};
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 

--- a/packages/node-sdk/sm/primitives/src/near-nep245/nep245-ivm.ts
+++ b/packages/node-sdk/sm/primitives/src/near-nep245/nep245-ivm.ts
@@ -1,6 +1,7 @@
 import { PrimitiveTypeNEARNEP245 } from "../builtin.ts";
+import type { MaterializedViewStrategy } from "@effectstream/db";
 
-export function nep245Ivm(name: string) {
+export function nep245Ivm(name: string, strategy: MaterializedViewStrategy) {
   const lowerName = name.toLowerCase();
   const validSQLName = lowerName.replace(/[^a-zA-Z0-9_]/g, "");
   if (validSQLName !== lowerName) {
@@ -8,6 +9,9 @@ export function nep245Ivm(name: string) {
   }
 
   const balanceTable = `primitives.nep245_balance_intermediate_${validSQLName}`;
+  const viewName = `primitives.nep245_balance_view_${validSQLName}`;
+  const selectSql =
+    `SELECT primitive_name, token_id, account_id, amount FROM ${balanceTable} WHERE amount > 0`;
 
   return `
     CREATE TABLE IF NOT EXISTS ${balanceTable} (
@@ -68,15 +72,7 @@ export function nep245Ivm(name: string) {
         FOR EACH ROW
         EXECUTE FUNCTION update_nep245_balance_${validSQLName}();
 
-    SELECT pgivm.create_immv('primitives.nep245_balance_view_${validSQLName}',
-        'SELECT
-            primitive_name,
-            token_id,
-            account_id,
-            amount
-        FROM ${balanceTable}
-        WHERE amount > 0;
-    ');
+    ${strategy.createView(viewName, selectSql)}
     `;
 }
 


### PR DESCRIPTION
The engine hard-required the `pg_ivm` extension, blocking deployment on managed Postgres (RDS, Cloud SQL, Neon). This PR makes it auto-detected with a plain-SQL-view fallback gated behind an explicit opt-in, so nobody silently boots production on the degraded path.

### Changes

- `MaterializedViewStrategy` interface with `pgIvmStrategy` (emits `pgivm.create_immv`) and `plainViewStrategy` (emits `CREATE OR REPLACE VIEW`).
- `detectCapabilities()` probes the extension at startup via a soft-fail `CREATE EXTENSION` + `pg_extension` lookup.
- `selectViewStrategy(capabilities)` encodes the policy:
  - pg_ivm available → uses it silently
  - pg_ivm missing + `ALLOW_NO_PG_IVM=true` → returns `plainViewStrategy` and emits a prominent multi-line `WARN`
  - pg_ivm missing + flag unset → **aborts startup** with a remediation error (install link + opt-in instructions)
- Strategy threaded through `Primitive.dynamicTables`, all 10 IVM emitters, `createDynamicTables`, runtime startup, and the db-emulator.
- Dropped unconditional `CREATE EXTENSION pg_ivm` from the v-0.0.0 system migration.
- New "Required Extension: `pg_ivm`" section in `docs/site/docs/home/1000-effectstream-engine/1002-database.md` covering install, the opt-out, and the performance tradeoff.

### Backward compatibility

`pgIvmStrategy` keeps the legacy unsuffixed migration name (`dynamic-tables-<type>-<name>`), so existing deployments find their applied migration rows and skip re-application on upgrade. Only the new fallback strategy uses a `-view` suffix.

### Atomicity & performance notes

- pg_ivm v1.11 source verified: `IVM_immediate_maintenance` triggers run synchronously in the same transaction as the underlying write. The plain-VIEW fallback inherits this atomicity unchanged via the `AFTER ROW` trigger on `primitive_accounting`.
- The fallback is correct but read-bound: the intermediate tables grow monotonically (zero-balance rows aren't purged), so plain-view reads become seq scan + filter at scale. The fallback is **dev/test and low-volume only** — documented prominently and enforced via the opt-in gate.
