### PR TITLE
ci: make testing path-aware (gate e2e, add per-template tests)

### DIFF
--- a/.github/ci-changes.test.ts
+++ b/.github/ci-changes.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { classify } from "./ci-changes.ts";
+
+// A fixed enabled set so these assertions don't shift as templates are
+// enabled/disabled in run-template-tests.ts.
+const ENABLED = ["preorder", "evm-cardano", "world-map-2d"];
+
+describe("classify — core", () => {
+  test("packages/** triggers core", () => {
+    expect(classify(["packages/node-sdk/sync/src/foo.ts"], ENABLED).core).toBe(true);
+  });
+
+  test("e2e/** triggers core", () => {
+    expect(classify(["e2e/runner.ts"], ENABLED).core).toBe(true);
+  });
+
+  test("e2e build-infra files trigger core", () => {
+    for (const f of [
+      ".github/Dockerfile",
+      ".github/run-e2e.sh",
+      "patch.sh",
+      "bun.lock",
+      "package.json",
+      "tsconfig.json",
+      "orchestrator.config.ts",
+      ".github/workflows/main.yaml",
+      ".github/ci-changes.ts",
+    ]) {
+      expect(classify([f], ENABLED).core).toBe(true);
+    }
+  });
+
+  test("template-only and doc-only changes do not trigger core", () => {
+    expect(classify(["templates/preorder/packages/node/main.ts"], ENABLED).core).toBe(false);
+    expect(classify(["templates/check.sh"], ENABLED).core).toBe(false);
+    expect(classify(["README.md", "docs/site/foo.md"], ENABLED).core).toBe(false);
+  });
+});
+
+describe("classify — templates", () => {
+  test("an enabled template dir change is collected", () => {
+    expect(classify(["templates/preorder/packages/node/main.ts"], ENABLED).templates).toEqual([
+      "preorder",
+    ]);
+  });
+
+  test("a disabled/unknown template dir change is ignored", () => {
+    expect(classify(["templates/dice/x.ts"], ENABLED).templates).toEqual([]);
+    expect(classify(["templates/not-a-real-template/x.ts"], ENABLED).templates).toEqual([]);
+  });
+
+  test("top-level files under templates/ are not templates", () => {
+    const r = classify(
+      [
+        "templates/run-template-tests.ts",
+        "templates/check.sh",
+        "templates/AGENTS.md",
+        "templates/update-packages.ts",
+      ],
+      ENABLED,
+    );
+    expect(r.templates).toEqual([]);
+    expect(r.core).toBe(false);
+  });
+
+  test("multiple enabled templates are deduped and sorted", () => {
+    const r = classify(
+      [
+        "templates/world-map-2d/a.ts",
+        "templates/preorder/b.ts",
+        "templates/preorder/c.ts",
+      ],
+      ENABLED,
+    );
+    expect(r.templates).toEqual(["preorder", "world-map-2d"]);
+  });
+});
+
+describe("classify — combined", () => {
+  test("packages + an enabled template set both signals", () => {
+    const r = classify(
+      ["packages/node-sdk/sync/src/foo.ts", "templates/evm-cardano/packages/node/main.ts"],
+      ENABLED,
+    );
+    expect(r.core).toBe(true);
+    expect(r.templates).toEqual(["evm-cardano"]);
+  });
+
+  test("empty / blank input yields no jobs", () => {
+    const r = classify(["", "   "], ENABLED);
+    expect(r.core).toBe(false);
+    expect(r.templates).toEqual([]);
+  });
+});

--- a/.github/ci-changes.ts
+++ b/.github/ci-changes.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+/**
+ * CI change classifier. Decides which jobs the GitHub workflow should run based
+ * on the files changed in the push / PR, and writes the result to $GITHUB_OUTPUT:
+ *
+ *   core=true|false                 # run the Docker e2e suite
+ *   templates=<space-separated>     # enabled template names whose dir changed
+ *
+ * `core` is true when `packages/**` or `e2e/**` change, plus the build-infra
+ * files the e2e image itself depends on (so a Dockerfile / lockfile change still
+ * re-runs e2e). `templates` is the set of changed `templates/<name>/...` dirs
+ * intersected with the ENABLED list in templates/run-template-tests.ts — the
+ * single source of truth. Unknown / disabled templates drop out here, so a push
+ * touching only those produces an empty list and the template job is skipped.
+ *
+ * Base/head come from BASE_SHA/HEAD_SHA env (injected by the workflow). If the
+ * base is missing or all-zeros (new branch, force-push) or the diff fails, we
+ * fall back to running everything — over-run rather than miss a real change.
+ */
+import { ENABLED } from "../templates/run-template-tests.ts";
+
+export interface ChangeClassification {
+  core: boolean;
+  templates: string[];
+}
+
+/** Top-level path prefixes that, if touched, require the full e2e suite. */
+const CORE_PREFIXES = ["packages/", "e2e/"] as const;
+
+/**
+ * Exact root-relative files the e2e build depends on. Changing any of these can
+ * alter the test environment, so they trigger e2e even though they live outside
+ * packages/ and e2e/.
+ */
+const CORE_FILES = new Set<string>([
+  ".github/Dockerfile",
+  ".github/run-e2e.sh",
+  ".github/ci-changes.ts",
+  ".github/workflows/main.yaml",
+  "patch.sh",
+  "package.json",
+  "bun.lock",
+  "tsconfig.json",
+  "orchestrator.config.ts",
+]);
+
+/**
+ * Pure classifier — given a list of changed (root-relative, forward-slash)
+ * paths and the enabled-template list, return which jobs to run. Exported for
+ * unit testing; no I/O.
+ */
+export function classify(
+  files: string[],
+  enabled: readonly string[],
+): ChangeClassification {
+  const enabledSet = new Set(enabled);
+  const templates = new Set<string>();
+  let core = false;
+
+  for (const raw of files) {
+    const f = raw.trim();
+    if (!f) continue;
+
+    if (CORE_PREFIXES.some((p) => f.startsWith(p)) || CORE_FILES.has(f)) {
+      core = true;
+    }
+
+    // templates/<name>/<something> — the trailing `/.+` requires a file *inside*
+    // a template dir, so top-level shared files (templates/check.sh,
+    // templates/run-template-tests.ts, templates/*.md) never match.
+    const m = /^templates\/([^/]+)\/.+/.exec(f);
+    if (m && enabledSet.has(m[1])) templates.add(m[1]);
+  }
+
+  return { core, templates: [...templates].sort() };
+}
+
+const ZERO_SHA = "0000000000000000000000000000000000000000";
+
+/** True when we can't trust the base SHA and should just run everything. */
+function baseIsUnusable(base: string | undefined): boolean {
+  return !base || base === ZERO_SHA || /^0+$/.test(base);
+}
+
+/** Collect the changed files via git, or return null if the diff can't be run. */
+function changedFiles(
+  eventName: string,
+  base: string,
+  head: string,
+): string[] | null {
+  // PR: diff against the merge-base (three-dot) to get only what the PR adds.
+  // push: plain two-arg diff between the before/after commits.
+  const args =
+    eventName === "pull_request"
+      ? ["diff", "--name-only", `${base}...${head}`]
+      : ["diff", "--name-only", base, head];
+
+  const proc = Bun.spawnSync(["git", ...args], { stdout: "pipe", stderr: "pipe" });
+  if (proc.exitCode !== 0) {
+    console.error(
+      `git ${args.join(" ")} failed:\n${proc.stderr.toString().trim()}`,
+    );
+    return null;
+  }
+  return proc.stdout.toString().split("\n").filter(Boolean);
+}
+
+if (import.meta.main) {
+  const eventName = process.env.EVENT_NAME ?? "push";
+  const base = process.env.BASE_SHA;
+  const head = process.env.HEAD_SHA ?? "HEAD";
+
+  let result: ChangeClassification;
+  let files: string[] | null = null;
+
+  if (baseIsUnusable(base)) {
+    console.log(
+      `No usable base SHA (BASE_SHA=${JSON.stringify(base)}) — running everything.`,
+    );
+    result = { core: true, templates: [...ENABLED].sort() };
+  } else {
+    files = changedFiles(eventName, base!, head);
+    if (files === null) {
+      console.log("git diff failed — running everything to be safe.");
+      result = { core: true, templates: [...ENABLED].sort() };
+    } else {
+      result = classify(files, ENABLED);
+    }
+  }
+
+  if (files) {
+    console.log(`Changed files (${files.length}):`);
+    for (const f of files) console.log(`  ${f}`);
+  }
+  console.log(`\ncore=${result.core}`);
+  console.log(`templates=${result.templates.join(" ")}`);
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    const { appendFileSync } = await import("fs");
+    appendFileSync(
+      out,
+      `core=${result.core}\ntemplates=${result.templates.join(" ")}\n`,
+    );
+  }
+}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,9 +7,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
+  # Decide which downstream jobs run, based on what changed.
+  #   core      → packages/** or e2e/** (plus the e2e build-infra files)
+  #   templates → space-separated list of ENABLED templates whose dir changed
+  changes:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    timeout-minutes: 5
+    outputs:
+      core: ${{ steps.classify.outputs.core }}
+      templates: ${{ steps.classify.outputs.templates }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Classify changes
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: bun .github/ci-changes.ts
+
+  # Existing Dockerized e2e suite — now gated on core changes.
+  e2e:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' && (github.event_name == 'push' || !github.event.pull_request.draft) }}
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -20,3 +48,47 @@ jobs:
 
       - name: Run e2e tests
         run: docker run --rm --name e2e_${{ github.run_number }} testing_image:${{ github.sha }}
+
+  # Per-template tests — runs the changed ENABLED templates serially in one job.
+  # Uses the SAME image as e2e; only the command differs. Tests resolve
+  # @effectstream/* from published npm (no LINK_LOCAL).
+  template-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.templates != '' && (github.event_name == 'push' || !github.event.pull_request.draft) }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build testing image
+        run: docker build -t testing_image:${{ github.sha }} -f .github/Dockerfile .
+
+      - name: Run template tests
+        run: |
+          docker run --rm --name templates_${{ github.run_number }} testing_image:${{ github.sha }} \
+            bash -lc "bun run templates/run-template-tests.ts ${{ needs.changes.outputs.templates }} --skip-disabled"
+
+  # Aggregate gate: a single stable check to mark required in branch protection.
+  # Passes when e2e/template-tests succeed or are skipped; fails if either fails
+  # or is cancelled (or if the changes job itself failed).
+  ci-ok:
+    needs: [changes, e2e, template-tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Verify required jobs
+        run: |
+          echo "changes=${{ needs.changes.result }}"
+          echo "e2e=${{ needs.e2e.result }}"
+          echo "template-tests=${{ needs.template-tests.result }}"
+          if [ "${{ needs.changes.result }}" = "failure" ] || \
+             [ "${{ needs.e2e.result }}" = "failure" ] || \
+             [ "${{ needs.e2e.result }}" = "cancelled" ] || \
+             [ "${{ needs.template-tests.result }}" = "failure" ] || \
+             [ "${{ needs.template-tests.result }}" = "cancelled" ]; then
+            echo "::error::A required job failed or was cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."

--- a/templates/run-template-tests.ts
+++ b/templates/run-template-tests.ts
@@ -6,6 +6,13 @@
  *   bun run templates/run-template-tests.ts                      # all enabled
  *   bun run templates/run-template-tests.ts preorder shinkai-v2   # specific ones
  *
+ * Flags:
+ *   --skip-disabled  If explicit template args are given but none are ENABLED,
+ *                    exit 0 (skip) instead of 1. Used by CI so a push touching
+ *                    only a disabled/unknown template passes. The ENABLED array
+ *                    is `export`ed so CI (.github/ci-changes.ts) can filter
+ *                    changed templates against it without running this file.
+ *
  * Env:
  *   LINK_LOCAL=1   After `bun install`, run each template's ./link.sh so the
  *                  tests resolve @effectstream/* to the local monorepo build
@@ -25,7 +32,7 @@ const LINK_LOCAL = ["1", "true", "yes"].includes(
   (process.env.LINK_LOCAL ?? "").toLowerCase(),
 );
 
-const ENABLED = [
+export const ENABLED = [
   "cardano-delegation",
   "evm-cardano",
   "evm-midnight-v2",
@@ -121,12 +128,23 @@ async function runTemplate(name: string): Promise<Result> {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
+  // --skip-disabled: when explicit template args are given but none are ENABLED,
+  // exit 0 (skip) instead of 1. Used by CI so that a push touching only a
+  // disabled/unknown template passes instead of failing. Without the flag the
+  // strict exit(1) is kept so manual runs still surface typos.
+  const skipDisabled = process.argv.includes("--skip-disabled");
+  const args = process.argv.slice(2).filter((a) => !a.startsWith("--"));
   const selected = args.length > 0
     ? ENABLED.filter((name) => args.includes(name))
     : ENABLED;
 
   if (selected.length === 0) {
+    if (skipDisabled && args.length > 0) {
+      console.log(
+        `No enabled templates among [${args.join(", ")}] — skipping. Enabled: ${ENABLED.join(", ")}`,
+      );
+      exit(0);
+    }
     console.error("No matching templates. Enabled:", ENABLED.join(", "));
     exit(1);
   }
@@ -188,4 +206,4 @@ async function main() {
   }
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
## What

Makes CI change-aware instead of running the full Docker e2e suite on every push.

A new **`changes`** job classifies the diff and gates the rest:

- **`e2e`** — runs only when `packages/**`, `e2e/**`, or the e2e build-infra files change (`.github/Dockerfile`, `.github/run-e2e.sh`, `patch.sh`, root `package.json`, `bun.lock`, `tsconfig.json`, `orchestrator.config.ts`, the workflow, the classifier). Otherwise unchanged from before.
- **`template-tests`** — when `templates/<name>/**` changes, runs the changed **ENABLED** templates serially in one job, inside the **same** image, against **published** `@effectstream/*` packages (no `LINK_LOCAL`). A changed template not in the ENABLED list drops out, so the run passes (`--skip-disabled`).
- **`ci-ok`** — always-run aggregate gate: passes when the others succeed or are skipped, fails if any failed/cancelled. Intended as the single required status check if branch protection is enabled later (currently `v-next` is unprotected, so it's just informational for now).

## How

- `.github/ci-changes.ts` (new) — pure `classify(files, enabled)` + a runner that diffs `BASE_SHA..HEAD_SHA` and writes `core` / `templates` to `$GITHUB_OUTPUT`. Unusable base SHA (new branch / force-push) → runs everything.
- `.github/ci-changes.test.ts` (new) — 10 unit tests for `classify()`.
- `templates/run-template-tests.ts` — `export ENABLED` (single source of truth), guard `main()` behind `import.meta.main`, add `--skip-disabled`.

## Verification (local)

- `bun test ./.github/ci-changes.test.ts` → 10 pass / 0 fail
- `run-template-tests.ts dice --skip-disabled` → exit 0; without flag → exit 1
- Live classifier on a real diff → correct `core` + template list, `$GITHUB_OUTPUT` written; zero-SHA fallback runs everything
- Both workflow YAMLs parse

> Note: the in-container `template-tests` path (Docker build + published install + chain spin-up) can only be fully exercised by CI on push.