### PR TITLE
test(templates): add LINK_LOCAL mode to run template tests against local build

### DIFF
--- a/templates/batcher-validations/link.sh
+++ b/templates/batcher-validations/link.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Link local @effectstream packages from the monorepo into this template.
+# Usage: ./link.sh
+# Run this instead of `bun install` when developing inside the monorepo.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MONOREPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+P="$MONOREPO_ROOT/packages"
+
+echo "Linking @effectstream packages from monorepo..."
+echo "  Monorepo: $MONOREPO_ROOT"
+echo ""
+
+cd "$SCRIPT_DIR"
+bun install 2>/dev/null || bun install --no-save 2>/dev/null || true
+
+NM="$SCRIPT_DIR/node_modules"
+
+link_pkg() {
+  local scope="$1"
+  local short_name="$2"
+  local local_path="$3"
+
+  if [ ! -d "$local_path" ]; then
+    echo "  SKIP @$scope/$short_name (not found at $local_path)"
+    return
+  fi
+
+  mkdir -p "$NM/@$scope"
+  rm -rf "$NM/@$scope/$short_name"
+  ln -sf "$local_path" "$NM/@$scope/$short_name"
+  echo "  LINK @$scope/$short_name -> $(echo "$local_path" | sed "s|$MONOREPO_ROOT/||")"
+}
+
+# Workspace packages (Bun doesn't always create node_modules symlinks for these)
+echo "Linking workspace packages..."
+link_pkg "batcher-validations" "batcher"       "$SCRIPT_DIR/packages/batcher"
+link_pkg "batcher-validations" "contracts-evm" "$SCRIPT_DIR/packages/contracts-evm"
+link_pkg "batcher-validations" "database"      "$SCRIPT_DIR/packages/database"
+link_pkg "batcher-validations" "frontend"      "$SCRIPT_DIR/packages/frontend"
+link_pkg "batcher-validations" "node"          "$SCRIPT_DIR/packages/node"
+link_pkg "batcher-validations" "tests"         "$SCRIPT_DIR/packages/tests"
+
+echo ""
+echo "Linking @effectstream packages from monorepo..."
+link_pkg "effectstream" "batcher-sdk"   "$P/batcher"
+link_pkg "effectstream" "concise"       "$P/effectstream-sdk/concise"
+link_pkg "effectstream" "config"        "$P/effectstream-sdk/config"
+link_pkg "effectstream" "coroutine"     "$P/effectstream-sdk/coroutine"
+link_pkg "effectstream" "db"            "$P/node-sdk/db"
+link_pkg "effectstream" "evm-contracts" "$P/chains/evm-contracts"
+link_pkg "effectstream" "evm-hardhat"   "$P/chains/evm-hardhat"
+link_pkg "effectstream" "log"           "$P/effectstream-sdk/log"
+link_pkg "effectstream" "orchestrator"  "$P/build-tools/orchestrator"
+link_pkg "effectstream" "runtime"       "$P/node-sdk/runtime"
+link_pkg "effectstream" "sm"            "$P/node-sdk/sm"
+link_pkg "effectstream" "wallets"       "$P/effectstream-sdk/wallets"
+
+echo ""
+echo "Done. You can now run: bun run dev"

--- a/templates/run-template-tests.ts
+++ b/templates/run-template-tests.ts
@@ -5,11 +5,25 @@
  * Usage:
  *   bun run templates/run-template-tests.ts                      # all enabled
  *   bun run templates/run-template-tests.ts preorder shinkai-v2   # specific ones
+ *
+ * Env:
+ *   LINK_LOCAL=1   After `bun install`, run each template's ./link.sh so the
+ *                  tests resolve @effectstream/* to the local monorepo build
+ *                  instead of the published packages. Every selected template
+ *                  MUST have a link.sh or the run aborts before any tests run.
+ *                  Also runs `bun install` at the monorepo root up front, since
+ *                  the linked orchestrator resolves some deps from the root
+ *                  workspace's node_modules.
  */
 import { exit } from "process";
+import fs from "fs";
 import path from "path";
 
 const __dirname = import.meta.dirname!;
+
+const LINK_LOCAL = ["1", "true", "yes"].includes(
+  (process.env.LINK_LOCAL ?? "").toLowerCase(),
+);
 
 const ENABLED = [
   "cardano-delegation",
@@ -64,6 +78,25 @@ async function runTemplate(name: string): Promise<Result> {
       };
     }
 
+    if (LINK_LOCAL) {
+      console.log(`\n> ./link.sh\n`);
+      const link = Bun.spawn(["bash", "./link.sh"], {
+        cwd: dir,
+        stdout: "inherit",
+        stderr: "inherit",
+        env: { ...process.env },
+      });
+      const linkExit = await link.exited;
+      if (linkExit !== 0) {
+        return {
+          name,
+          success: false,
+          duration: Date.now() - start,
+          error: `link.sh failed (exit code ${linkExit})`,
+        };
+      }
+    }
+
     const proc = Bun.spawn(["bun", "run", "test"], {
       cwd: dir,
       stdout: "inherit",
@@ -96,6 +129,36 @@ async function main() {
   if (selected.length === 0) {
     console.error("No matching templates. Enabled:", ENABLED.join(", "));
     exit(1);
+  }
+
+  if (LINK_LOCAL) {
+    const missing = selected.filter(
+      (name) => !fs.existsSync(path.join(__dirname, name, "link.sh")),
+    );
+    if (missing.length > 0) {
+      console.error(
+        `LINK_LOCAL is set but these template(s) have no link.sh: ${missing.join(", ")}`,
+      );
+      exit(1);
+    }
+
+    // link.sh symlinks @effectstream/* to monorepo source. The linked
+    // orchestrator resolves some deps (e.g. @effectstream/db/start-pglite) via
+    // import.meta.resolve, which walks the monorepo's own node_modules — so the
+    // root workspace must be installed first or that resolution fails.
+    const root = path.join(__dirname, "..");
+    console.log("LINK_LOCAL=1: running `bun install` at monorepo root\n");
+    const rootInstall = Bun.spawn(["bun", "install"], {
+      cwd: root,
+      stdout: "inherit",
+      stderr: "inherit",
+      env: { ...process.env },
+    });
+    if ((await rootInstall.exited) !== 0) {
+      console.error("Monorepo root `bun install` failed");
+      exit(1);
+    }
+    console.log("\nLINK_LOCAL=1: linking local monorepo packages after install\n");
   }
 
   console.log(`Running tests for ${selected.length} template(s): ${selected.join(", ")}\n`);

--- a/templates/zswap-da/link.sh
+++ b/templates/zswap-da/link.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Link local @effectstream packages from the monorepo into this template.
+# Usage: ./link.sh
+# Run this instead of `bun install` when developing inside the monorepo.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MONOREPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+P="$MONOREPO_ROOT/packages"
+
+echo "Linking @effectstream packages from monorepo..."
+echo "  Monorepo: $MONOREPO_ROOT"
+echo ""
+
+cd "$SCRIPT_DIR"
+bun install 2>/dev/null || bun install --no-save 2>/dev/null || true
+
+NM="$SCRIPT_DIR/node_modules"
+
+link_pkg() {
+  local scope="$1"
+  local short_name="$2"
+  local local_path="$3"
+
+  if [ ! -d "$local_path" ]; then
+    echo "  SKIP @$scope/$short_name (not found at $local_path)"
+    return
+  fi
+
+  mkdir -p "$NM/@$scope"
+  rm -rf "$NM/@$scope/$short_name"
+  ln -sf "$local_path" "$NM/@$scope/$short_name"
+  echo "  LINK @$scope/$short_name -> $(echo "$local_path" | sed "s|$MONOREPO_ROOT/||")"
+}
+
+# Workspace packages (Bun doesn't always create node_modules symlinks for these)
+echo "Linking workspace packages..."
+link_pkg "zswap-da" "batcher"             "$SCRIPT_DIR/packages/batcher"
+link_pkg "zswap-da" "contracts-celestia"  "$SCRIPT_DIR/packages/contracts-celestia"
+link_pkg "zswap-da" "contracts-midnight"  "$SCRIPT_DIR/packages/contracts-midnight"
+link_pkg "zswap-da" "contract-offer-files" "$SCRIPT_DIR/packages/contracts-midnight/contract-offer-files"
+link_pkg "zswap-da" "database"            "$SCRIPT_DIR/packages/database"
+link_pkg "zswap-da" "frontend"            "$SCRIPT_DIR/packages/frontend"
+link_pkg "zswap-da" "node"                "$SCRIPT_DIR/packages/node"
+link_pkg "zswap-da" "tests"               "$SCRIPT_DIR/packages/tests"
+
+echo ""
+echo "Linking @effectstream packages from monorepo..."
+link_pkg "effectstream" "batcher-sdk"               "$P/batcher"
+link_pkg "effectstream" "celestia"                  "$P/binaries/celestia"
+link_pkg "effectstream" "concise"                   "$P/effectstream-sdk/concise"
+link_pkg "effectstream" "config"                    "$P/effectstream-sdk/config"
+link_pkg "effectstream" "coroutine"                 "$P/effectstream-sdk/coroutine"
+link_pkg "effectstream" "db"                        "$P/node-sdk/db"
+link_pkg "effectstream" "log"                       "$P/effectstream-sdk/log"
+link_pkg "effectstream" "midnight-contracts"        "$P/chains/midnight-contracts"
+link_pkg "effectstream" "npm-midnight-indexer"      "$P/binaries/midnight-indexer"
+link_pkg "effectstream" "npm-midnight-node"         "$P/binaries/midnight-node"
+link_pkg "effectstream" "npm-midnight-proof-server" "$P/binaries/midnight-proof-server"
+link_pkg "effectstream" "orchestrator"              "$P/build-tools/orchestrator"
+link_pkg "effectstream" "runtime"                   "$P/node-sdk/runtime"
+link_pkg "effectstream" "sm"                        "$P/node-sdk/sm"
+link_pkg "effectstream" "utils"                     "$P/effectstream-sdk/utils"
+
+# When @effectstream/midnight-contracts is linked to monorepo source, its
+# node_modules/@midnight-ntwrk/* symlinks point to the monorepo root's .bun/ copies.
+# The template has its own copies in its .bun/ cache. Two WASM copies = instanceof failure.
+# Fix: redirect ALL @midnight-ntwrk symlinks to the template's .bun/ copies.
+echo ""
+echo "Fixing @midnight-ntwrk WASM resolution for linked packages..."
+LINKED_MC="$P/chains/midnight-contracts/node_modules/@midnight-ntwrk"
+if [ -d "$LINKED_MC" ]; then
+  for pkg_path in "$LINKED_MC"/*/; do
+    pkg=$(basename "$pkg_path")
+    src=$(find "$NM/.bun" -maxdepth 1 -type d -name "@midnight-ntwrk+${pkg}@*" | sort -V | tail -1)
+    if [ -n "$src" ] && [ -d "$src/node_modules/@midnight-ntwrk/$pkg" ]; then
+      rm -rf "$LINKED_MC/$pkg"
+      ln -sf "$src/node_modules/@midnight-ntwrk/$pkg" "$LINKED_MC/$pkg"
+      echo "  RELINK @midnight-ntwrk/$pkg"
+    fi
+  done
+fi
+
+echo ""
+echo "Done. You can now run: bun run dev"


### PR DESCRIPTION
## Summary
- New `LINK_LOCAL=1` env in `templates/run-template-tests.ts`: runs each template's `link.sh` after `bun install` so tests resolve `@effectstream/*` to the local monorepo build instead of the published packages.
- Runs `bun install` at the monorepo root up front under `LINK_LOCAL` (the linked orchestrator resolves some deps via `import.meta.resolve` from the root workspace's `node_modules`); aborts cleanly up front if any selected template lacks a `link.sh`.
- Adds the missing `link.sh` for `zswap-da` and `batcher-validations` so the full enabled set can run with linking.

Default behavior (no `LINK_LOCAL`) is unchanged. Linking is top-level only, matching the other templates' existing `link.sh`.

## Test plan
- [x] `bun run templates/run-template-tests.ts` (no env) — unchanged behavior.
- [x] `LINK_LOCAL=1 bun run templates/run-template-tests.ts` — full suite: **8/9 PASS**, only `zswap-da` fails on the environmental Celestia GLIBC 2.38 issue (unrelated to this change).
- [x] Pre-flight aborts with a clear error if any selected template has no `link.sh`.
- [x] `evm-midnight-v2` confirmed reproducible after a flaky run (passes on re-run).