### PR TITLE
feat(wallets): expose full Midnight WalletFacade through MidnightLocalConnector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -460,7 +460,7 @@
     },
     "packages/batcher": {
       "name": "@effectstream/batcher-sdk",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/event-client": "workspace:*",
@@ -503,7 +503,7 @@
     },
     "packages/binaries/avail-light-client": {
       "name": "@effectstream/npm-avail-light-client",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "npm-avail-light-client": "index.js",
       },
@@ -514,7 +514,7 @@
     },
     "packages/binaries/avail-node": {
       "name": "@effectstream/npm-avail-node",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "npm-avail-node": "index.js",
       },
@@ -525,7 +525,7 @@
     },
     "packages/binaries/bitcoin-core": {
       "name": "@effectstream/bitcoin-core",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "bitcoin-core": "./index.js",
       },
@@ -535,7 +535,7 @@
     },
     "packages/binaries/celestia": {
       "name": "@effectstream/celestia",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "celestia": "./index.js",
       },
@@ -545,7 +545,7 @@
     },
     "packages/binaries/grafana-alloy": {
       "name": "@effectstream/grafana-alloy",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "grafana-alloy": "index.js",
       },
@@ -555,7 +555,7 @@
     },
     "packages/binaries/grafana-loki": {
       "name": "@effectstream/grafana-loki",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "grafana-loki": "index.js",
       },
@@ -565,7 +565,7 @@
     },
     "packages/binaries/midnight-indexer": {
       "name": "@effectstream/npm-midnight-indexer",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "npm-midnight-indexer": "index.js",
       },
@@ -578,7 +578,7 @@
     },
     "packages/binaries/midnight-node": {
       "name": "@effectstream/npm-midnight-node",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "npm-midnight-node": "index.js",
       },
@@ -590,7 +590,7 @@
     },
     "packages/binaries/midnight-proof-server": {
       "name": "@effectstream/npm-midnight-proof-server",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "npm-midnight-proof-server": "index.js",
       },
@@ -601,7 +601,7 @@
     },
     "packages/binaries/near-sandbox": {
       "name": "@effectstream/near-sandbox",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "near-sandbox": "./index.js",
       },
@@ -611,7 +611,7 @@
     },
     "packages/binaries/ord": {
       "name": "@effectstream/ord",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "ord": "./index.js",
       },
@@ -646,7 +646,7 @@
     },
     "packages/build-tools/orchestrator": {
       "name": "@effectstream/orchestrator",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "bin": {
         "orchestrator": "src/cli.ts",
       },
@@ -656,11 +656,11 @@
     },
     "packages/chains/avail-contracts": {
       "name": "@effectstream/avail-contracts",
-      "version": "0.100.16",
+      "version": "0.100.18",
     },
     "packages/chains/bitcoin-contracts": {
       "name": "@effectstream/bitcoin-contracts",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "bitcoinjs-lib": "^7.0.0",
         "ecpair": "^3.0.0",
@@ -669,11 +669,11 @@
     },
     "packages/chains/cardano-contracts": {
       "name": "@effectstream/cardano-contracts",
-      "version": "0.100.16",
+      "version": "0.100.18",
     },
     "packages/chains/evm-contracts": {
       "name": "@effectstream/evm-contracts",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@nomicfoundation/hardhat-ignition": "3.0.2",
         "@nomicfoundation/hardhat-ignition-viem": "3.0.2",
@@ -688,7 +688,7 @@
     },
     "packages/chains/evm-hardhat": {
       "name": "@effectstream/evm-hardhat",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -705,7 +705,7 @@
     },
     "packages/chains/midnight-contracts": {
       "name": "@effectstream/midnight-contracts",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@midnight-ntwrk/compact-js": "2.5.0",
@@ -738,14 +738,14 @@
     },
     "packages/effectstream-sdk/chain-types": {
       "name": "@effectstream/chain-types",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/concise": {
       "name": "@effectstream/concise",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -756,7 +756,7 @@
     },
     "packages/effectstream-sdk/config": {
       "name": "@effectstream/config",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@dcspark/carp-client": "^3.3.0",
         "@dcspark/cip34-js": "3.0.1",
@@ -773,7 +773,7 @@
     },
     "packages/effectstream-sdk/coroutine": {
       "name": "@effectstream/coroutine",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@pgtyped/parser": "2.4.2",
@@ -785,7 +785,7 @@
     },
     "packages/effectstream-sdk/crypto": {
       "name": "@effectstream/crypto",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
         "@effectstream/utils": "workspace:*",
@@ -812,7 +812,7 @@
     },
     "packages/effectstream-sdk/events": {
       "name": "@effectstream/event-client",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -826,7 +826,7 @@
     },
     "packages/effectstream-sdk/log": {
       "name": "@effectstream/log",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
@@ -848,14 +848,14 @@
     },
     "packages/effectstream-sdk/precompile": {
       "name": "@effectstream/precompile",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/utils": {
       "name": "@effectstream/utils",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@foxglove/crc": "^1.0.1",
@@ -876,7 +876,7 @@
     },
     "packages/effectstream-sdk/wallets": {
       "name": "@effectstream/wallets",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@aurowallet/mina-provider": "^1.0.12",
         "@effectstream/concise": "workspace:*",
@@ -902,6 +902,7 @@
         "web3-utils": "^4.3.3",
       },
       "devDependencies": {
+        "@effectstream/midnight-contracts": "workspace:*",
         "@lucid-evolution/lucid": "^0.4.30",
         "@lucid-evolution/provider": "^0.1.91",
         "@lucid-evolution/utils": "^0.1.66",
@@ -910,6 +911,7 @@
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.1.0",
       },
       "peerDependencies": {
+        "@effectstream/midnight-contracts": "workspace:*",
         "@lucid-evolution/lucid": "^0.4.29",
         "@lucid-evolution/provider": "^0.1.90",
         "@lucid-evolution/utils": "^0.1.66",
@@ -918,6 +920,7 @@
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^2.1.0",
       },
       "optionalPeers": [
+        "@effectstream/midnight-contracts",
         "@lucid-evolution/lucid",
         "@lucid-evolution/provider",
         "@lucid-evolution/utils",
@@ -928,14 +931,14 @@
     },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/wallets": "workspace:*",
       },
     },
     "packages/node-sdk/db": {
       "name": "@effectstream/db",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/coroutine": "workspace:*",
         "@effectstream/log": "workspace:*",
@@ -958,7 +961,7 @@
     },
     "packages/node-sdk/db-emulator": {
       "name": "@effectstream/db-emulator",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@pgtyped/runtime": "2.4.2",
         "effection": "^3.5.0",
@@ -967,7 +970,7 @@
     },
     "packages/node-sdk/events": {
       "name": "@effectstream/event-server",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -975,7 +978,7 @@
     },
     "packages/node-sdk/node": {
       "name": "@effectstream/node-sdk",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/chain-types": "workspace:*",
         "@effectstream/concise": "workspace:*",
@@ -993,7 +996,7 @@
     },
     "packages/node-sdk/runtime": {
       "name": "@effectstream/runtime",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1025,7 +1028,7 @@
     },
     "packages/node-sdk/sm": {
       "name": "@effectstream/sm",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1047,7 +1050,7 @@
     },
     "packages/node-sdk/sync": {
       "name": "@effectstream/sync",
-      "version": "0.100.16",
+      "version": "0.100.18",
       "dependencies": {
         "@cardano-sdk/core": "^0.46.11",
         "@cardano-sdk/util": "^0.17.1",

--- a/packages/effectstream-sdk/wallets/package.json
+++ b/packages/effectstream-sdk/wallets/package.json
@@ -18,6 +18,7 @@
     "./midnight-local": "./src/midnight/local.ts"
   },
   "peerDependencies": {
+    "@effectstream/midnight-contracts": "workspace:*",
     "@lucid-evolution/lucid": "^0.4.29",
     "@lucid-evolution/provider": "^0.1.90",
     "@lucid-evolution/utils": "^0.1.66",
@@ -26,6 +27,7 @@
     "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^2.1.0"
   },
   "peerDependenciesMeta": {
+    "@effectstream/midnight-contracts": { "optional": true },
     "@lucid-evolution/lucid": { "optional": true },
     "@lucid-evolution/provider": { "optional": true },
     "@lucid-evolution/utils": { "optional": true },
@@ -34,6 +36,7 @@
     "@midnight-ntwrk/wallet-sdk-unshielded-wallet": { "optional": true }
   },
   "devDependencies": {
+    "@effectstream/midnight-contracts": "workspace:*",
     "@lucid-evolution/lucid": "^0.4.30",
     "@lucid-evolution/provider": "^0.1.91",
     "@lucid-evolution/utils": "^0.1.66",

--- a/packages/effectstream-sdk/wallets/src/midnight/local.test.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/local.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { AddressType } from "@effectstream/utils";
 import { verifySignature } from "@midnight-ntwrk/ledger-v8";
@@ -53,6 +53,81 @@ describe("MidnightLocalProvider", () => {
       innerSig as never,
     );
     expect(okAgain).toBe(true);
+  });
+
+  test("facade mode: networkUrls triggers buildWalletFacade and exposes the full WalletFacade on the api", async () => {
+    // Sentinel objects so we can assert the facade-path code actually wired
+    // through whatever buildWalletFacade returned.
+    const fakeFacade = { __kind: "WalletFacade", shielded: {}, dust: {}, unshielded: {} };
+    const fakeShielded = {
+      address: {
+        coinPublicKeyString: () => "deadbeef-coin-pub-key",
+        encryptionPublicKeyString: () => "deadbeef-enc-pub-key",
+      },
+      balances: {},
+    };
+    const buildSpy = mock(async (
+      networkUrls: unknown,
+      seed: string,
+      _networkId: unknown,
+      _syncMode: unknown,
+    ) => ({
+      wallet: fakeFacade,
+      zswapSecretKeys: {} as never,
+      walletZswapSecretKeys: {} as never,
+      dustSecretKey: {} as never,
+      walletDustSecretKey: {} as never,
+      dustAddress: `dust-for-${seed.slice(0, 8)}`,
+      unshieldedAddress: `unshielded-for-${seed.slice(0, 8)}`,
+      unshieldedKeystore: {} as never,
+      __echoedNetworkUrls: networkUrls,
+    }));
+    const getInitialSpy = mock(async (_shielded: unknown) => fakeShielded);
+
+    mock.module("@effectstream/midnight-contracts", () => ({
+      buildWalletFacade: buildSpy,
+      getInitialShieldedState: getInitialSpy,
+    }));
+
+    const provider = await MidnightLocalConnector.instance().connectFromSeed({
+      seed: DETERMINISTIC_SEED,
+      networkId: "undeployed",
+      networkUrls: {
+        indexer: "http://127.0.0.1:8088/api/v3/graphql",
+        indexerWS: "ws://127.0.0.1:8088/api/v3/graphql/ws",
+        node: "http://127.0.0.1:9944",
+        proofServer: "http://127.0.0.1:6300",
+      },
+    });
+
+    expect(buildSpy).toHaveBeenCalledTimes(1);
+    const [networkUrlsArg, seedArg, networkIdArg, syncModeArg] = buildSpy.mock.calls[0]!;
+    expect(seedArg).toBe(DETERMINISTIC_SEED);
+    expect(networkIdArg).toBe("undeployed");
+    expect(syncModeArg).toBe("all");
+    expect(networkUrlsArg).toMatchObject({
+      indexer: "http://127.0.0.1:8088/api/v3/graphql",
+      indexerWS: "ws://127.0.0.1:8088/api/v3/graphql/ws",
+      node: "http://127.0.0.1:9944",
+      proofServer: "http://127.0.0.1:6300",
+      id: "undeployed",
+    });
+
+    const api = provider.getConnection().api as unknown as MidnightLocalApi;
+    expect(api.walletFacade).toBe(fakeFacade);
+    expect(api.dustAddress).toBe(`dust-for-${DETERMINISTIC_SEED.slice(0, 8)}`);
+    expect(api.shieldedAddress).toBe("deadbeef-coin-pub-key");
+
+    // getShieldedAddresses no longer throws in facade mode.
+    await expect(api.getShieldedAddresses()).resolves.toEqual({
+      shieldedAddress: "deadbeef-coin-pub-key",
+    });
+
+    expect(provider.getConnection().metadata.displayName).toBe(
+      "Midnight (local seed, facade)",
+    );
+
+    mock.restore();
   });
 
   test("signMessage round-trips through CryptoManager.Midnight().verifySignature", async () => {

--- a/packages/effectstream-sdk/wallets/src/midnight/local.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/local.ts
@@ -8,20 +8,55 @@ import type {
 } from "../IProvider.ts";
 import type { MidnightApi } from "./midnight.ts";
 
+/**
+ * Network endpoints required to bring up the full WalletFacade. Mirrors
+ * `NetworkUrls` from `@effectstream/midnight-contracts` but with every field
+ * required (so consumers can't accidentally leave one unset).
+ */
+export type MidnightLocalNetworkUrls = {
+  /** GraphQL indexer HTTP endpoint. */
+  indexer: string;
+  /** GraphQL indexer WebSocket endpoint. */
+  indexerWS: string;
+  /** Midnight node RPC endpoint (used as the wallet relay; http→ws is rewritten internally). */
+  node: string;
+  /** Proof-server HTTP endpoint. */
+  proofServer: string;
+  /** Optional network id override; defaults to `connectFromSeed`'s `networkId` arg. */
+  id?: string;
+};
+
+export type MidnightLocalSyncMode = "all" | "dust-only";
+
 export type MidnightLocalConnectArgs = {
   /** 64-character hex seed. Generated when omitted. */
   seed?: string;
   /** Midnight network id — sets the bech32 prefix on the unshielded address. */
   networkId: string;
+  /**
+   * Network URLs for the full WalletFacade. When supplied, the connector builds
+   * a complete wallet (shielded + dust + unshielded) via
+   * `@effectstream/midnight-contracts.buildWalletFacade` and exposes it on
+   * `getConnection().api.walletFacade`. Required for shielded tx submission,
+   * `balanceAndProveTransaction`, dust fee payment, etc.
+   *
+   * When omitted, the connector returns the signing-only path (unshielded
+   * keystore `signData`) — useful for offline signature flows or signature
+   * verification dry runs that don't need to stand up indexer + proof-server.
+   */
+  networkUrls?: MidnightLocalNetworkUrls;
+  /** Defaults to "all" when `networkUrls` is supplied. Ignored otherwise. */
+  syncMode?: MidnightLocalSyncMode;
 };
 
 /**
- * Shape exposed on `getConnection().api`. A minimal subset of `ConnectedAPI`
+ * Shape exposed on `getConnection().api`. Mirrors a subset of `ConnectedAPI`
  * that the rest of Effectstream's Midnight code consumes:
- *   - `signData` mirrors the dapp-connector-api shape.
- *   - `getShieldedAddresses` is stubbed (shielded sync is out of scope for the
- *     lite/seed-only path — callers that need shielded/dust addresses should
- *     build the full WalletFacade via `@effectstream/midnight-contracts`).
+ *   - `signData` mirrors the dapp-connector-api shape (works in both modes).
+ *   - `getShieldedAddresses` returns the real shielded coin public key when
+ *     the full facade is built; throws in signing-only mode.
+ *   - `walletFacade` / `dustAddress` / `shieldedAddress` are populated only
+ *     when `networkUrls` was supplied at connect time.
  */
 export type MidnightLocalApi = {
   signData: (
@@ -35,6 +70,28 @@ export type MidnightLocalApi = {
   verifyingKey: string;
   /** Bech32-encoded unshielded address. */
   unshieldedAddress: string;
+  /**
+   * Full Midnight `WalletFacade`. Populated only when `networkUrls` was passed
+   * to `connectFromSeed`. Cast to
+   * `import("@midnight-ntwrk/wallet-sdk-facade").WalletFacade` for typed
+   * access. Carries `submitTransaction`, `balanceFinalizedTransaction`,
+   * `balanceUnboundTransaction`, `balanceUnprovenTransaction`, `signRecipe`,
+   * `signUnprovenTransaction`, `state()`, `waitForSyncedState()`, etc.
+   */
+  walletFacade?: unknown;
+  /** Bech32-encoded dust address. Populated only in facade mode. */
+  dustAddress?: string;
+  /** Hex-encoded shielded coin public key. Populated only in facade mode. */
+  shieldedAddress?: string;
+  /**
+   * Escape hatch: the entire `WalletResult` returned by
+   * `@effectstream/midnight-contracts.buildWalletFacade`. Exposes the raw
+   * secret keys (`zswapSecretKeys`, `dustSecretKey`, `unshieldedKeystore`) that
+   * advanced flows (manual tx balancing, custom dust handling) need. Cast to
+   * `import("@effectstream/midnight-contracts").WalletResult`.
+   * Populated only in facade mode.
+   */
+  walletResult?: unknown;
 };
 
 export class MidnightLocalConnector {
@@ -51,27 +108,34 @@ export class MidnightLocalConnector {
   /**
    * Build a Midnight wallet identity from a hex seed.
    *
-   * This is the "lite" / signing-only path: it derives the unshielded
-   * keystore from the seed and exposes a CIP-30-shaped `signData` backed by
-   * `unshieldedKeystore.signData(...)`. It does NOT bring up the shielded /
-   * dust wallets — that requires a live indexer + proof server and lives in
-   * `@effectstream/midnight-contracts`'s `buildWalletFacade`.
+   * Two modes, picked by whether `args.networkUrls` is supplied:
+   *
+   *  - **Facade mode** (`networkUrls` set): builds the full Midnight wallet via
+   *    `@effectstream/midnight-contracts.buildWalletFacade` — shielded + dust +
+   *    unshielded sub-wallets, connected to a live indexer + node + proof
+   *    server. The complete `WalletFacade` is exposed on
+   *    `getConnection().api.walletFacade`, enabling `submitTransaction`,
+   *    `balanceAndProveTransaction`, dust fee payment, etc. Requires
+   *    `@effectstream/midnight-contracts` to be installed (optional peer dep).
+   *
+   *  - **Signing-only mode** (`networkUrls` omitted): derives the unshielded
+   *    keystore from the seed and exposes a CIP-30-shaped `signData` backed by
+   *    `unshieldedKeystore.signData(...)`. No network IO. Suitable for offline
+   *    signature flows and signature-verification dry runs.
    */
   connectFromSeed = async (
     args: MidnightLocalConnectArgs,
   ): Promise<MidnightLocalProvider> => {
-    const hdMod = await import("@midnight-ntwrk/wallet-sdk-hd").catch(() => {
-      throw new Error(
-        "@midnight-ntwrk/wallet-sdk-hd is required for WalletMode.MidnightLocal.",
-      );
-    });
-    const keystoreMod = await import(
-      "@midnight-ntwrk/wallet-sdk-unshielded-wallet"
-    ).catch(() => {
-      throw new Error(
-        "@midnight-ntwrk/wallet-sdk-unshielded-wallet is required for WalletMode.MidnightLocal.",
-      );
-    });
+    if (args.networkUrls != null) {
+      return await this.connectWithFacade(args, args.networkUrls);
+    }
+    return await this.connectSigningOnly(args);
+  };
+
+  private connectSigningOnly = async (
+    args: MidnightLocalConnectArgs,
+  ): Promise<MidnightLocalProvider> => {
+    const { hdMod, keystoreMod } = await loadKeystoreDeps();
 
     const seed = args.seed ?? generateRandomHexSeed(32);
     const unshieldedSeed = deriveUnshieldedSeed(
@@ -102,7 +166,7 @@ export class MidnightLocalConnector {
       },
       getShieldedAddresses: async () => {
         throw new Error(
-          "MidnightLocal lite mode does not expose a shielded address. Build a WalletFacade via @effectstream/midnight-contracts for shielded/dust support.",
+          "MidnightLocal signing-only mode does not expose a shielded address. Pass `networkUrls` to connectFromSeed to build the full WalletFacade.",
         );
       },
       seed,
@@ -121,6 +185,90 @@ export class MidnightLocalConnector {
     this.provider = new MidnightLocalProvider(
       conn,
       unshieldedAddress as MidnightAddress,
+      unshieldedKeystore,
+    );
+    return this.provider;
+  };
+
+  private connectWithFacade = async (
+    args: MidnightLocalConnectArgs,
+    networkUrls: MidnightLocalNetworkUrls,
+  ): Promise<MidnightLocalProvider> => {
+    const contractsMod = await import(
+      "@effectstream/midnight-contracts"
+    ).catch(() => {
+      throw new Error(
+        "@effectstream/midnight-contracts is required when `networkUrls` is passed to MidnightLocal.connectFromSeed. Install it as a peer dependency.",
+      );
+    });
+    const { hdMod, keystoreMod } = await loadKeystoreDeps();
+
+    const seed = args.seed ?? generateRandomHexSeed(32);
+    const unshieldedSeed = deriveUnshieldedSeed(
+      hdMod,
+      seed,
+      hdMod.Roles.NightExternal,
+    );
+    const unshieldedKeystore = keystoreMod.createKeystore(
+      unshieldedSeed,
+      args.networkId as never,
+    );
+    const verifyingKey = String(unshieldedKeystore.getPublicKey());
+
+    const fullNetworkUrls = {
+      indexer: networkUrls.indexer,
+      indexerWS: networkUrls.indexerWS,
+      node: networkUrls.node,
+      proofServer: networkUrls.proofServer,
+      id: networkUrls.id ?? args.networkId,
+    };
+
+    const walletResult = await contractsMod.buildWalletFacade(
+      fullNetworkUrls,
+      seed,
+      args.networkId as never,
+      args.syncMode ?? "all",
+    );
+
+    const initialShielded = await contractsMod.getInitialShieldedState(
+      walletResult.wallet.shielded,
+    );
+    const shieldedAddress = initialShielded.address.coinPublicKeyString();
+
+    const api: MidnightLocalApi = {
+      signData: async (data, options) => {
+        const bytes =
+          options.encoding === "hex"
+            ? Buffer.from(data, "hex")
+            : Buffer.from(data, "utf-8");
+        const signature = unshieldedKeystore.signData(bytes);
+        return {
+          data,
+          signature: String(signature),
+          verifyingKey,
+        };
+      },
+      getShieldedAddresses: async () => ({ shieldedAddress }),
+      seed,
+      verifyingKey,
+      unshieldedAddress: walletResult.unshieldedAddress,
+      walletFacade: walletResult.wallet,
+      dustAddress: walletResult.dustAddress,
+      shieldedAddress,
+      walletResult,
+    };
+
+    const conn: ActiveConnection<MidnightApi> = {
+      api: api as unknown as MidnightApi,
+      metadata: {
+        name: "midnight-local",
+        displayName: "Midnight (local seed, facade)",
+      },
+    };
+
+    this.provider = new MidnightLocalProvider(
+      conn,
+      walletResult.unshieldedAddress as MidnightAddress,
       unshieldedKeystore,
     );
     return this.provider;
@@ -174,6 +322,25 @@ export class MidnightLocalProvider implements IProvider<MidnightApi> {
 
   /** Expose the keystore for callers that need the raw signing primitive. */
   getUnshieldedKeystore = (): unknown => this.unshieldedKeystore;
+}
+
+async function loadKeystoreDeps(): Promise<{
+  hdMod: typeof import("@midnight-ntwrk/wallet-sdk-hd");
+  keystoreMod: typeof import("@midnight-ntwrk/wallet-sdk-unshielded-wallet");
+}> {
+  const hdMod = await import("@midnight-ntwrk/wallet-sdk-hd").catch(() => {
+    throw new Error(
+      "@midnight-ntwrk/wallet-sdk-hd is required for WalletMode.MidnightLocal.",
+    );
+  });
+  const keystoreMod = await import(
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet"
+  ).catch(() => {
+    throw new Error(
+      "@midnight-ntwrk/wallet-sdk-unshielded-wallet is required for WalletMode.MidnightLocal.",
+    );
+  });
+  return { hdMod, keystoreMod };
 }
 
 function deriveUnshieldedSeed(

--- a/templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts
+++ b/templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts
@@ -38,10 +38,20 @@ export async function midnightPropertyTest(db: Client) {
   );
 
   await assert(
-    "Midnight property: build wallet and sync funds",
+    "Midnight property: build wallet via @effectstream/wallets MidnightLocal (facade mode) and sync funds",
     async () => {
-      const { buildWalletFacade, syncAndWaitForFunds } = await import(
-        "../../frontend/client/src/increment.ts"
+      // Build the wallet through the unified @effectstream/wallets entry point.
+      // Supplying `networkUrls` switches MidnightLocal from signing-only to the
+      // full WalletFacade (shielded + dust + unshielded sub-wallets connected
+      // to the live indexer + node + proof server). The facade ends up at
+      // `api.walletFacade`; the raw `WalletResult` (secret keys, keystore,
+      // addresses) ends up at `api.walletResult` for advanced flows like the
+      // manual balance/sign/finalize loop below.
+      const { MidnightLocalConnector } = await import(
+        "@effectstream/wallets/midnight-local"
+      );
+      const { syncAndWaitForFunds } = await import(
+        "@effectstream/midnight-contracts"
       );
       const { CompiledContract } = await import("@midnight-ntwrk/compact-js");
       const { findDeployedContract } = await import(
@@ -62,22 +72,31 @@ export async function midnightPropertyTest(db: Client) {
       const { setNetworkId } = await import(
         "@midnight-ntwrk/midnight-js-network-id"
       );
-      const { NetworkId } = await import(
-        "@midnight-ntwrk/wallet-sdk-abstractions"
-      );
 
       setNetworkId(MIDNIGHT_NETWORK_ID as any);
-      const networkId = MIDNIGHT_NETWORK_ID as NetworkId.NetworkId;
 
-      console.log("  Building wallet...");
-      const walletResult = await buildWalletFacade(
+      console.log("  Building wallet via MidnightLocalConnector...");
+      const provider = await MidnightLocalConnector.instance().connectFromSeed({
+        seed: GENESIS_SEED,
+        networkId: MIDNIGHT_NETWORK_ID,
         networkUrls,
-        GENESIS_SEED,
-        networkId,
-      );
+      });
+      const api = provider.getConnection().api as any;
+      const walletResult = api.walletResult as Awaited<
+        ReturnType<
+          typeof import("@effectstream/midnight-contracts")["buildWalletFacade"]
+        >
+      >;
+      if (walletResult == null) {
+        throw new Error(
+          "MidnightLocalConnector did not return walletResult — facade mode wiring is broken.",
+        );
+      }
       console.log("  Wallet built. Syncing funds...");
+      // Engine's syncAndWaitForFunds takes the bare WalletFacade; pull it off
+      // walletResult.wallet (which is the same object exposed as api.walletFacade).
       const { shieldedBalance, dustBalance } = await syncAndWaitForFunds(
-        walletResult,
+        walletResult.wallet,
         { timeoutMs: 300_000 },
       );
       console.log(


### PR DESCRIPTION
## Summary

`MidnightLocalConnector.connectFromSeed` now accepts an optional `networkUrls` arg. When supplied, the connector dynamic-imports `@effectstream/midnight-contracts` and calls `buildWalletFacade(...)` to bring up the **complete** Midnight wallet (shielded + dust + unshielded sub-wallets, connected to a live indexer + node + proof server). The resulting `WalletFacade` is surfaced on `getConnection().api.walletFacade`; the underlying `WalletResult` (secret keys, keystore, addresses) is surfaced on `getConnection().api.walletResult` for advanced flows like manual balance/sign/finalize.

When `networkUrls` is omitted, the existing signing-only path is preserved — no network IO, no extra deps required.

Sibling to #741 (EVM Viem `IProvider.sendTransaction`).

## Why

The prior `MidnightLocalProvider` self-described as "lite by design" and threw on `getShieldedAddresses()`. That framing wasn't accurate — the upstream `@midnight-ntwrk/wallet-sdk-facade` ships a complete wallet (`submitTransaction`, `balanceFinalizedTransaction`, `signRecipe`, `state()`, ...), and `@effectstream/midnight-contracts.buildWalletFacade` already constructed it correctly. The local-JS wallet was artificially restricted to unshielded keystore signing.

With this change, templates choose `WalletMode.MidnightLocal` and (with `networkUrls` set) get a wallet capable of submitting real Compact contract transactions — analog of the EvmViem fix landed in #741.

## What changed

- **`packages/effectstream-sdk/wallets/src/midnight/local.ts`** — `MidnightLocalConnectArgs` gains optional `networkUrls` + `syncMode`. `connectFromSeed` dispatches: with `networkUrls` it calls `buildWalletFacade` via dynamic import and exposes the full facade + `WalletResult` on the api; without, the existing keystore-signing path runs unchanged. `getShieldedAddresses()` returns the real shielded coin public key in facade mode.
- **`packages/effectstream-sdk/wallets/package.json`** — `@effectstream/midnight-contracts` declared as an optional peer dependency (mirrors how `@lucid-evolution/*` is wired for Cardano local).
- **`packages/effectstream-sdk/wallets/src/midnight/local.test.ts`** — adds a unit test that mocks `@effectstream/midnight-contracts` and asserts the connector wires `buildWalletFacade`'s output onto the api shape correctly. Existing 3 lite-mode tests retained.
- **`templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts`** — refactored to obtain its WalletFacade via the new entry point instead of importing `buildWalletFacade` directly. Proves the abstraction is a clean drop-in.

## Test plan

- [x] `bun test packages/effectstream-sdk/wallets/src/midnight/local.test.ts` — **4/4 PASS** (lite-mode regression + new facade-mode unit test)
- [x] `LINK_LOCAL=1 bun run templates/run-template-tests.ts evm-midnight-v2` — **PASS in 3m6s**. Phase D's "Midnight property" tests now build the wallet via `MidnightLocalConnector.connectFromSeed({ ..., networkUrls })`, submit a Compact contract call through `walletResult.wallet.submitTransaction(...)`, and the engine indexer captures the event → DB row → API → frontend.
- [x] No dependency cycle (`@effectstream/midnight-contracts` does not depend on `@effectstream/wallets`)
- [x] Existing signing-only callers continue to work — `networkUrls` is optional

## Follow-ups (not in this PR)

- Cardano local-JS already exposes a full wallet via `getConnection().api.lucid` (Lucid is a complete wallet — build/sign/submit/UTxO). The migration skill should document this pattern in the same place the Midnight facade is described.
- The template's `frontend/client/src/increment.ts` still ships its own `syncAndWaitForFunds(walletResult, ...)` wrapper. Worth a follow-up to drop the wrapper and use the engine helper directly (signature difference: takes `WalletFacade` vs `WalletResult`).