### PR TITLE
fix(release): commit package.json bumps at all depths + reconcile 0.100.18

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,12 +48,14 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Stage ONLY package.json files (root + every package). Thanks to the
-          # script's version-only cleanup, the staged diff is version fields only.
-          git add package.json packages/**/package.json
+          # Stage ONLY package.json files (root + every package, ANY depth).
+          # Quote the pathspec and use git's :(glob) magic so `**` matches nested
+          # dirs (packages/node-sdk/node/...) — bash globstar is off in CI, which
+          # would otherwise collapse `**` to one level and miss most packages.
+          git add package.json ':(glob)packages/**/package.json'
           # Safety net: if anything other than a `version:` line slipped into the
           # staged diff, abort rather than commit unexpected content.
-          if git diff --cached -U0 -- package.json packages/**/package.json \
+          if git diff --cached -U0 -- package.json ':(glob)packages/**/package.json' \
                | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
                | grep -vqE '^[+-][[:space:]]*"version":'; then
             echo "::error::Staged diff contains non-version changes — aborting commit."

--- a/packages/binaries/avail-light-client/package.json
+++ b/packages/binaries/avail-light-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/npm-avail-light-client",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "A wrapper for the Avail Light Client CLI",
   "main": "_index.js",
   "bin": {

--- a/packages/binaries/avail-node/package.json
+++ b/packages/binaries/avail-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/npm-avail-node",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "A wrapper for the Avail node binary",
   "main": "index.js",
   "bin": {

--- a/packages/binaries/bitcoin-core/package.json
+++ b/packages/binaries/bitcoin-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/bitcoin-core",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "type": "module",
   "main": "./index.js",
   "bin": {

--- a/packages/binaries/celestia/package.json
+++ b/packages/binaries/celestia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/celestia",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "type": "module",
   "main": "./index.js",
   "bin": {

--- a/packages/binaries/grafana-alloy/package.json
+++ b/packages/binaries/grafana-alloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/grafana-alloy",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "Grafana Alloy binary wrapper for EffectStream",
   "main": "install.js",
   "bin": {

--- a/packages/binaries/grafana-loki/package.json
+++ b/packages/binaries/grafana-loki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/grafana-loki",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "Grafana Loki binary wrapper for EffectStream",
   "main": "index.js",
   "bin": {

--- a/packages/binaries/midnight-indexer/package.json
+++ b/packages/binaries/midnight-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/npm-midnight-indexer",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "Downloads and runs the Midnight Indexer. It needs a running Midnight Node",
   "main": "index.js",
   "scripts": {

--- a/packages/binaries/midnight-node/package.json
+++ b/packages/binaries/midnight-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/npm-midnight-node",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "Downloads and starts the binary for Midnight Node",
   "main": "index.js",
   "scripts": {

--- a/packages/binaries/midnight-proof-server/package.json
+++ b/packages/binaries/midnight-proof-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/npm-midnight-proof-server",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "A wrapper for the Midnight proof server binary",
   "main": "index.js",
   "bin": {

--- a/packages/binaries/near-sandbox/package.json
+++ b/packages/binaries/near-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/near-sandbox",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "type": "module",
   "main": "./index.js",
   "bin": {

--- a/packages/binaries/ord/package.json
+++ b/packages/binaries/ord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/ord",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "type": "module",
   "main": "./index.js",
   "bin": {

--- a/packages/build-tools/orchestrator/package.json
+++ b/packages/build-tools/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/orchestrator",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/chains/avail-contracts/package.json
+++ b/packages/chains/avail-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/avail-contracts",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/chains/bitcoin-contracts/package.json
+++ b/packages/chains/bitcoin-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/bitcoin-contracts",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/chains/cardano-contracts/package.json
+++ b/packages/chains/cardano-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/cardano-contracts",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/chains/evm-contracts/package.json
+++ b/packages/chains/evm-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/evm-contracts",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "description": "EVM smart contract interfaces for EffectStream",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",

--- a/packages/chains/evm-hardhat/package.json
+++ b/packages/chains/evm-hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/evm-hardhat",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/chains/midnight-contracts/package.json
+++ b/packages/chains/midnight-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/midnight-contracts",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/chain-types/package.json
+++ b/packages/effectstream-sdk/chain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/chain-types",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/concise/package.json
+++ b/packages/effectstream-sdk/concise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/concise",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/config/package.json
+++ b/packages/effectstream-sdk/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/config",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/coroutine/package.json
+++ b/packages/effectstream-sdk/coroutine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/coroutine",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/crypto/package.json
+++ b/packages/effectstream-sdk/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/crypto",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/events/package.json
+++ b/packages/effectstream-sdk/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/event-client",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/log/package.json
+++ b/packages/effectstream-sdk/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/log",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/precompile/package.json
+++ b/packages/effectstream-sdk/precompile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/precompile",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/utils/package.json
+++ b/packages/effectstream-sdk/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/utils",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/effectstream-sdk/wallets/package.json
+++ b/packages/effectstream-sdk/wallets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/wallets",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/db-emulator/package.json
+++ b/packages/node-sdk/db-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/db-emulator",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/db/package.json
+++ b/packages/node-sdk/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/db",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/events/package.json
+++ b/packages/node-sdk/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/event-server",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/node/package.json
+++ b/packages/node-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/node-sdk",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/runtime/package.json
+++ b/packages/node-sdk/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/runtime",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/sm/package.json
+++ b/packages/node-sdk/sm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/sm",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {

--- a/packages/node-sdk/sync/package.json
+++ b/packages/node-sdk/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effectstream/sync",
-  "version": "0.100.17",
+  "version": "0.100.18",
   "license": "MIT",
   "homepage": "https://effectstream.github.io/docs/",
   "repository": {


### PR DESCRIPTION
## Problem

The `v0.100.18` release [published all 37 packages to npm](https://www.npmjs.com/package/@effectstream/node-sdk) correctly, but the commit pushed back to `v-next` (`ebc74c26`) only updated **root + batcher + frontend** — the 34 packages nested two levels deep stayed at `0.100.17` in the repo, drifting from npm.

**Root cause:** `git add packages/**/package.json` in the release workflow. GitHub Actions bash runs with `globstar` **off**, so `**` collapses to a single `*`, matching only `packages/<dir>/package.json` (one level) — bash expands it and git never globs. Verified locally: bash → 2 matches, git `:(glob)` → 38.

## Fix

1. **Workflow** (`fix(release): stage package.json at all depths`): quote the pathspec and use git's `:(glob)` magic — `':(glob)packages/**/package.json'` — for both `git add` and the safety-net `git diff`, so `**` matches all depths regardless of shell globstar. Future releases will commit every package's bump.
2. **Reconcile** (`chore(release): reconcile package versions to 0.100.18`): version-only bump of the 35 lagging publishable packages to `0.100.18` so the repo matches npm + root.

## Verification

- Demonstrated bash (2 files) vs git `:(glob)` (38 files) discrepancy.
- Reconcile diff is strictly version-only across 35 `package.json` files.
- Next release (e.g. `v0.100.19`) would now converge all packages via the fixed `git add`.