### PR TITLE
fix(wallets): keep node-only deploy.ts out of browser bundles + install Playwright in CI

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -116,6 +116,15 @@ ENV NODE_ENV=development
 RUN bun install
 RUN /app/patch.sh
 
+# Install the Chromium browser the wallets-ui e2e suite drives via Playwright.
+# `bunx` from the package dir resolves the locally-installed playwright, so the
+# downloaded browser revision matches the `playwright` import in run-tests.ts
+# (a floating `playwright@latest` could fetch a mismatched revision). bun install
+# does not download browsers, so without this the suite fails with
+# "Executable doesn't exist at .../ms-playwright/chromium_headless_shell-*".
+# `--with-deps` pulls the OS libraries chrome-headless-shell needs on trixie.
+RUN cd /app/e2e/wallets-ui && bunx playwright install --with-deps chromium
+
 # ── Common environment ──────────────────────────────────────────────────────
 ENV EFFECTSTREAM_STDOUT=true
 ENV POLKADOTJS_DISABLE_ESM_CJS_WARNING=1

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -116,13 +116,9 @@ ENV NODE_ENV=development
 RUN bun install
 RUN /app/patch.sh
 
-# Install the Chromium browser the wallets-ui e2e suite drives via Playwright.
-# `bunx` from the package dir resolves the locally-installed playwright, so the
-# downloaded browser revision matches the `playwright` import in run-tests.ts
-# (a floating `playwright@latest` could fetch a mismatched revision). bun install
-# does not download browsers, so without this the suite fails with
-# "Executable doesn't exist at .../ms-playwright/chromium_headless_shell-*".
-# `--with-deps` pulls the OS libraries chrome-headless-shell needs on trixie.
+# `bun install` doesn't fetch browsers; the wallets-ui suite drives Chromium via
+# Playwright. Run from the package dir so bunx uses the pinned playwright (a
+# floating version could fetch a mismatched browser revision).
 RUN cd /app/e2e/wallets-ui && bunx playwright install --with-deps chromium
 
 # ── Common environment ──────────────────────────────────────────────────────

--- a/packages/effectstream-sdk/wallets/src/midnight/local.test.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/local.test.ts
@@ -84,7 +84,7 @@ describe("MidnightLocalProvider", () => {
     }));
     const getInitialSpy = mock(async (_shielded: unknown) => fakeShielded);
 
-    mock.module("@effectstream/midnight-contracts", () => ({
+    mock.module("@effectstream/midnight-contracts/wallet-info", () => ({
       buildWalletFacade: buildSpy,
       getInitialShieldedState: getInitialSpy,
     }));

--- a/packages/effectstream-sdk/wallets/src/midnight/local.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/local.ts
@@ -194,8 +194,15 @@ export class MidnightLocalConnector {
     args: MidnightLocalConnectArgs,
     networkUrls: MidnightLocalNetworkUrls,
   ): Promise<MidnightLocalProvider> => {
+    // Import the narrow `/wallet-info` subpath rather than the package barrel.
+    // The barrel (`@effectstream/midnight-contracts`) re-exports `deploy.ts`,
+    // which imports `node:fs/promises` — a specifier the browser polyfill
+    // (`node-stdlib-browser`) can't resolve, breaking any frontend bundle that
+    // includes `@effectstream/wallets`. `buildWalletFacade` and
+    // `getInitialShieldedState` (the only members we use) live in
+    // `get-wallet-info.ts`, which is node-only-fs-free.
     const contractsMod = await import(
-      "@effectstream/midnight-contracts"
+      "@effectstream/midnight-contracts/wallet-info"
     ).catch(() => {
       throw new Error(
         "@effectstream/midnight-contracts is required when `networkUrls` is passed to MidnightLocal.connectFromSeed. Install it as a peer dependency.",

--- a/packages/effectstream-sdk/wallets/src/midnight/local.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/local.ts
@@ -194,13 +194,9 @@ export class MidnightLocalConnector {
     args: MidnightLocalConnectArgs,
     networkUrls: MidnightLocalNetworkUrls,
   ): Promise<MidnightLocalProvider> => {
-    // Import the narrow `/wallet-info` subpath rather than the package barrel.
-    // The barrel (`@effectstream/midnight-contracts`) re-exports `deploy.ts`,
-    // which imports `node:fs/promises` — a specifier the browser polyfill
-    // (`node-stdlib-browser`) can't resolve, breaking any frontend bundle that
-    // includes `@effectstream/wallets`. `buildWalletFacade` and
-    // `getInitialShieldedState` (the only members we use) live in
-    // `get-wallet-info.ts`, which is node-only-fs-free.
+    // Use the `/wallet-info` subpath, not the package barrel: the barrel
+    // re-exports `deploy.ts` (`node:fs/promises`), which breaks browser bundles
+    // of `@effectstream/wallets`.
     const contractsMod = await import(
       "@effectstream/midnight-contracts/wallet-info"
     ).catch(() => {


### PR DESCRIPTION
## Problem

The `wallets` e2e suite was failing in CI with three cascading issues:

### 1. `vite build` failed (the real regression)
PR #743 added a dynamic `import("@effectstream/midnight-contracts")` in `wallets/src/midnight/local.ts` (`connectWithFacade`). Rollup bundles dynamic-import targets, and that package's barrel (`mod.ts`) re-exports `deploy.ts`, which does `import { writeFile } from "node:fs/promises"`. The browser polyfill (`node-stdlib-browser`) has no `fs/promises` mapping, so it resolved to `empty.js/promises` → `ENOTDIR`:

```
[vite:load-fallback] Could not load .../node-stdlib-browser/cjs/mock/empty.js/promises
  (imported by ../../packages/chains/midnight-contracts/src/deploy.ts): ENOTDIR
```

Before that PR, `@effectstream/midnight-contracts` was never in the browser graph, so the build passed.

### 2. "fastify server did not bind" — a cascade of #1
`server/main.ts` serves `client/dist` via `@fastify/static`, which throws when the failed build left no `dist`.

### 3. Playwright "Executable doesn't exist" — independent CI gap
The CI Dockerfile installs bun/node/foundry/compact/solc but never installs the Playwright browser, and `bun install` doesn't download it.

## Fix

- **`wallets/src/midnight/local.ts`** — narrow the dynamic import to the `@effectstream/midnight-contracts/wallet-info` subpath (`get-wallet-info.ts`). That's where the only two used members (`buildWalletFacade`, `getInitialShieldedState`) live, and its entire transitive subgraph (`constants.ts`, `types.ts`, `midnight-env.ts`) never touches `deploy.ts` or `node:fs/promises`. Fixes #1 and #2 at the source — benefits any frontend bundling `@effectstream/wallets`, not just this e2e suite.
- **`wallets/src/midnight/local.test.ts`** — update `mock.module(...)` to the same subpath specifier.
- **`.github/Dockerfile`** — add `RUN cd /app/e2e/wallets-ui && bunx playwright install --with-deps chromium` after `bun install`, resolved from the package dir so the browser revision matches the pinned playwright. Fixes #3.

## Validation

Installed the `compact` toolchain, compiled the counter/eip-20 Compact contracts, and ran the **full vite build locally** — it completes: `✓ 5127 modules transformed → built in 10.82s`, producing a complete `dist/`. The `deploy.ts`/`fs-promises` error is gone.