### PR TITLE
Resilient pg pool error handling for serverless Postgres

### DIFF
--- a/packages/effectstream-sdk/log/src/mod.ts
+++ b/packages/effectstream-sdk/log/src/mod.ts
@@ -11,6 +11,7 @@ export {
 } from "./const.ts";
 export { attachTransport } from "./tslog.ts";
 export { DefaultLogLevels } from "./tslog.ts";
+export { installUnhandledRejectionLogger } from "./process-handlers.ts";
 
 // re-exporting this
 // so that we don't need to re-import opentelemetry in every component

--- a/packages/effectstream-sdk/log/src/process-handlers.ts
+++ b/packages/effectstream-sdk/log/src/process-handlers.ts
@@ -1,0 +1,38 @@
+import { SeverityNumber } from "@opentelemetry/api-logs";
+import { log } from "./mod.ts";
+
+/**
+ * Install a process-wide `unhandledRejection` handler.
+ *
+ * By default the handler logs the error at ERROR and re-crashes the process
+ * via `process.exit(1)` — preserving the "let it crash" semantic that Node /
+ * Bun apply when no handler is registered. The point of installing this
+ * handler is *visibility*: without it, Bun crashes silently with no log line
+ * about what the rejection actually was.
+ *
+ * Pass `shouldSurvive` to opt specific errors out of the crash — useful for
+ * known-transient failures from external systems (e.g. a pg pool ECONNRESET
+ * from a serverless Postgres cold-start). Surviving errors are logged at
+ * WARN; non-surviving ones at ERROR before exit.
+ *
+ * Idempotent: only the first call in this module registers a listener.
+ */
+let unhandledRejectionLoggerInstalled = false;
+
+export function installUnhandledRejectionLogger(
+  componentName: string,
+  shouldSurvive?: (reason: unknown) => boolean,
+): void {
+  if (unhandledRejectionLoggerInstalled) return;
+  unhandledRejectionLoggerInstalled = true;
+  process.on("unhandledRejection", (reason: unknown) => {
+    const survive = shouldSurvive?.(reason) ?? false;
+    log.remote(
+      componentName,
+      ["unhandledRejection"],
+      survive ? SeverityNumber.WARN : SeverityNumber.ERROR,
+      (log) => log(reason),
+    );
+    if (!survive) process.exit(1);
+  });
+}

--- a/packages/node-sdk/db/src/mod.ts
+++ b/packages/node-sdk/db/src/mod.ts
@@ -54,6 +54,7 @@ export * from "./sql/tables.queries.ts";
 
 export * from "./event-indexing.ts";
 export * from "./register-events.ts";
+export * from "./transient-pg-errors.ts";
 export * from "./pg-connection.ts";
 export * from "./scheduled-constructors.ts";
 export * from "./system.ts";

--- a/packages/node-sdk/db/src/pg-connection.ts
+++ b/packages/node-sdk/db/src/pg-connection.ts
@@ -1,10 +1,28 @@
 import type { Client, PoolClient, PoolConfig } from "pg";
 import pg from "pg";
-import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
+import {
+  ComponentNames,
+  installUnhandledRejectionLogger,
+  log,
+  SeverityNumber,
+} from "@effectstream/log";
 import { type Operation, run, sleep } from "effection";
 import { ENV } from "@effectstream/utils/node-env";
+import { isTransientPgError } from "./transient-pg-errors.ts";
+
+export { isTransientPgError } from "./transient-pg-errors.ts";
 
 let readonlyDBConn: pg.Pool | null;
+let unhandledRejectionLoggerInstalled = false;
+
+function logPoolError(err: unknown, tags: string[]): void {
+  log.remote(
+    ComponentNames.EFFECTSTREAM_PGLITE,
+    tags,
+    isTransientPgError(err) ? SeverityNumber.WARN : SeverityNumber.ERROR,
+    (l) => l(err),
+  );
+}
 
 // PGLite does not support multiple connections, so we need to use a mutex to ensure that only one query is executed at a time.
 // * For transactions use yield* acquireDBMutex(); ...Your Operations... releaseDBMutex();
@@ -148,6 +166,14 @@ export const getConnection = (
   creds?: PoolConfig,
   readonly = false,
 ): pg.Pool => {
+  if (!unhandledRejectionLoggerInstalled) {
+    unhandledRejectionLoggerInstalled = true;
+    installUnhandledRejectionLogger(
+      ComponentNames.EFFECTSTREAM_PGLITE,
+      isTransientPgError,
+    );
+  }
+
   if (!creds) {
     creds = {
       host: ENV.DB_HOST,
@@ -163,30 +189,19 @@ export const getConnection = (
   const MAX_CONNECTIONS = ENV.PGLITE ? 1 : 10;
 
   const pool = new pg.Pool({ ...creds, max: MAX_CONNECTIONS });
-  pool.on("error", (err: unknown) =>
-    log.remote(
-      ComponentNames.EFFECTSTREAM_PGLITE,
-      ["query"],
-      SeverityNumber.ERROR,
-      (log) => log(err),
-    ));
+  pool.on("error", (err: unknown) => logPoolError(err, ["query"]));
   pool.on("connect", (_client: PoolClient) => {
     // On each new client initiated, need to register for error(this is a serious bug on pg, the client throw errors although it should not)
     // https://github.com/brianc/node-postgres/issues/2499#issuecomment-805477725
-    _client.on("error", (err: Error) => {
-      log.remote(
-        ComponentNames.EFFECTSTREAM_PGLITE,
-        ["connect"],
-        SeverityNumber.ERROR,
-        (log) => log(err),
-      );
-    });
+    _client.on("error", (err: Error) => logPoolError(err, ["connect"]));
   });
 
   if (readonly) {
     const ensureReadOnly =
       `SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;`;
-    void pool.query(ensureReadOnly); // note: this query modifies the DB state
+    void pool.query(ensureReadOnly).catch((err: unknown) =>
+      logPoolError(err, ["readonly-setup"]),
+    );
     readonlyDBConn = pool;
   }
 
@@ -199,13 +214,6 @@ export const getPersistentConnection = (creds: PoolConfig): Client => {
   client.connect(() => {});
   // https://github.com/brianc/node-postgres/issues/2499#issuecomment-805477725
   // On each new client initiated, need to register for error(this is a serious bug on pg, the client throw errors although it should not)
-  client.on("error", (err: Error) => {
-    log.remote(
-      ComponentNames.EFFECTSTREAM_PGLITE,
-      ["query"],
-      SeverityNumber.ERROR,
-      (log) => log(err),
-    );
-  });
+  client.on("error", (err: Error) => logPoolError(err, ["persistent"]));
   return client;
 };

--- a/packages/node-sdk/db/src/pg-connection.ts
+++ b/packages/node-sdk/db/src/pg-connection.ts
@@ -1,28 +1,16 @@
 import type { Client, PoolClient, PoolConfig } from "pg";
 import pg from "pg";
-import {
-  ComponentNames,
-  installUnhandledRejectionLogger,
-  log,
-  SeverityNumber,
-} from "@effectstream/log";
+import { ComponentNames, installUnhandledRejectionLogger } from "@effectstream/log";
 import { type Operation, run, sleep } from "effection";
 import { ENV } from "@effectstream/utils/node-env";
 import { isTransientPgError } from "./transient-pg-errors.ts";
+import { poolErrors } from "./pool-error-tracker.ts";
 
 export { isTransientPgError } from "./transient-pg-errors.ts";
+export { poolErrors, PoolErrorTracker } from "./pool-error-tracker.ts";
 
 let readonlyDBConn: pg.Pool | null;
 let unhandledRejectionLoggerInstalled = false;
-
-function logPoolError(err: unknown, tags: string[]): void {
-  log.remote(
-    ComponentNames.EFFECTSTREAM_PGLITE,
-    tags,
-    isTransientPgError(err) ? SeverityNumber.WARN : SeverityNumber.ERROR,
-    (l) => l(err),
-  );
-}
 
 // PGLite does not support multiple connections, so we need to use a mutex to ensure that only one query is executed at a time.
 // * For transactions use yield* acquireDBMutex(); ...Your Operations... releaseDBMutex();
@@ -156,6 +144,8 @@ export async function runPreparedQuery<T>(
     });
     result = await Promise.race([p, timeout]);
     clearTimeout(t);
+    // A successful query proves the DB is reachable end-to-end
+    poolErrors.markHealthy();
   } finally {
     releaseDBMutex(`pq:${name}`);
   }
@@ -189,18 +179,20 @@ export const getConnection = (
   const MAX_CONNECTIONS = ENV.PGLITE ? 1 : 10;
 
   const pool = new pg.Pool({ ...creds, max: MAX_CONNECTIONS });
-  pool.on("error", (err: unknown) => logPoolError(err, ["query"]));
+  pool.on("error", (err: unknown) => poolErrors.log(err, ["query"]));
   pool.on("connect", (_client: PoolClient) => {
-    // On each new client initiated, need to register for error(this is a serious bug on pg, the client throw errors although it should not)
+    // Successful connect proves the DB is reachable — reset the failure clock.
+    poolErrors.markHealthy();
+    // Register a per-client error handler; pg can emit errors on idle clients.
     // https://github.com/brianc/node-postgres/issues/2499#issuecomment-805477725
-    _client.on("error", (err: Error) => logPoolError(err, ["connect"]));
+    _client.on("error", (err: Error) => poolErrors.log(err, ["connect"]));
   });
 
   if (readonly) {
     const ensureReadOnly =
       `SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;`;
     void pool.query(ensureReadOnly).catch((err: unknown) =>
-      logPoolError(err, ["readonly-setup"]),
+      poolErrors.log(err, ["readonly-setup"]),
     );
     readonlyDBConn = pool;
   }
@@ -213,7 +205,6 @@ export const getPersistentConnection = (creds: PoolConfig): Client => {
   const client = new pg.Client(creds);
   client.connect(() => {});
   // https://github.com/brianc/node-postgres/issues/2499#issuecomment-805477725
-  // On each new client initiated, need to register for error(this is a serious bug on pg, the client throw errors although it should not)
-  client.on("error", (err: Error) => logPoolError(err, ["persistent"]));
+  client.on("error", (err: Error) => poolErrors.log(err, ["persistent"]));
   return client;
 };

--- a/packages/node-sdk/db/src/pool-error-tracker.test.ts
+++ b/packages/node-sdk/db/src/pool-error-tracker.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, expect, test } from "bun:test";
+
+// Thresholds are read from env at module load (and `envMs` rejects 0, so use
+// small positive values). SUSTAINED=5ms → a failure older than 5ms is
+// "sustained"; FATAL=30ms → older than 30ms triggers the process.exit
+// escalation. Dynamic import so these are picked up before the module
+// computes its constants.
+process.env.POOL_SUSTAINED_THRESHOLD_MS = "5";
+process.env.POOL_FATAL_THRESHOLD_MS = "30";
+const { PoolErrorTracker } = await import("./pool-error-tracker.ts");
+
+const transient = () => ({
+  code: "ECONNRESET",
+  message: "Client network socket disconnected before secure TLS connection",
+  stack: "    at node_modules/pg-pool/index.js:45:11",
+});
+
+const realExit = process.exit;
+afterEach(() => {
+  process.exit = realExit;
+});
+
+test("ignores non-transient errors (auth/schema bugs)", () => {
+  const t = new PoolErrorTracker();
+  t.log(new Error("column foo does not exist"), ["sync-write"]);
+  expect(t.state().consecutive).toBe(0);
+  expect(t.state().sustained).toBe(false);
+});
+
+test("counts consecutive transient failures and reports sustained", async () => {
+  const t = new PoolErrorTracker();
+  t.log(transient(), ["sync-write"]);
+  expect(t.state().sustained).toBe(false); // fresh failure, < 5ms old
+  await Bun.sleep(15); // exceed SUSTAINED_THRESHOLD_MS=5, stay under FATAL=30
+  t.log(transient(), ["sync-write"]);
+  const s = t.state();
+  expect(s.consecutive).toBe(2);
+  expect(s.sustained).toBe(true);
+});
+
+test("markHealthy resets the failure clock", () => {
+  const t = new PoolErrorTracker();
+  t.log(transient(), ["sync-write"]);
+  t.markHealthy();
+  const s = t.state();
+  expect(s.consecutive).toBe(0);
+  expect(s.firstFailureAt).toBe(0);
+  expect(s.sustained).toBe(false);
+});
+
+test("exits the process once failures persist past the fatal threshold", async () => {
+  let exitCode: number | undefined;
+  process.exit = ((code?: number) => {
+    exitCode = code;
+  }) as typeof process.exit;
+
+  const t = new PoolErrorTracker();
+  t.log(transient(), ["sync-write"]); // starts the clock; not yet fatal
+  await Bun.sleep(40); // exceed FATAL_THRESHOLD_MS=20
+  t.log(transient(), ["sync-write"]); // now duration >= fatal → schedules exit
+
+  // exit is deferred via setImmediate so the fatal log line can flush first.
+  await new Promise((resolve) => setImmediate(resolve));
+  expect(exitCode).toBe(1);
+});

--- a/packages/node-sdk/db/src/pool-error-tracker.ts
+++ b/packages/node-sdk/db/src/pool-error-tracker.ts
@@ -1,0 +1,81 @@
+import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
+import { isTransientPgError } from "./transient-pg-errors.ts";
+
+/** After this long, treat continuous transient failures as a real outage. */
+const SUSTAINED_THRESHOLD_MS = 60_000;
+/** After this long, exit so the orchestrator restarts the process. */
+const FATAL_THRESHOLD_MS = 5 * 60_000;
+
+/**
+ * Tracks consecutive transient pool errors. Severity escalates WARN → ERROR
+ * once failures persist past `SUSTAINED_THRESHOLD_MS`, and the process exits
+ * past `FATAL_THRESHOLD_MS` (relying on the orchestrator's restart policy).
+ * Call `markHealthy()` on any positive signal to reset.
+ */
+export class PoolErrorTracker {
+  private consecutive = 0;
+  private firstFailureAt = 0;
+
+  log(err: unknown, tags: string[]): void {
+    // Non-transient errors are a different failure mode (auth, schema, etc.).
+    if (!isTransientPgError(err)) {
+      log.remote(
+        ComponentNames.EFFECTSTREAM_PGLITE,
+        tags,
+        SeverityNumber.ERROR,
+        (l) => l(err),
+      );
+      return;
+    }
+
+    if (this.consecutive === 0) this.firstFailureAt = Date.now();
+    this.consecutive++;
+
+    const durationMs = Date.now() - this.firstFailureAt;
+    const sustained = durationMs >= SUSTAINED_THRESHOLD_MS;
+    const fatal = durationMs >= FATAL_THRESHOLD_MS;
+
+    log.remote(
+      ComponentNames.EFFECTSTREAM_PGLITE,
+      fatal
+        ? [...tags, "sustained-failure", "fatal"]
+        : sustained
+        ? [...tags, "sustained-failure"]
+        : tags,
+      sustained ? SeverityNumber.ERROR : SeverityNumber.WARN,
+      (l) => l({ err, consecutive: this.consecutive, durationMs }),
+    );
+
+    if (fatal) {
+      // Defer to the next tick so the log line above has a chance to flush.
+      setImmediate(() => process.exit(1));
+    }
+  }
+
+  /** Call when the DB has proven reachable (e.g. successful pool connect). */
+  markHealthy(): void {
+    this.consecutive = 0;
+    this.firstFailureAt = 0;
+  }
+
+  /** Read-only snapshot for health checks, heartbeats, or external probes. */
+  state(): {
+    consecutive: number;
+    firstFailureAt: number;
+    sustainedDurationMs: number;
+    sustained: boolean;
+  } {
+    const durationMs = this.firstFailureAt === 0
+      ? 0
+      : Date.now() - this.firstFailureAt;
+    return {
+      consecutive: this.consecutive,
+      firstFailureAt: this.firstFailureAt,
+      sustainedDurationMs: durationMs,
+      sustained: durationMs >= SUSTAINED_THRESHOLD_MS,
+    };
+  }
+}
+
+/** Process-wide singleton — failures aggregate at DB-health granularity. */
+export const poolErrors = new PoolErrorTracker();

--- a/packages/node-sdk/db/src/pool-error-tracker.ts
+++ b/packages/node-sdk/db/src/pool-error-tracker.ts
@@ -1,10 +1,16 @@
 import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import { isTransientPgError } from "./transient-pg-errors.ts";
 
+function envMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const parsed = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 /** After this long, treat continuous transient failures as a real outage. */
-const SUSTAINED_THRESHOLD_MS = 60_000;
+const SUSTAINED_THRESHOLD_MS = envMs("POOL_SUSTAINED_THRESHOLD_MS", 60_000);
 /** After this long, exit so the orchestrator restarts the process. */
-const FATAL_THRESHOLD_MS = 5 * 60_000;
+const FATAL_THRESHOLD_MS = envMs("POOL_FATAL_THRESHOLD_MS", 5 * 60_000);
 
 /**
  * Tracks consecutive transient pool errors. Severity escalates WARN → ERROR

--- a/packages/node-sdk/db/src/transient-pg-errors.test.ts
+++ b/packages/node-sdk/db/src/transient-pg-errors.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test";
+import { isTransientPgError } from "./transient-pg-errors.ts";
+
+test("isTransientPgError - Neon pg-pool TLS reset", () => {
+  expect(
+    isTransientPgError({
+      code: "ECONNRESET",
+      message:
+        "Client network socket disconnected before secure TLS connection was established",
+      stack: "    at /app/node_modules/.bun/pg-pool@3.14.0/node_modules/pg-pool/index.js:45:11",
+    }),
+  ).toBe(true);
+});
+
+test("isTransientPgError - rejects non-pg ETIMEDOUT", () => {
+  expect(
+    isTransientPgError({
+      code: "ETIMEDOUT",
+      message: "fetch failed",
+      stack: "    at node:internal/deps/undici/undici.js:1234:5",
+    }),
+  ).toBe(false);
+});
+
+test("isTransientPgError - walks cause chain", () => {
+  const inner = {
+    code: "ECONNRESET",
+    message:
+      "Client network socket disconnected before secure TLS connection was established",
+    stack: "    at node_modules/pg-pool/index.js:45:11",
+  };
+  expect(isTransientPgError({ message: "wrapper", cause: inner })).toBe(true);
+});
+
+test("isTransientPgError - rejects logic errors", () => {
+  expect(isTransientPgError(new Error("column foo does not exist"))).toBe(
+    false,
+  );
+});
+
+test("isTransientPgError - idle pool message without stack", () => {
+  expect(
+    isTransientPgError({
+      message: "Connection terminated unexpectedly",
+    }),
+  ).toBe(true);
+});

--- a/packages/node-sdk/db/src/transient-pg-errors.ts
+++ b/packages/node-sdk/db/src/transient-pg-errors.ts
@@ -4,6 +4,7 @@ const TRANSIENT_PG_MESSAGES = [
   "Connection terminated unexpectedly",
   "Client has encountered a connection error",
   "Client network socket disconnected before secure TLS connection",
+  "Query read timeout",
 ] as const;
 
 function* walkErrors(reason: unknown): Generator<unknown> {
@@ -35,7 +36,8 @@ function isTransientPgErrorSingle(err: unknown): boolean {
   if (hasTransientPgMessage(err)) return true;
   if (!isFromPgStack(err)) return false;
   const code = (err as { code?: string }).code;
-  return code === "ECONNRESET" || code === "EPIPE";
+  return code === "ECONNRESET" || code === "EPIPE" ||
+    code === "ECONNREFUSED";
 }
 
 /**

--- a/packages/node-sdk/db/src/transient-pg-errors.ts
+++ b/packages/node-sdk/db/src/transient-pg-errors.ts
@@ -1,0 +1,54 @@
+const PG_STACK_RE = /node_modules\/(pg-pool|pg)\//;
+
+const TRANSIENT_PG_MESSAGES = [
+  "Connection terminated unexpectedly",
+  "Client has encountered a connection error",
+  "Client network socket disconnected before secure TLS connection",
+] as const;
+
+function* walkErrors(reason: unknown): Generator<unknown> {
+  let current: unknown = reason;
+  const seen = new Set<unknown>();
+  while (current != null && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    yield current;
+    current = (current as { cause?: unknown }).cause;
+  }
+}
+
+function isFromPgStack(err: unknown): boolean {
+  if (err == null || typeof err !== "object" || !("stack" in err)) {
+    return false;
+  }
+  return PG_STACK_RE.test(String((err as Error).stack));
+}
+
+function hasTransientPgMessage(err: unknown): boolean {
+  if (err == null || typeof err !== "object") return false;
+  const msg = (err as { message?: string }).message;
+  if (typeof msg !== "string") return false;
+  return TRANSIENT_PG_MESSAGES.some((fragment) => msg.includes(fragment));
+}
+
+function isTransientPgErrorSingle(err: unknown): boolean {
+  if (err == null || typeof err !== "object") return false;
+  if (hasTransientPgMessage(err)) return true;
+  if (!isFromPgStack(err)) return false;
+  const code = (err as { code?: string }).code;
+  return code === "ECONNRESET" || code === "EPIPE";
+}
+
+/**
+ * Returns true for pg / network errors that are normal on serverless Postgres
+ * (Neon, etc.): cold-start RSTs, idle-socket evictions, transient TLS blips.
+ * The pool recovers on the next query — use with `installUnhandledRejectionLogger`
+ * from `@effectstream/log` so these do not crash the process.
+ *
+ * Intentionally narrow: known-recoverable conditions only; logic/SQL bugs still crash.
+ */
+export function isTransientPgError(reason: unknown): boolean {
+  for (const err of walkErrors(reason)) {
+    if (isTransientPgErrorSingle(err)) return true;
+  }
+  return false;
+}

--- a/packages/node-sdk/runtime/src/api/http-server.ts
+++ b/packages/node-sdk/runtime/src/api/http-server.ts
@@ -13,6 +13,7 @@ import {
   getTableSchema,
   type IGetAllAddressesResult,
   type IGetAllTableNamesResult,
+  poolErrors,
   releaseDBMutex,
   runPreparedQuery,
   waitUntilFree,
@@ -345,19 +346,29 @@ export const startHttpServer = function* (
     yield* until(apiRouter(server, dbConn));
   }
 
+  const HealthDbSchema = Type.Object({
+    consecutive: Type.Number(),
+    firstFailureAt: Type.Number(),
+    sustainedDurationMs: Type.Number(),
+    sustained: Type.Boolean(),
+  });
+  const HealthResponseSchema = Type.Object({
+    status: Type.String(),
+    db: HealthDbSchema,
+  });
   server.get("/health", {
     schema: {
       tags: ["status"],
       response: {
-        200: Type.Object({
-          status: Type.String(),
-        }),
+        200: HealthResponseSchema,
+        503: HealthResponseSchema,
       },
     },
-  }, () => {
-    return {
-      status: "ok",
-    };
+  }, (_req, reply) => {
+    const db = poolErrors.state();
+    return reply
+      .status(db.sustained ? 503 : 200)
+      .send({ status: db.sustained ? "db-unreachable" : "ok", db });
   });
 
   server.get("/addresses", {

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -29,7 +29,10 @@ import {
   until,
 } from "effection";
 import { initTelemetry } from "./telemetry.ts";
-import { type PendingEvent, processFinalizedBlock } from "./process-blocks.ts";
+import {
+  type PendingEvent,
+  processFinalizedBlockWithRetry,
+} from "./process-blocks.ts";
 import { startHttpServer } from "./api/http-server.ts";
 import type { StartConfig } from "./types.ts";
 import type { Client } from "pg";
@@ -135,34 +138,19 @@ export function* start(config: StartConfig): Operation<void> {
   }
 
   for (const value of yield* each(finalizedBlockStream)) {
-    // We request a dbClient for a non-shared dbConn object.
-    // For PGLite, this is not enough, as the can only be one connection at a time.
-    // So we request a DBMutex as well.
-    let dbClient: Client | undefined;
-    // Custom app events emitted by STFs during this block. Collected by
-    // processFinalizedBlock and flushed below ONLY after it returns — i.e.
-    // strictly after the block's COMMIT. See plan invariant I1.
-    let blockAppEvents: PendingEvent[] = [];
-    try {
-      yield* acquireDBMutex(`processing-blocks:${value.blockNumber}`);
-      dbClient = yield* until((dbConn as any).connect()); // Client,
-
-      const result = yield* processFinalizedBlock(
-        value,
-        config,
-        dbClient as any, // Client,
-        blockHash,
-      );
-      const resultHash = result.blockHash;
-      blockAppEvents = result.events;
-      if (resultHash !== "0x0") {
-        blockHash = resultHash;
-      }
-    } finally {
-      releaseDBMutex(`processing-blocks:${value.blockNumber}`);
-      if (dbClient) {
-        (dbClient as any).release(); // Client,
-      }
+    // processFinalizedBlockWithRetry owns connection checkout, the per-block
+    // DB mutex (PGLite), and transient-pg retry/backoff. App events it
+    // collects are flushed below ONLY after it returns — i.e. strictly after
+    // the block's COMMIT.
+    const result = yield* processFinalizedBlockWithRetry(
+      value,
+      config,
+      dbConn as any, // Pool,
+      blockHash,
+    );
+    const blockAppEvents: PendingEvent[] = result.events;
+    if (result.blockHash !== "0x0") {
+      blockHash = result.blockHash;
     }
 
     // Used to emit & log the block range for each protocol.

--- a/packages/node-sdk/runtime/src/process-blocks.ts
+++ b/packages/node-sdk/runtime/src/process-blocks.ts
@@ -1,6 +1,6 @@
 import type { ChainBlock } from "@effectstream/sync";
-import { call, type Operation, until } from "effection";
-import type { Pool } from "pg";
+import { call, type Operation, sleep, until } from "effection";
+import type { Pool, PoolClient } from "pg";
 import { type BaseStfInput, type EmitFn, primitiveTransitionFunction } from "@effectstream/sm";
 import { PreparedQuery } from "@pgtyped/runtime";
 import type {
@@ -9,12 +9,16 @@ import type {
   SyncStateUpdateStream,
 } from "@effectstream/coroutine";
 import {
+  acquireDBMutex,
   blockHeightDone,
   deleteEmptyBlocks,
   deleteScheduled,
   getFutureGameInputByBlockHeight,
   getFutureGameInputByMaxTimestamp,
   insertGameInputResult,
+  isTransientPgError,
+  poolErrors,
+  releaseDBMutex,
   removePages,
   saveLastBlock,
 } from "@effectstream/db";
@@ -336,8 +340,29 @@ export function* processFinalizedBlock(
 
     /* STEP 8: Commit the transaction. */
     yield* until(dbConn.query("COMMIT"));
+    // A successful COMMIT proves the DB is reachable end-to-end — reset the
+    // pool failure clock so the write path also feeds the health tracker
+    // (it otherwise only sees floating pool errors and the read-side API).
+    poolErrors.markHealthy();
   } catch (err) {
-    yield* until(dbConn.query("ROLLBACK"));
+    // Best-effort rollback. If the socket is dead the ROLLBACK throws too;
+    // swallow that so it doesn't mask the original error — the caller's retry
+    // loop keys off the original (transient) error, not a rollback failure.
+    try {
+      yield* until(dbConn.query("ROLLBACK"));
+    } catch (rollbackErr) {
+      log.remote(
+        ComponentNames.EFFECTSTREAM_SYNC,
+        "block-processing",
+        SeverityNumber.WARN,
+        (log) =>
+          log(
+            `ROLLBACK failed for block ${value.blockNumber} (connection likely dead): ${
+              String(rollbackErr)
+            }`,
+          ),
+      );
+    }
     log.remote(
       ComponentNames.EFFECTSTREAM_SYNC,
       "block-processing",
@@ -345,12 +370,89 @@ export function* processFinalizedBlock(
       (log) =>
         log(`Error processing block ${value.blockNumber}: ${String(err)}`),
     );
-    // We cannot recover from this error.
+    // Re-throw: `processFinalizedBlockWithRetry` decides whether this is a
+    // retryable transient pg failure or a fatal bug.
     throw err;
   }
 
-  return { 
-    blockHash: hasOperations ? blockHash : "0x0" as PaimaBlockHash, 
-    events: blockEvents 
+  return {
+    blockHash: hasOperations ? blockHash : "0x0" as PaimaBlockHash,
+    events: blockEvents
   };
+}
+
+/** Caps the exponential backoff between block-retry attempts. */
+const MAX_RETRY_BACKOFF_MS = 5_000;
+
+/**
+ * Run {@link processFinalizedBlock} against a freshly checked-out pool client,
+ * retrying the whole block on transient pg failures (Neon cold-starts,
+ * idle-socket evictions, TLS blips).
+ *
+ * The previous socket is dead after such a failure, so each attempt
+ * re-acquires a client and reprocesses the block from `BEGIN` — safe because
+ * the failed tx never committed and the caller only advances the block stream
+ * after this returns.
+ *
+ * `poolErrors` governs escalation: it logs WARN→ERROR as the outage persists
+ * and calls `process.exit(1)` once it crosses the fatal threshold, letting the
+ * orchestrator restart us. A non-transient error (a real SQL/logic bug) is
+ * re-thrown and crashes, as before.
+ *
+ * Owns the per-block DB mutex (for PGLite) and client lifecycle so the caller
+ * doesn't have to.
+ */
+export function* processFinalizedBlockWithRetry(
+  value: ChainBlock,
+  config: StartConfig,
+  pool: Pool,
+  previousBlockHash: EffectstreamBlockHash | null,
+): Operation<ProcessFinalizedBlockResult> {
+  const lockName = `processing-blocks:${value.blockNumber}`;
+  let attempt = 0;
+  while (true) {
+    let dbClient: PoolClient | undefined;
+    let transientErr: unknown;
+    try {
+      yield* acquireDBMutex(lockName);
+      dbClient = yield* until(pool.connect());
+      return yield* processFinalizedBlock(
+        value,
+        config,
+        dbClient as unknown as Pool, // a checked-out client, used as the tx conn
+        previousBlockHash,
+      );
+    } catch (err) {
+      if (!isTransientPgError(err)) throw err;
+      transientErr = err;
+    } finally {
+      releaseDBMutex(lockName);
+      if (dbClient) {
+        // Passing the error destroys the client instead of recycling it, so
+        // the pool never hands the dead socket back out. On success
+        // `transientErr` is undefined and the client returns to the pool.
+        try {
+          dbClient.release(transientErr as Error | undefined);
+        } catch {
+          /* already released/destroyed */
+        }
+      }
+    }
+
+    attempt++;
+    poolErrors.log(transientErr, ["sync-write"]);
+    const backoffMs = Math.min(500 * 2 ** (attempt - 1), MAX_RETRY_BACKOFF_MS);
+    log.local(
+      ComponentNames.EFFECTSTREAM_SYNC,
+      "block-processing",
+      SeverityNumber.WARN,
+      (l) =>
+        l(
+          `transient db error on block ${value.blockNumber}; retry #${attempt} in ${backoffMs}ms: ${
+            String(transientErr)
+          }`,
+        ),
+    );
+    yield* sleep(backoffMs);
+  }
 }


### PR DESCRIPTION
### Problem

Running against Neon (or any managed pg with idle eviction) crashed the
node with an unhandled `ECONNRESET` during TLS reconnect. We had no
process-level safety net and no way to distinguish a cold-start blip from
a real outage.

### Changes (3 commits)

**1. Unhandled-rejection logger + transient pg predicate**
- `installUnhandledRejectionLogger(component, shouldSurvive?)` in
  `@effectstream/log`: single process handler, logs at WARN if the
  predicate matches, ERROR + `process.exit(1)` otherwise.
- `isTransientPgError()` in `@effectstream/db`: narrow predicate matching
  `ECONNRESET` / `EPIPE` (with pg-stack guard) and three known pg/TLS
  messages. Walks `cause` chains. Five unit tests.
- `pg-connection.ts` installs the logger on first `getConnection()`.

**2. `PoolErrorTracker`**
- Tracks consecutive transient failures with two thresholds:
  - **≥ `SUSTAINED_THRESHOLD_MS` (60s)** → WARN → ERROR + `sustained-failure` tag
  - **≥ `FATAL_THRESHOLD_MS` (5min)** → `fatal` tag + `process.exit(1)` for orchestrator restart
- Both env-overridable (`POOL_SUSTAINED_THRESHOLD_MS` / `POOL_FATAL_THRESHOLD_MS`).
- Resets on successful `connect` *and* successful `runPreparedQuery`
  (the latter closes a warm-connection-reuse gap that would have caused
  false fatal exits hours later).
- `poolErrors.state()` exposed for consumers.

**3. ECONNREFUSED + /health integration**
- `ECONNREFUSED` and `"Query read timeout"` added to the transient set.
- `GET /health` now returns `poolErrors.state()` and flips to **HTTP 503**
  when `sustained === true` — usable as a readiness probe.

### Verification
[pool-error-e2e.zip](https://github.com/user-attachments/files/28328892/pool-error-e2e.zip)

- Unit: `bun test ./packages/node-sdk/db/src/transient-pg-errors.test.ts` — 5/5.
- E2E (attached, not committed): `pool-error-e2e.zip` drives the full
  baseline → kill pg → escalate → fatal exit → respawn cycle in ~35s. README inside.

```
eduardosoto@Eduardos-MacBook-Pro paima-engine % bun scripts/test-pool-health-e2e.ts
auto-detected brew postgres: postgresql@18
[+0.0s] config: SUSTAINED=10000ms FATAL=30000ms
[+0.0s] target: http://localhost:9999/health
[+0.0s] no orchestrator detected; launching one
           DB_HOST=localhost DB_PORT=5432 DB_USER=eduardosoto DB_NAME=effectstream_test PGLITE=false
[+0.2s] dropped+recreated database effectstream_test
[+0.2s] applying migrations...
[+6.7s] starting orchestrator (background)...
[+67.0s] FAIL timeout waiting for: orchestrator boot
           last observation: UNREACHABLE (Unable to connect. Is the computer able to access the url?)
[+67.0s] TEST FAILED: timeout: orchestrator boot
[+67.0s] stopping orchestrator...
eduardosoto@Eduardos-MacBook-Pro paima-engine % bun scripts/test-pool-health-e2e.ts
auto-detected brew postgres: postgresql@18
[+0.0s] config: SUSTAINED=10000ms FATAL=30000ms
[+0.0s] target: http://localhost:9999/health
[+0.0s] node already listening on http://localhost:9999/health — using it
[+0.0s] PASS baseline healthy  →  HTTP 200 ok consecutive=0 sustainedFor=0.0s sustained=false
[+0.0s] $ brew services stop "postgresql@18" >/dev/null 2>&1 &
    BREW_PID=$!
    while kill -0 $BREW_PID 2>/dev/null; do
      pkill -KILL -f "postgresql@18/bin/postgres" 2>/dev/null || true
      sleep 0.2
    done
    pkill -KILL -f "postgresql@18/bin/postgres" 2>/dev/null || true
[+0.9s] verified: pg unreachable (psql exit 2)
[+0.9s] PASS counter incrementing  →  HTTP 200 ok consecutive=1 sustainedFor=0.5s sustained=false
[+10.5s] PASS sustained=true and HTTP 503  →  HTTP 503 db-unreachable consecutive=11 sustainedFor=10.1s sustained=true
[+31.0s] PASS node exited (fetch fails)  →  UNREACHABLE (Unable to connect. Is the computer able to access the url?)
[+31.0s] $ brew services restart postgresql@18
[+32.5s] phase 7: polling for supervised restart (30s, best-effort)...
[+62.7s] note: no recovery within 30s — supervisor may not be configured (this is not a failure)
[+62.7s] ALL REQUIRED PHASES PASSED
```
