### PR TITLE
fix(wallets): implement IProvider.sendTransaction on EvmViem (with receipt verification)

### DIFF
--- a/packages/effectstream-sdk/wallets/src/effectstream.ts
+++ b/packages/effectstream-sdk/wallets/src/effectstream.ts
@@ -5,6 +5,7 @@ import { type Chain, numberToHex } from "viem";
 import { utf8ToHex } from "web3-utils";
 import type { EthersEvmProvider } from "./evm/ethers.ts";
 import type { EvmInjectedProvider } from "./evm/injected.ts";
+import type { ViemEvmProvider } from "./evm/viem.ts";
 import type { AbiItem } from "web3-utils";
 import { type TransactionReceipt, Web3 } from "web3";
 import { createMessageForBatcher } from "@effectstream/concise";
@@ -189,7 +190,8 @@ export async function sendSelfSequencedTransaction(
 
   const evmProvider = wallet.provider as
     | EthersEvmProvider
-    | EvmInjectedProvider;
+    | EvmInjectedProvider
+    | ViemEvmProvider;
 
   const hexData = utf8ToHex(JSON.stringify(conciseData));
   const effectstreamL2Contract = await effectstreamConfig.getEffectstreamL2Contract();

--- a/packages/effectstream-sdk/wallets/src/evm/viem.ts
+++ b/packages/effectstream-sdk/wallets/src/evm/viem.ts
@@ -1,4 +1,5 @@
 import {
+  createPublicClient,
   createWalletClient,
   http,
   type Chain,
@@ -165,6 +166,28 @@ export class ViemEvmProvider implements IProvider<ViemApi> {
     if (typeof hash !== "string") {
       throw new Error(
         `[ViemEvmProvider.sendTransaction] expected string tx hash, got ${typeof hash}`,
+      );
+    }
+
+    // Wait for the receipt + verify status. viem's sendTransaction returns
+    // the hash as soon as the tx is broadcast, NOT once it has mined. If we
+    // returned the hash without checking the receipt, a reverted tx would
+    // look "successful" to the engine's `wait-receipt` confirmation path,
+    // and the indexer would never see a matching event because the contract
+    // call reverted on chain. Match the EvmInjected / EthersEvmProvider
+    // contract: only return when the tx is mined AND its status is 0x1.
+    const chain = (this.conn.api as WalletClient).chain;
+    const transport = (this.conn.api as WalletClient).transport;
+    const publicClient = createPublicClient({
+      chain: chain ?? undefined,
+      transport: http((transport as { url?: string })?.url),
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: hash as `0x${string}`,
+    });
+    if (receipt.status !== "success") {
+      throw new Error(
+        `[ViemEvmProvider.sendTransaction] tx ${hash} reverted on chain (status=${receipt.status})`,
       );
     }
     return { txHash: hash };

--- a/packages/effectstream-sdk/wallets/src/evm/viem.ts
+++ b/packages/effectstream-sdk/wallets/src/evm/viem.ts
@@ -119,4 +119,54 @@ export class ViemEvmProvider implements IProvider<ViemApi> {
       message,
     });
   };
+
+  /**
+   * Submit an EIP-1193-shaped transaction request (matching the
+   * `EvmInjectedProvider.sendTransaction` shape — all numeric fields are
+   * hex strings) by delegating to viem's hoisted `walletClient.sendTransaction`.
+   *
+   * `account` + `chain` are hoisted on the underlying `WalletClient` at
+   * connect time (see `ViemConnector.connectFromPrivateKey`), so we only
+   * need to convert the hex-string numeric fields to bigints that viem
+   * expects, and pass through `to` / `data` as 0x-strings.
+   *
+   * Without this method, the high-level `sendTransaction(wallet, …)` helper
+   * in `effectstream.ts` rejects with `evmProvider.sendTransaction is not a
+   * function` when invoked against a `WalletMode.EvmViem` wallet — blocking
+   * any frontend that wants to drive the engine's tx flow via the local-JS
+   * wallet (e.g. headless Playwright e2e tests).
+   */
+  sendTransaction = async (tx: {
+    to?: string;
+    from: string;
+    gas?: string;
+    gasPrice?: string;
+    data: string;
+    value?: string;
+    maxPriorityFeePerGas?: string;
+    maxFeePerGas?: string;
+  }): Promise<{ txHash: string }> => {
+    if (this.account == null) {
+      throw new Error("ViemEvmProvider.sendTransaction: account is missing");
+    }
+    const toBigInt = (h?: string): bigint | undefined =>
+      h == null ? undefined : BigInt(h);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const hash = await (this.conn.api as any).sendTransaction({
+      account: this.account,
+      to: tx.to as `0x${string}` | undefined,
+      data: tx.data as `0x${string}`,
+      value: toBigInt(tx.value),
+      gas: toBigInt(tx.gas),
+      gasPrice: toBigInt(tx.gasPrice),
+      maxFeePerGas: toBigInt(tx.maxFeePerGas),
+      maxPriorityFeePerGas: toBigInt(tx.maxPriorityFeePerGas),
+    });
+    if (typeof hash !== "string") {
+      throw new Error(
+        `[ViemEvmProvider.sendTransaction] expected string tx hash, got ${typeof hash}`,
+      );
+    }
+    return { txHash: hash };
+  };
 }


### PR DESCRIPTION
## Summary

Implements `IProvider.sendTransaction` on the `WalletMode.EvmViem` provider so frontends using the local-JS wallet can drive the engine's high-level `sendTransaction(wallet, …)` flow end-to-end. Before this PR, calling that helper with an EvmViem wallet rejected with:

```
evmProvider.sendTransaction is not a function
```

— blocking headless Playwright e2e tests, dev tooling, and any code that wanted to use the local-JS wallet through the engine's tx surface instead of poking viem's `walletClient.writeContract` directly.

## Changes

- **`packages/effectstream-sdk/wallets/src/evm/viem.ts`** — add `sendTransaction` method on `ViemEvmProvider`. Matches the EvmInjected / EthersEvmProvider shape (`Web3TransactionRequest` in, `{ txHash: string }` out): converts hex-string numeric fields to bigints, delegates to the hoisted `walletClient.sendTransaction`, then `waitForTransactionReceipt` and asserts `status === 'success'` so a reverted tx doesn't silently look successful.
- **`packages/effectstream-sdk/wallets/src/effectstream.ts`** — include `ViemEvmProvider` in the type union for `wallet.provider` inside `sendSelfSequencedTransaction`.

## Test plan

- [x] `bun build packages/effectstream-sdk/wallets/src/evm/viem.ts --target=bun` — exit 0.
- [x] `bun test packages/effectstream-sdk/wallets/src/evm/viem.test.ts` — 2 pass, 0 fail (existing tests).
- [x] Consumed by [`feat/template-world-map-2d-migrate-to-0.100.18`](https://github.com/effectstream/effectstream/pull/733) — the LINK_LOCAL Phase C e2e drives `submitMove(4,4)` via the EvmViem wallet and verifies the chain receipt end-to-end. 19/19 PASS.

## Follow-up (not in this PR)

The world-map-2d e2e currently asserts the chain receipt resolves cleanly but does NOT yet assert that the indexer parses the resulting event into a DB row. The reverted-tx case is now correctly surfaced (was silent before), but with the receipt check green the indexer still does not observe a 'Creating scheduled data for Effectstream L2 input …' log for the e2e-submitted move. Suspected calldata-encoding mismatch between the engine's web3-encoder (`effectstreamL2Contract.methods.effectstreamSubmitGameInput(hexData).encodeABI()` in `sendSelfSequencedTransaction`) and what the EVM primitive's event-parser expects. Tracked in the world-map-2d `e2e.test.ts` with a reproducer.