### PR TITLE
feat(sync): synthetic `test` sync protocol + in-process harness + docs

### DIFF
--- a/e2e/runner.ts
+++ b/e2e/runner.ts
@@ -16,6 +16,7 @@ const suites = [
   { name: "near", script: "./near/run-tests.ts" },
   { name: "features", script: "./features/run-tests.ts" },
   { name: "wallets", script: "./wallets-ui/run-tests.ts" },
+  { name: "sync-repro", script: "./sync-repro/run-tests.ts" },
 ];
 
 const __dirname = import.meta.dirname ?? ".";

--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -1,0 +1,28 @@
+/**
+ * E2E suite: deterministic sync-service reproductions.
+ *
+ * Unlike the other suites, this one needs no orchestrator/chains — it runs the
+ * in-process reproduction tests (real runtime + PGLite + the synthetic `test`
+ * chain) that reproduce the unbounded-buffering and restart-resume issues.
+ *
+ * NOTE: these tests assert the FIXED behaviour, so they are expected to FAIL
+ * until the backpressure (C) and block-accurate-resume (D) fixes are applied.
+ * See packages/node-sdk/sync/CLAUDE.md and
+ * packages/node-sdk/runtime/test/reproduction/RESULTS.md.
+ */
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+const proc = Bun.spawn(
+  ["bun", "test", "packages/node-sdk/runtime/test/reproduction/"],
+  {
+    cwd: repoRoot,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env },
+  },
+);
+
+const code = await proc.exited;
+process.exit(code);

--- a/packages/effectstream-sdk/config/src/schema/network/all.ts
+++ b/packages/effectstream-sdk/config/src/schema/network/all.ts
@@ -12,6 +12,7 @@ import { ConfigNetworkSchemaNtp } from "./ntp.ts";
 import { ConfigNetworkSchemaBitcoin } from "./bitcoin.ts";
 import { ConfigNetworkSchemaCelestia } from "./celestia.ts";
 import { ConfigNetworkSchemaNear } from "./near.ts";
+import { ConfigNetworkSchemaTest } from "./test.ts";
 
 export const networkTypes = {
   [ConfigNetworkType.NTP]: ConfigNetworkSchemaNtp,
@@ -25,6 +26,7 @@ export const networkTypes = {
   [ConfigNetworkType.BITCOIN]: ConfigNetworkSchemaBitcoin,
   [ConfigNetworkType.CELESTIA]: ConfigNetworkSchemaCelestia,
   [ConfigNetworkType.NEAR]: ConfigNetworkSchemaNear,
+  [ConfigNetworkType.TEST]: ConfigNetworkSchemaTest,
 } as const;
 
 export type ConfigNetworkSubmapping<T extends ConfigNetworkType> = ToMapping<

--- a/packages/effectstream-sdk/config/src/schema/network/test.ts
+++ b/packages/effectstream-sdk/config/src/schema/network/test.ts
@@ -1,0 +1,29 @@
+import { Type } from "@sinclair/typebox";
+import type { Static } from "@sinclair/typebox";
+import { ConfigSchema } from "../utils.ts";
+import { ConfigNetworkType } from "./types.ts";
+import { type MergeIntersects } from "@effectstream/utils";
+
+// ===========
+// Base schema
+// ===========
+
+/**
+ * Synthetic test network. Blocks are computed arithmetically:
+ *   timestamp(page) = startTime + blockTimeMS * page
+ * exactly like NTP, so it can act as either the main clock (TEST_MAIN) or a
+ * parallel chain (TEST_PARALLEL). Used only by the deterministic sync tests;
+ * excluded from the publish script.
+ */
+export const ConfigNetworkSchemaTest = new ConfigSchema({
+  required: Type.Object({
+    name: Type.String(),
+    type: Type.Literal(ConfigNetworkType.TEST),
+    startTime: Type.Number(),
+    blockTimeMS: Type.Number(),
+  }),
+  optional: Type.Object({}),
+});
+export type ConfigNetworkTest = MergeIntersects<
+  Static<ReturnType<typeof ConfigNetworkSchemaTest.allProperties<true>>>
+>;

--- a/packages/effectstream-sdk/config/src/schema/network/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/network/types.ts
@@ -11,4 +11,10 @@ export enum ConfigNetworkType {
   BITCOIN = "bitcoin",
   CELESTIA = "celestia",
   NEAR = "near",
+  /**
+   * Synthetic, fully in-memory chain used for deterministic tests.
+   * Blocks are computed arithmetically (no RPC). Excluded from publishing.
+   * See packages/node-sdk/sync/src/sync-protocols/test/.
+   */
+  TEST = "test",
 }

--- a/packages/effectstream-sdk/config/src/schema/network/utils.ts
+++ b/packages/effectstream-sdk/config/src/schema/network/utils.ts
@@ -50,6 +50,9 @@ export function caip2PrefixFor(
     case ConfigNetworkType.NTP:
       // TODO What to return here
       return `ntp:${config.name}`;
+    case ConfigNetworkType.TEST:
+      // Synthetic test chain — namespace by its configured name.
+      return `test:${config.name}`;
     case ConfigNetworkType.EVM:
       // https://github.com/ChainAgnostic/namespaces/tree/main/eip155
       return `eip155:${config.chainId}`;

--- a/packages/effectstream-sdk/config/src/schema/primitive/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/primitive/types.ts
@@ -32,6 +32,10 @@ type MidnightTPrimitivePayload = Record<string, any>;
 
 type NtpPrimitivePayload = never;
 
+type TestMainPrimitivePayload = never;
+/** Arbitrary JSON payload declared per-event on a TEST_PARALLEL chain. */
+type TestParallelPrimitivePayload = Record<string, unknown>;
+
 type CardanoCarpPrimitivePayload = {
   TODO_MISSING_FIELDS: string;
 };
@@ -85,4 +89,6 @@ interface ProtocolPayloadMap {
   [ConfigSyncProtocolType.MIDNIGHT_PARALLEL]: MidnightTPrimitivePayload;
   [ConfigSyncProtocolType.BITCOIN_RPC_PARALLEL]: BitcoinPrimitivePayload;
   [ConfigSyncProtocolType.CELESTIA_PARALLEL]: CelestiaPrimitivePayload;
+  [ConfigSyncProtocolType.TEST_MAIN]: TestMainPrimitivePayload;
+  [ConfigSyncProtocolType.TEST_PARALLEL]: TestParallelPrimitivePayload;
 }

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/all.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/all.ts
@@ -50,9 +50,16 @@ import {
   CommonResponseNtpMain,
   ConfigSyncProtocolSchemaNtpMain,
 } from "./ntp/rpc.ts";
+import {
+  CommonResponseTestMain,
+  CommonResponseTestParallel,
+  ConfigSyncProtocolSchemaTestMain,
+  ConfigSyncProtocolSchemaTestParallel,
+} from "./test/rpc.ts";
 
 export const mainSyncProtocolTypes = {
   [ConfigSyncProtocolType.NTP_MAIN]: ConfigSyncProtocolSchemaNtpMain,
+  [ConfigSyncProtocolType.TEST_MAIN]: ConfigSyncProtocolSchemaTestMain,
 } as const;
 
 export type ConfigSyncProtocolMappingMain = ToMapping<
@@ -78,6 +85,8 @@ export const parallelSyncProtocolTypes = {
     ConfigSyncProtocolSchemaCelestiaParallel,
   [ConfigSyncProtocolType.NEAR_RPC_PARALLEL]:
     ConfigSyncProtocolSchemaNearParallel,
+  [ConfigSyncProtocolType.TEST_PARALLEL]:
+    ConfigSyncProtocolSchemaTestParallel,
 } as const;
 
 export const syncProtocolCommonResponse = {
@@ -97,6 +106,8 @@ export const syncProtocolCommonResponse = {
     CommonResponseCelestiaRpcParallel,
   [ConfigSyncProtocolType.NEAR_RPC_PARALLEL]:
     CommonResponseNearRpcParallel,
+  [ConfigSyncProtocolType.TEST_MAIN]: CommonResponseTestMain,
+  [ConfigSyncProtocolType.TEST_PARALLEL]: CommonResponseTestParallel,
 } as const satisfies Record<ConfigSyncProtocolType, TSchema>;
 export type ConfigSyncProtocolCommonAll = typeof syncProtocolCommonResponse;
 

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/test/rpc.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/test/rpc.ts
@@ -1,0 +1,93 @@
+import { Type } from "@sinclair/typebox";
+import type { Static } from "@sinclair/typebox";
+import { ConfigSyncProtocolType } from "../types.ts";
+import {
+  NameField,
+  PollingSyncProtocol,
+  StartStopBlockheight,
+} from "../../common.ts";
+import { type MergeIntersects, TypeboxHelpers } from "@effectstream/utils";
+import {
+  CommonResponseParallelSyncProtocol,
+  type ConfigSyncProtocolCommonResponse,
+  genCommonResponse,
+} from "../common.ts";
+
+// ===========
+// Base schema
+// ===========
+
+export const ConfigSyncProtocolSchemaTestBase = NameField.cloneMerge(
+  PollingSyncProtocol,
+).cloneMerge(StartStopBlockheight).cloneMerge({
+  required: Type.Object({}),
+  optional: Type.Object({
+    stepSize: Type.Number({ default: 1000 }),
+  }),
+});
+
+export const CommonResponseTestBase = {
+  internal: {},
+  payload: {
+    ownChain: Type.Object({
+      blockNumber: TypeboxHelpers.BlockNumber(),
+    }),
+  },
+} as const satisfies ConfigSyncProtocolCommonResponse;
+
+/**
+ * A single deterministic event a TEST_PARALLEL chain will emit. When the
+ * fetcher reaches `atBlock`, it emits one primitive carrying `payload`, which
+ * flows through the merge + STF and lands in `effectstream.primitive_accounting`.
+ */
+const TestEvent = Type.Object({
+  atBlock: Type.Number(),
+  payload: Type.Unsafe<Record<string, unknown>>(
+    Type.Object({}, { additionalProperties: true }),
+  ),
+});
+
+// ======================
+// TEST_MAIN config (clock)
+// ======================
+
+export const ConfigSyncProtocolSchemaTestMain = ConfigSyncProtocolSchemaTestBase
+  .cloneMerge({
+    required: Type.Object({
+      type: Type.Literal(ConfigSyncProtocolType.TEST_MAIN),
+    }),
+    optional: Type.Object({}),
+  });
+export type ConfigSyncProtocolTestMain = MergeIntersects<
+  Static<ReturnType<typeof ConfigSyncProtocolSchemaTestMain.allProperties<true>>>
+>;
+
+export const CommonResponseTestMain = genCommonResponse(
+  CommonResponseTestBase,
+);
+
+// ==============================
+// TEST_PARALLEL config (events)
+// ==============================
+
+export const ConfigSyncProtocolSchemaTestParallel =
+  ConfigSyncProtocolSchemaTestBase
+    .cloneMerge({
+      required: Type.Object({
+        type: Type.Literal(ConfigSyncProtocolType.TEST_PARALLEL),
+      }),
+      optional: Type.Object({
+        delayMs: TypeboxHelpers.IntervalMs({ default: 0 }),
+        events: Type.Array(TestEvent, { default: [] }),
+      }),
+    });
+export type ConfigSyncProtocolTestParallel = MergeIntersects<
+  Static<
+    ReturnType<typeof ConfigSyncProtocolSchemaTestParallel.allProperties<true>>
+  >
+>;
+
+export const CommonResponseTestParallel = genCommonResponse(
+  CommonResponseParallelSyncProtocol,
+  CommonResponseTestBase,
+);

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
@@ -17,6 +17,10 @@ export enum ConfigSyncProtocolType {
   BITCOIN_RPC_PARALLEL = "bitcoin-rpc-parallel",
   CELESTIA_PARALLEL = "celestia-rpc-parallel",
   NEAR_RPC_PARALLEL = "near-rpc-parallel",
+  /** Synthetic test chain acting as the main clock (see ConfigNetworkType.TEST). */
+  TEST_MAIN = "test-main",
+  /** Synthetic test chain acting as a parallel data source that emits configured events. */
+  TEST_PARALLEL = "test-parallel",
 }
 
 export const SyncProtocolToNetwork = {
@@ -30,6 +34,8 @@ export const SyncProtocolToNetwork = {
   [ConfigSyncProtocolType.BITCOIN_RPC_PARALLEL]: ConfigNetworkType.BITCOIN,
   [ConfigSyncProtocolType.CELESTIA_PARALLEL]: ConfigNetworkType.CELESTIA,
   [ConfigSyncProtocolType.NEAR_RPC_PARALLEL]: ConfigNetworkType.NEAR,
+  [ConfigSyncProtocolType.TEST_MAIN]: ConfigNetworkType.TEST,
+  [ConfigSyncProtocolType.TEST_PARALLEL]: ConfigNetworkType.TEST,
 } satisfies Record<ConfigSyncProtocolType, ConfigNetworkType>;
 
 export type NetworkTypeFromSyncProtocol<T extends ConfigSyncProtocolType> =
@@ -129,6 +135,9 @@ type NearPrimitive = BasePrimitive & {
 
 type NtpMainPrimitive = BasePrimitive & {};
 
+type TestMainPrimitive = BasePrimitive & {};
+type TestParallelPrimitive = BasePrimitive & {};
+
 export type BitcoinPrimitiveDirection = "inputs" | "outputs" | "both";
 
 type BitcoinPrimitive = BasePrimitive & {
@@ -162,6 +171,8 @@ export type ProtocolPrimitiveMap = {
   [ConfigSyncProtocolType.BITCOIN_RPC_PARALLEL]: BitcoinPrimitive;
   [ConfigSyncProtocolType.CELESTIA_PARALLEL]: CelestiaPrimitive;
   [ConfigSyncProtocolType.NEAR_RPC_PARALLEL]: NearPrimitive;
+  [ConfigSyncProtocolType.TEST_MAIN]: TestMainPrimitive;
+  [ConfigSyncProtocolType.TEST_PARALLEL]: TestParallelPrimitive;
 };
 
 /**

--- a/packages/node-sdk/runtime/src/api/http-server.ts
+++ b/packages/node-sdk/runtime/src/api/http-server.ts
@@ -25,6 +25,7 @@ import type {
   EvmFetcher,
   MidnightFetcher,
   NtpFetcher,
+  TestFetcher,
   UtxoRpcFetcher,
 } from "@effectstream/sync";
 import fastifySwagger, {
@@ -285,6 +286,24 @@ export const startHttpServer = function* (
               const cfg = ntpFetcher.config.network;
               if (!cfg?.startTime || !cfg?.blockTimeMS) {
                 return reply.status(500).send({ error: "NTP config missing" });
+              }
+              for (let n = from; n <= to; n++) {
+                const timestamp = BigInt(cfg.startTime) +
+                  BigInt(cfg.blockTimeMS) * BigInt(n);
+                blocks.push({
+                  blockNumber: n,
+                  timestamp,
+                  hash: `0x${timestamp.toString(16)}`,
+                });
+              }
+            }
+            break;
+          case ConfigNetworkType.TEST:
+            {
+              const testFetcher = fetcher as TestFetcher;
+              const cfg = testFetcher.config.network;
+              if (!cfg?.startTime || !cfg?.blockTimeMS) {
+                return reply.status(500).send({ error: "TEST config missing" });
               }
               for (let n = from; n <= to; n++) {
                 const timestamp = BigInt(cfg.startTime) +

--- a/packages/node-sdk/runtime/src/config-snapshot.ts
+++ b/packages/node-sdk/runtime/src/config-snapshot.ts
@@ -23,11 +23,19 @@ import { getEnv } from "@effectstream/utils/runtime";
  *   Bitcoin, Celestia          → syncProtocol.startBlockHeight
  */
 function extractImmutableConfig(protocol: SyncProtocolWithNetwork): Record<string, unknown> {
-  if (protocol.networkType === ConfigNetworkType.NTP) {
-    const ntpNetwork = protocol.network as { startTime: number; blockTimeMS: number };
+  // NTP and the synthetic TEST chain both derive blocks arithmetically from
+  // network.startTime + network.blockTimeMS, so those are the immutable fields.
+  if (
+    protocol.networkType === ConfigNetworkType.NTP ||
+    protocol.networkType === ConfigNetworkType.TEST
+  ) {
+    const arithmeticNetwork = protocol.network as {
+      startTime: number;
+      blockTimeMS: number;
+    };
     return {
-      startTime: ntpNetwork.startTime,
-      blockTimeMS: ntpNetwork.blockTimeMS,
+      startTime: arithmeticNetwork.startTime,
+      blockTimeMS: arithmeticNetwork.blockTimeMS,
     };
   }
 

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -62,6 +62,9 @@ export function* start(config: StartConfig): Operation<void> {
   const syncProtocols = yield* startup(dbConn as any, // Client,
     syncInfo, config);
 
+  // Test-only: surface live sync protocols (e.g. for buffer-size assertions).
+  config.dev?.onStarted?.({ syncProtocols });
+
   log.remote(
     ComponentNames.EFFECTSTREAM_RUNTIME,
     [],

--- a/packages/node-sdk/runtime/src/types.ts
+++ b/packages/node-sdk/runtime/src/types.ts
@@ -1,4 +1,5 @@
 import type { Operation } from "effection";
+import type { AllSyncProtocols } from "@effectstream/sync";
 import type { SyncProtocolWithNetwork } from "@effectstream/config";
 import type { AppEvents, BaseStfInput, BaseStfOutput, Primitive } from "@effectstream/sm";
 import type { FastifyInstance } from "fastify";
@@ -72,5 +73,11 @@ export type StartConfig = {
   dev?: {
     /** Reset public-schema tables on each sync reset. For local testing only. */
     resetPublicData?: boolean;
+    /**
+     * Test-only hook invoked once the sync protocols are instantiated (after
+     * `genSyncProtocols`, before the merge starts). Lets tests observe live
+     * state such as `bufferedData.size()`. No effect in production.
+     */
+    onStarted?: (ctx: { syncProtocols: AllSyncProtocols[] }) => void;
   };
 };

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -1,0 +1,327 @@
+/**
+ * Deterministic, in-process harness for reproducing sync-service issues.
+ *
+ * - Runs a real PGLite server in-process (state survives a simulated restart
+ *   because the server stays alive while the node task is halted/restarted).
+ * - Boots the real runtime (`start()`) over a synthetic `test` chain whose tip
+ *   is controlled via {@link TestChainControl}, so scenarios are deterministic
+ *   (fixed tips → a well-defined "stable" state we can poll for).
+ *
+ * Lives in the runtime package because it imports `start()` (the sync package
+ * must not depend on runtime). See ./buffering.test.ts and ./resume.test.ts,
+ * and RESULTS.md for measurements.
+ */
+import pg from "pg";
+import { type PgliteHandle, startPglite } from "@effectstream/db/start-pglite";
+import { run, type Task } from "effection";
+import {
+  ConfigBuilder,
+  toSyncProtocolWithNetwork,
+  withEffectstreamStaticConfig,
+} from "@effectstream/config";
+import { init, start } from "../../src/main.ts";
+import type { StartConfigGameStateTransitions } from "../../src/types.ts";
+import { type AllSyncProtocols, TestChainControl } from "@effectstream/sync";
+import { Primitive } from "@effectstream/sm";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── A minimal user-defined primitive ─────────────────────────────────────────
+// Writes one row to effectstream.primitive_accounting per event (no STF needed:
+// stateMachinePayload is null). Tests assert on that table.
+export const TEST_PRIMITIVE_TYPE = "TEST:EVENT";
+
+export class TestEventPrimitive extends Primitive<any, any> {
+  readonly internalTypeName = TEST_PRIMITIVE_TYPE as any;
+  override grammar = [] as any;
+  constructor(config: any) {
+    super(config);
+  }
+  // deno-lint-ignore require-yield
+  override *getPayload(_height: any, primitiveTransactionData: any): any {
+    const payload = primitiveTransactionData.output.payload;
+    return {
+      isBatched: false,
+      data: [
+        {
+          fromAddressAndType: { type: "none", address: "0x0" },
+          accountingPayload: payload,
+          stateMachinePayload: null,
+        },
+      ],
+    };
+  }
+  override getConfig(): any {
+    return {
+      name: this.instanceName,
+      type: this.internalTypeName,
+      startBlockHeight: this.startBlockHeight,
+      scheduledPrefix: this.stateMachinePrefix,
+    };
+  }
+}
+
+const noopStf: StartConfigGameStateTransitions = function* () {};
+
+// ── Env / DB lifecycle ───────────────────────────────────────────────────────
+
+let portCounter = 5544;
+
+export type Harness = {
+  pglite: PgliteHandle;
+  pool: pg.Pool;
+  dataDir: string;
+  runNode: (opts: RunNodeOpts) => Promise<RunningNode>;
+  /**
+   * Simulate a full process restart: close the PGLite server (severing the
+   * stopped node's lingering pool, which otherwise holds PGLite's single
+   * connection) and reopen it on the SAME data dir (state persists on disk).
+   */
+  simulateRestart: () => Promise<void>;
+  teardown: () => Promise<void>;
+};
+
+export type RunNodeOpts = {
+  config: ReturnType<ConfigBuilder["build"]> | any;
+  /** Unique per boot so the (test-only) HTTP server never collides. */
+  apiPort: number;
+};
+
+export type RunningNode = {
+  task: Task<unknown>;
+  /** Live sync protocols (captured via the dev.onStarted hook). */
+  syncProtocols: () => AllSyncProtocols[];
+  /** Boot error, if start() threw. */
+  bootError: () => unknown;
+  stop: () => Promise<void>;
+};
+
+/**
+ * Start a PGLite server + connect a query pool. Sets the lazily-read ENV the
+ * runtime uses (DB_*, PGLITE). Keep one Harness per test; reuse across the
+ * simulated restart so the page queue persists.
+ */
+export async function setupHarness(): Promise<Harness> {
+  const dbPort = portCounter++;
+  const dataDir = mkdtempSync(join(tmpdir(), "sync-repro-"));
+
+  process.env.PGLITE = "true";
+  process.env.PGLITE_DATA_DIR = dataDir;
+  process.env.DB_HOST = "localhost";
+  process.env.DB_PORT = String(dbPort);
+  process.env.DB_NAME = "postgres";
+  process.env.DB_USER = "postgres";
+  // No MQTT broker in tests: it binds fixed ports (8883/9883) that aren't freed
+  // by halt(), so it would collide on restart. Event publishes are
+  // fire-and-forget and swallowed when no broker is present.
+  process.env.MQTT_BROKER = "false";
+
+  const makePool = (port: number) =>
+    new pg.Pool({
+      host: "localhost",
+      port,
+      user: "postgres",
+      database: "postgres",
+      max: 1,
+    });
+
+  let pglite = await startPglite(dbPort);
+  let pool = makePool(dbPort);
+
+  const runNode = async (opts: RunNodeOpts): Promise<RunningNode> => {
+    // Re-assert THIS harness's DB env before booting. Tests may create multiple
+    // harnesses (each calls setupHarness, which mutates the shared process.env);
+    // without this the node would connect to whichever harness ran setup last.
+    process.env.PGLITE = "true";
+    process.env.PGLITE_DATA_DIR = dataDir;
+    process.env.DB_HOST = "localhost";
+    process.env.DB_PORT = String(dbPort);
+    process.env.DB_NAME = "postgres";
+    process.env.DB_USER = "postgres";
+    process.env.MQTT_BROKER = "false";
+    process.env.EFFECTSTREAM_API_PORT = String(opts.apiPort);
+    // The PrimitiveRegistry is a process-global singleton. A real restart gets
+    // a fresh process; here we clear it in place so primitives re-register
+    // cleanly (otherwise "Primitive ... already exists").
+    const reg = (globalThis as { EFFECTSTREAM_REGISTRY?: Record<string, unknown> })
+      .EFFECTSTREAM_REGISTRY;
+    if (reg) for (const k of Object.keys(reg)) delete reg[k];
+    let captured: AllSyncProtocols[] = [];
+    let bootErr: unknown = undefined;
+    const cfg = opts.config;
+    const task = run(function* () {
+      yield* init();
+      yield* withEffectstreamStaticConfig(cfg, function* () {
+        yield* start({
+          appName: "sync-repro",
+          appVersion: "1.0.0",
+          syncInfo: toSyncProtocolWithNetwork(cfg),
+          gameStateTransitions: noopStf,
+          userDefinedPrimitives: { [TEST_PRIMITIVE_TYPE]: TestEventPrimitive },
+          dev: {
+            resetPublicData: false,
+            onStarted: ({ syncProtocols }) => {
+              captured = syncProtocols;
+            },
+          },
+        });
+      });
+    });
+    // start() runs forever; surface boot failures instead of an unhandled
+    // reject. `halted` is the expected rejection from stop()/task.halt().
+    Promise.resolve(task).catch((e) => {
+      if (String(e).includes("halted")) return;
+      bootErr = e;
+    });
+    return {
+      task,
+      syncProtocols: () => captured,
+      bootError: () => bootErr,
+      stop: async () => {
+        await task.halt();
+      },
+    };
+  };
+
+  const harness: Harness = {
+    pglite,
+    pool,
+    dataDir,
+    runNode,
+    simulateRestart: async () => {
+      // Keep the PGLite server alive (closing/reopening it is WASM-fragile and
+      // loses state). State persists in the live instance; the node task is
+      // halted/rebooted by the test. The stopped node's pool lingers but the
+      // gateway multiplexes sockets over the one PGLite db.
+    },
+    teardown: async () => {
+      TestChainControl.clear();
+      await pool.end().catch(() => {});
+      await pglite.close().catch(() => {});
+      rmSync(dataDir, { recursive: true, force: true });
+    },
+  };
+  return harness;
+}
+
+// ── Polling helpers ──────────────────────────────────────────────────────────
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Latest finalized effectstream block height (incl. empty blocks). */
+export async function latestFinalizedHeight(pool: pg.Pool): Promise<number> {
+  try {
+    const res = await pool.query(
+      `SELECT MAX(block_height)::int AS h FROM effectstream.effectstream_blocks
+       WHERE effectstream_block_hash IS NOT NULL`,
+    );
+    return res.rows[0]?.h ?? 0;
+  } catch (e) {
+    // The system migrations may not have created the table yet during boot.
+    if ((e as { code?: string })?.code === "42P01") return 0;
+    throw e;
+  }
+}
+
+/** Wait until finalized height reaches `target` (or timeout). */
+export async function waitForHeight(
+  node: RunningNode,
+  pool: pg.Pool,
+  target: number,
+  timeoutMs = 30_000,
+): Promise<number> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const err = node.bootError();
+    if (err) throw new Error(`node boot failed: ${String(err)}`);
+    const h = await latestFinalizedHeight(pool);
+    if (h >= target) return h;
+    await sleep(50);
+  }
+  throw new Error(
+    `waitForHeight(${target}) timed out at ${await latestFinalizedHeight(pool)}`,
+  );
+}
+
+/**
+ * Wait until the finalized height stops advancing for `quietMs` (the system
+ * has reached its deterministic stable state given fixed tips).
+ */
+export async function waitUntilStable(
+  node: RunningNode,
+  pool: pg.Pool,
+  { quietMs = 800, timeoutMs = 30_000 } = {},
+): Promise<number> {
+  const startedAt = Date.now();
+  let last = -1;
+  let lastChange = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const err = node.bootError();
+    if (err) throw new Error(`node boot failed: ${String(err)}`);
+    const h = await latestFinalizedHeight(pool);
+    if (h !== last) {
+      last = h;
+      lastChange = Date.now();
+    } else if (Date.now() - lastChange >= quietMs) {
+      return h;
+    }
+    await sleep(50);
+  }
+  return last;
+}
+
+/** Count primitive_accounting rows whose payload carries the given marker. */
+export async function countEventRows(
+  pool: pg.Pool,
+  marker: string,
+): Promise<number> {
+  const res = await pool.query(
+    `SELECT COUNT(*)::int AS c FROM effectstream.primitive_accounting
+     WHERE payload->>'marker' = $1`,
+    [marker],
+  );
+  return res.rows[0]?.c ?? 0;
+}
+
+/** Page-queue rows for a protocol (the durable per-chunk queue). */
+export async function pageRows(
+  pool: pg.Pool,
+  protocolName: string,
+): Promise<{ page_number: number }[]> {
+  const res = await pool.query(
+    `SELECT page_number FROM effectstream.sync_protocol_pagination
+     WHERE protocol_name = $1 ORDER BY page_number ASC`,
+    [protocolName],
+  );
+  return res.rows;
+}
+
+/** Hex of the most-recent non-empty (non-"0x0") effectstream block hash. */
+export async function lastNonEmptyBlockHash(
+  pool: pg.Pool,
+): Promise<string | null> {
+  try {
+    const res = await pool.query(
+      `SELECT encode(effectstream_block_hash, 'hex') AS h
+       FROM effectstream.effectstream_blocks
+       WHERE effectstream_block_hash IS NOT NULL
+         AND effectstream_block_hash != '\\x307830'::bytea
+       ORDER BY block_height DESC LIMIT 1`,
+    );
+    return res.rows[0]?.h ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Sample a protocol's in-memory buffered-data size now. */
+export function bufferSize(
+  node: RunningNode,
+  protocolName: string,
+): number {
+  const sp = node.syncProtocols().find((p) => p.name === protocolName);
+  return sp ? sp.bufferedData.size() : 0;
+}
+
+export { sleep };

--- a/packages/node-sdk/runtime/test/reproduction/sanity.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/sanity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Sanity end-to-end test for the synthetic `test` chain (no fixes required).
+ *
+ * Proves the foundation this PR adds works: a TEST_MAIN clock + a TEST_PARALLEL
+ * chain sync through the real runtime (`start()` + PGLite), a config-declared
+ * event is processed into `effectstream.primitive_accounting`, and committed
+ * state survives a restart.
+ *
+ * (The buffering / resume / fast-catchup reproduction tests land alongside their
+ * fixes in follow-up PRs — they assert behaviour that only those fixes provide.)
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+  ConfigBuilder,
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+} from "@effectstream/config";
+import { TestChainControl } from "@effectstream/sync";
+import {
+  countEventRows,
+  type Harness,
+  latestFinalizedHeight,
+  setupHarness,
+  TEST_PRIMITIVE_TYPE,
+  waitForHeight,
+  waitUntilStable,
+} from "./harness.ts";
+
+const START_TIME = 1_700_000_000_000;
+const BLOCK_TIME_MS = 1000;
+
+function buildConfig() {
+  return new ConfigBuilder()
+    .setNamespace((b) => b.setSecurityNamespace("sync-sanity"))
+    .buildNetworks((b) =>
+      b
+        .addNetwork({
+          name: "clock",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+        .addNetwork({
+          name: "chainP",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+    )
+    .buildDeployments((b) => b)
+    .buildSyncProtocols((b) =>
+      b
+        .addMain(
+          (n) => n.clock,
+          () => ({
+            name: "mainClock",
+            type: ConfigSyncProtocolType.TEST_MAIN,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: 1000,
+          }),
+        )
+        .addParallel(
+          (n) => (n as any).chainP,
+          () => ({
+            name: "parallelP",
+            type: ConfigSyncProtocolType.TEST_PARALLEL,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: 1000,
+            delayMs: 0,
+            events: [{ atBlock: 50, payload: { marker: "evt50" } }],
+          }),
+        )
+    )
+    .buildPrimitives((b) =>
+      b.addPrimitive(
+        (sp) => (sp as any).parallelP,
+        () => ({
+          name: "testEvt",
+          type: TEST_PRIMITIVE_TYPE,
+          startBlockHeight: 1,
+        }),
+      )
+    )
+    .build();
+}
+
+let h: Harness;
+
+beforeAll(async () => {
+  h = await setupHarness();
+});
+
+afterAll(async () => {
+  await h?.teardown();
+});
+
+test("test chain syncs, processes a configured event, and survives restart", async () => {
+  // Parallel tip (200) stays ahead of the main clock (100) so the merge is not
+  // gated at the chunk boundary.
+  TestChainControl.setTip("mainClock", 100);
+  TestChainControl.setTip("parallelP", 200);
+
+  const n1 = await h.runNode({ config: buildConfig(), apiPort: 19131 });
+  await waitForHeight(n1, h.pool, 100);
+  await waitUntilStable(n1, h.pool);
+
+  expect(await latestFinalizedHeight(h.pool)).toBe(100);
+  // The event declared at block 50 was processed into primitive_accounting.
+  expect(await countEventRows(h.pool, "evt50")).toBe(1);
+  await n1.stop();
+
+  // Restart: committed state must persist (chain already fully caught up).
+  await h.simulateRestart();
+  TestChainControl.setTip("mainClock", 100);
+  TestChainControl.setTip("parallelP", 200);
+
+  const n2 = await h.runNode({ config: buildConfig(), apiPort: 19132 });
+  await waitUntilStable(n2, h.pool);
+
+  expect(await latestFinalizedHeight(h.pool)).toBe(100);
+  expect(await countEventRows(h.pool, "evt50")).toBe(1);
+  await n2.stop();
+}, 60_000);

--- a/packages/node-sdk/sync/CLAUDE.md
+++ b/packages/node-sdk/sync/CLAUDE.md
@@ -1,0 +1,187 @@
+# `@effectstream/sync` — how the sync service works
+
+This package fetches data from every configured chain, interleaves it into a single
+deterministic stream of **effectstream blocks** ordered by time, and hands that stream
+to the runtime for state-machine execution.
+
+> **Naming gotcha:** despite the project name and an `effect` (Effect-TS) entry in the
+> root `package.json`, the sync service uses **[`effection`](https://frontside.com/effection)**,
+> a generator-based structured-concurrency library. Effect-TS is **not imported anywhere**
+> in source. Everywhere below, an "effect" is an `effection` `Operation<T>` — a lazy,
+> cancellable computation written as a `function*` and composed with `yield*`.
+
+## effection in 30 seconds
+
+| effection | rough analogy |
+|---|---|
+| `Operation<T>` | a lazy, cancellable `async` function |
+| `function*` / `yield*` | `async` / `await` |
+| `spawn(op)` | fork a child task (dies with its parent scope) |
+| `call(() => promise)` / `until(promise)` | `await` a Promise inside an Operation |
+| `all([...ops])` | `Promise.all` |
+| `createChannel()` + `each(ch)` | an async stream / `for await` |
+| `conditionVariable()` (`@effectstream/utils`, `concurrency/condVar.ts`) | a monitor wait/wake |
+
+Because every loop is `spawn`ed under the runtime's `start()` scope, cancelling the parent
+tears down every fetcher, the merge, the heartbeat, and the HTTP server cleanly.
+
+## The pipeline at a glance
+
+```
+config (syncProtocols.main + syncProtocols.parallel)
+        │  genSyncProtocols()  → one SyncState per chain, main at index 0
+        ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  PER-CHAIN FETCH LOOPS              one spawn per protocol             │
+│  startSync(state):  stateToInput → readData → updateState             │
+│    → push Output to bufferedData (Deque)  + wake newData/newPageCondVar│
+│    → upsertPage(page_number = chunk_end) into sync_protocol_pagination │
+│    → producerChannel.send(...)  ← NOTE: nothing consumes this today    │
+└────────────────────────────────────────┬─────────────────────────────┘
+                                          ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  MERGE LOOP   startMerge()    one spawn, produces ONE ChainBlock/iter  │
+│   i=0 main:   toRootOutput(front datum)  → new root block @ timestamp T│
+│   i>0 parallel: wait page>T, drain buffered data ≤T via mergeDatum()   │
+│   → finalizedBlockStream.send(block); then run cleanups (pop Deques)   │
+└────────────────────────────────────────┬─────────────────────────────┘
+                                          ▼
+   runtime/src/main.ts:  for (block of each(finalizedBlockStream))
+     acquire DB mutex → processFinalizedBlock (STF) → COMMIT
+     → removePages(< merged block) → fire-and-forget MQTT events → each.next()
+```
+
+## The three per-chain abstractions (`src/sync-protocols/<chain>/`)
+
+1. **Fetcher** — `BaseDataFetcher` subclass (`base/fetcher.ts`). `readData(input)` fetches a
+   page-range of raw chain data → `DataFetched { output[], lastPage }`. Implements
+   `PaginatedFetcher` (`getLatestPage`, `nextInterval`, `previousInterval`,
+   `intervalFromStart`) for chunked pagination by `stepSize`, and optionally
+   `PrimitiveFetcher` (`base/primitive.ts`: `readPrimitives` / `groupByPage`) to extract
+   app-relevant primitives from raw blocks.
+
+2. **State** — `SyncState` subclass (`base/state.ts`). Holds `bufferedData` (a `denque`
+   Deque of fetched-not-yet-merged data, `state.ts:50`), `lastPage` (high-water mark,
+   `state.ts:70`), two CondVars (`newDataCondVar` / `newPageCondVar`, `state.ts:57-63`),
+   and error/health counters. Defines the chain↔root contract:
+   - `stateToInput()` — compute the next page-range to fetch (via `common/page-helpers.ts:genInputRange`)
+   - `toRootPage()` — map a block → millisecond timestamp (the **merge key**)
+   - `toRootOutput()` — **main only** — produce a root `ChainBlock`
+   - `mergeDatum()` — **parallel only** — fold this chain's data into the root
+   - `updateState()` (`state.ts:109`) — push outputs to the Deque, wake CondVars, and
+     persist the page (`upsertPage`, `state.ts:132`).
+
+3. **types.ts** — `Input` / `Output` / `Page` aliases (+ a `Client.ts` per chain where an
+   RPC client is needed).
+
+**main vs parallel** is structural in config — `toSyncProtocolWithNetwork`
+(`@effectstream/config`, `config/utils.ts`) builds the array **main-first**, then parallels —
+but enforced at runtime only by thrown errors: e.g. `evm/state.ts` `toRootOutput` throws
+"Only main chains create root outputs"; `ntp/state.ts` `mergeDatum` throws "Only parallel
+chains merge into root". **The main chain must be at index 0.**
+
+## The two driving loops
+
+**`startSync(state)`** (`src/sync-protocols/orchestration/sync.ts`) spawns:
+- `startAsync()` — optional background producer (websocket subs for utxorpc/midnight;
+  no-op for NTP/EVM).
+- the **polling loop**: `stateToInput()` → `readData()` → `updateState()` →
+  `producerChannel.send()` (`sync.ts:70`). Errors are swallowed via `tryYield`, bump
+  `consecutiveErrors`, log, sleep `pollingInterval`, continue. The loop only sleeps when
+  `stateToInput` returns `undefined` (caught up); while behind it fetches chunks
+  back-to-back.
+
+**`startMerge(syncProtocols, finalizedBlockStream)`** (`orchestration/merge.ts`) loops; per
+iteration it walks protocols in order:
+- **main (i=0, root not yet set):** wait for first page, peek the front buffered datum,
+  `toRootOutput` → a fresh `ChainBlock` whose `timestamp` becomes the slot boundary `T`.
+- **parallel (i>0):** block on `newPageCondVar` until *that chain's page has advanced past
+  `T`* (proving it scanned all data up to `T`), then drain every buffered datum with
+  timestamp ≤ `T` into the root via `mergeDatum`.
+- send the block downstream, **then** run cleanups that pop consumed data from each Deque.
+
+## Key design ideas
+
+1. **Time is the universal merge key.** Every chain maps blocks → ms timestamp. The main
+   chain (usually NTP, a wall-clock heartbeat at `blockTimeMS`) emits empty root blocks at a
+   fixed cadence; parallel chains' data is bucketed into those slots.
+2. **Page ≠ Data.** `lastPage` advances even on an empty query, so a parallel chain can
+   signal "scanned up to `T`, found nothing" and let the merge proceed. `newPageCondVar`
+   = progress; `newDataCondVar` = content.
+3. **Confirmation depth as a time shift.** `common/utils.ts:applyDelay` *adds* `delayMs` to
+   a parallel chain's timestamp so older blocks merge into more-recent root slots.
+4. **Mutate-after-commit.** `OutputAndCleanup` keeps data in the Deque until the block is
+   safely produced; the consumer commits to Postgres *before* emitting events.
+5. **Durable, resumable page queue.** `effectstream.sync_protocol_pagination` is keyed
+   `(protocol_name, page_number)`. Fetch appends a row per chunk (`upsertPage`,
+   `page_number = chunk_end`); on commit the consumer deletes consumed chunks
+   (`removePages(page_number < merged_block)`, `runtime/process-blocks.ts:328`); on boot
+   `restoreState` resumes from `getPage` = `ORDER BY page_number ASC LIMIT 1` (oldest
+   remaining chunk).
+
+---
+
+## Findings (open issues, as of this investigation)
+
+Both bite hardest during **deep catch-up** — e.g. DB synced 3 days ago with a 0.25s chain
+(~1.04M blocks behind) and a 6s chain (~43k behind), NTP main at `blockTimeMS: 1000`.
+
+### 1. Unbounded buffering + head-of-line blocking (performance / OOM)
+
+The fetch loop has **no backpressure** and **no clamp** relative to the merge or other
+chains: `genInputRange` (`common/page-helpers.ts`) clamps each fetch only to the chain's own
+tip and `nextPage + stepSize`. A `grep` confirms the only reads of `bufferedData.size()` are
+the merge's first-datum wait (`merge.ts:110`) and the heartbeat log (`runtime/main.ts:106`) —
+nothing pauses fetching when the Deque grows.
+
+Consequences during catch-up:
+- Each chain races to its own tip, filling its in-memory Deque toward the **entire backlog**
+  (~1.04M block objects for the 0.25s chain; NTP fills ~259k near-instantly since it's pure
+  arithmetic). Drain happens only at serial-replay speed (one DB txn + STF per block in
+  `processFinalizedBlock`), which is far slower than fetch → peak memory ≈ whole backlog →
+  **OOM risk**. No cap exists.
+- The merge is gated per timestamp `T` on the slowest chain's *page* to advance
+  (`mergeIntoRoot`, `merge.ts`), so a slow/stalled chain stalls all block production while
+  the others keep ballooning (head-of-line blocking).
+
+→ Fix: **(C) backpressure** — cap `bufferedData` and pause the fetch loop until the merge drains.
+
+### 2. Silent data gap on restart (correctness)
+
+The page queue is **chunk-granular** but commits are **single-block-granular**:
+- fetch persists `upsertPage(page_number = chunk_end)` (`base/state.ts:132`; `own = ownBlockNumber = Number(data.to)`),
+- commit deletes `removePages(page_number < merged_block_N)` (`process-blocks.ts:328`),
+- restart resumes from `getPage` = oldest remaining chunk, at `nextInterval(own).from = chunk_end + 1`.
+
+During catch-up chunks are full `stepSize`, so at restart the committed watermark `N` sits
+**inside** the oldest retained chunk `[start, end]` (`start ≤ N < end ⇒ end ≥ N ⇒ not deleted`).
+Resume jumps to `end + 1`, **silently skipping source blocks `(N, end]`** (up to
+`stepSize - 1`). The in-memory Deque held them; they're gone on restart; the effectstream
+height continues seamlessly with **missing primitives → divergent app state**. There is
+**no error** and **no restart/resume test** (the only tests in `test/examples.test.ts` are
+export smoke-checks). The existing `getSyncAndLastPage` `synced_page` (`MIN(page_number)`)
+is itself chunk-granular and does not reflect the true committed block.
+
+→ Fix: **(D) block-accurate resume** — persist the committed per-protocol watermark and
+resume from `watermark + 1`, reconciling stale fetched-ahead page rows.
+
+### 3. Serial replay is the catch-up bottleneck
+
+Block cadence is the main chain's granularity (1/s for NTP@1000), so 3 days ≈ 259,200
+effectstream blocks, each a separate DB transaction + STF run. Most are empty during
+catch-up.
+
+→ Fix: **(E) faster replay** (conservative, flag-gated) — coalesce consecutive empty
+catch-up blocks into fewer transactions while preserving steady-state semantics and the
+block-hash chain.
+
+> This PR adds the synthetic `test` chain (`src/sync-protocols/test/`) and an
+> in-process harness (`packages/node-sdk/runtime/test/reproduction/`, in the
+> runtime package because it boots the full `start()`, which sync must not depend
+> on). `sanity.test.ts` proves the chain syncs, processes a configured event, and
+> survives a restart. See `docs/ADDING-A-SYNC-PROTOCOL.md` for how to add a chain
+> (with `test` as the worked example).
+>
+> Deterministic reproductions of #1/#2/#3 and their fixes land in **follow-up
+> PRs**, each test alongside its fix: #1 → fetch backpressure; #2 →
+> block-accurate resume; #3 → opt-in empty-block commit batching during catch-up.

--- a/packages/node-sdk/sync/docs/ADDING-A-SYNC-PROTOCOL.md
+++ b/packages/node-sdk/sync/docs/ADDING-A-SYNC-PROTOCOL.md
@@ -1,0 +1,164 @@
+# Adding a new chain / sync protocol
+
+This is the end-to-end checklist for registering a new chain, distilled from
+adding the synthetic **`test`** chain (its files are the worked example — search
+for `TEST_MAIN` / `TEST_PARALLEL` / `ConfigNetworkType.TEST`). Read
+`packages/node-sdk/sync/CLAUDE.md` first for how the sync service works.
+
+A chain needs a **network type** (`ConfigNetworkType`) and one or more
+**sync-protocol types** (`ConfigSyncProtocolType`). A network may have several
+sync protocols (e.g. Cardano has CARP + UTXORPC; the `test` chain has a `main`
+clock variant and a `parallel` variant). Each sync protocol is either **main**
+(produces root blocks via `toRootOutput`) or **parallel** (folds data into the
+root via `mergeDatum`).
+
+> TypeScript is your friend here: several registries are
+> `satisfies Record<ConfigSyncProtocolType, …>`, so the compiler forces you to
+> add entries. But note this repo does **not** typecheck cleanly under
+> `bunx tsc` (it runs via bun's loaders); validate by running
+> `bun test ./packages` and a config that uses the new chain.
+
+## Pick an archetype to copy
+
+Start from the closest existing chain rather than from scratch:
+
+| Your chain | Copy | Notes |
+|---|---|---|
+| Synthetic / arithmetic clock (no RPC) | `ntp/`, `test/` | blocks computed from `startTime`+`blockTimeMS`; main role |
+| RPC, polled, emits primitives (parallel) | `evm/` | `getLatestPage` from RPC; `readPrimitives` filters logs; needs a viem client |
+| Bitcoin-style RPC | `bitcoin/` | custom `Client.ts` (`BitcoinRpcClient`), small `stepSize` (25) |
+| Streaming / subscription (push) | `utxorpc/`, `midnight/` | override **`startAsync`**; a `Client.ts` + a multiplexer/buffer feed the channel |
+| Substrate-based | `avail/`, `midnight/` | substrate network schema + genesis hash |
+| NEAR-style | `near/` | `Client.ts`, event-standard filters |
+
+`stepSize` (chunk size) defaults vary by chain: 1000 (EVM/NTP/Avail), 25
+(Bitcoin), 10 (Midnight/Celestia/NEAR) — pick what the RPC can serve per call.
+
+## 1. Config (`@effectstream/config`, `src/schema/`)
+
+- **`network/types.ts`** — add to the `ConfigNetworkType` enum.
+- **`network/<chain>.ts`** (new) — a `new ConfigSchema({ required, optional })`
+  describing the network (mirror `network/ntp.ts`). Optional fields **must** have
+  a `default`.
+- **`network/all.ts`** — import the schema and add it to `networkTypes`. (This is
+  all that's needed for the network to appear in `NetworkConfig` — it's derived
+  from `networkTypes`.)
+- **`network/utils.ts`** — add a `case` to `caip2PrefixFor` (the trailing
+  `throw` means an un-handled type fails at runtime).
+- **`sync-protocols/types.ts`** —
+  - add to the `ConfigSyncProtocolType` enum;
+  - add to `SyncProtocolToNetwork` (**exhaustive** `satisfies Record`);
+  - add a `…Primitive` type and an entry in `ProtocolPrimitiveMap`.
+- **`sync-protocols/<chain>/rpc.ts`** (new) — `ConfigSchema`s for each variant +
+  a `CommonResponse…` per variant (mirror `ntp/rpc.ts` for main,
+  `evm/rpc.ts` for parallel). Shared fields come from `NameField`,
+  `PollingSyncProtocol`, `StartStopBlockheight` via `.cloneMerge(...)`.
+- **`sync-protocols/all.ts`** — register each variant in `mainSyncProtocolTypes`
+  / `parallelSyncProtocolTypes`, and its `CommonResponse` in
+  `syncProtocolCommonResponse` (**exhaustive** `satisfies Record`).
+- **`primitive/types.ts`** — add a payload type + entry in `ProtocolPayloadMap`
+  (used by `FlattenSyncProtocolIOFor`).
+
+`mod.ts` re-exports are optional for the rpc files (NTP/NEAR/test rpc are *not*
+re-exported; `all.ts` imports them directly). `CommonResponse` has **no
+node-sdk runtime consumer** — it's config-side type derivation — so you have
+latitude on its exact shape.
+
+## 2. Sync (`@effectstream/sync`, `src/`)
+
+- **`sync-protocols/<chain>/types.ts`** — `Page`, `Input` (`PageSyncRange<Page>`),
+  `Output` (must include `primitives: PrimitiveType[]` if the chain emits any),
+  `PrimitiveType = FlattenSyncProtocolIOFor<…>`, `toMsTimestamp`.
+- **`sync-protocols/<chain>/fetcher.ts`** — extend `BaseDataFetcher`; implement
+  `readData` (+ `PaginatedFetcher`: `getLatestPage`/`nextInterval`/
+  `previousInterval`/`intervalFromStart`, and `PrimitiveFetcher` if it emits
+  primitives). `lastPage.own`/`ownBlockNumber` = the **chunk end** (`data.to`).
+  Page-request helpers live in `base/page.ts`
+  (`genImmediatePageRequests`/`genOnDemandPageRequests`).
+- **`sync-protocols/<chain>/Client.ts`** (new, only if it talks to a node) — the
+  RPC/stream client (e.g. `bitcoin/fetcher.ts:BitcoinRpcClient`,
+  `near/NearClient.ts`). EVM-family chains instead use a viem client built with
+  `createViemPublicClient` + `getViemNetwork` (declare the network via the
+  builder's `addViemNetwork`).
+- **`sync-protocols/<chain>/state.ts`** — extend `SyncState`; implement
+  `stateToInput` (via `common/page-helpers.ts:genInputRange`), `toRootPage`
+  (→ ms timestamp; use `applyDelay` for confirmation depth), `toRootOutput`
+  (main), `mergeDatum` (parallel), `getNamespace`, and a static `restoreState`
+  that reads `getPage`. For **streaming** chains, override **`startAsync()`** to
+  run the subscription/producer in the background (it feeds `bufferedData`);
+  polled chains leave it as the no-op default. (A `maxBufferedData` backpressure
+  cap on the constructor is a planned follow-up — see CLAUDE.md finding #1.)
+- **`syncProtocolFactory.ts`** — add an `else if (entry.networkType === …)`
+  branch constructing the client + fetcher + `restoreState`.
+- **`sync-protocols/types.ts`** — add the state class to the `AllSyncProtocols`
+  union.
+- **`sync-protocols/mod.ts`** — export the new fetcher/state.
+
+## 3. Runtime (`@effectstream/runtime`, `src/`)
+
+- **`api/http-server.ts`** — add a `case` to the `switch (networkType)` in the
+  blocks endpoint (import the fetcher).
+- **`config-snapshot.ts`** — `extractImmutableConfig` **throws** for un-handled
+  protocol types. Add the chain to the right branch (NTP/TEST share
+  `startTime`+`blockTimeMS`; most parallel chains use `startBlockHeight`).
+- **`main.ts` clock detection** (only if your chain can be the **main** clock) —
+  the lag threshold is derived from the main clock's `blockTimeMS` via a
+  `syncInfo.find(...)` that today keys on `NTP_MAIN`. If your chain is a new main
+  clock and you want lag logging (and the planned catch-up batching) to engage,
+  add its `*_MAIN` type to that predicate.
+
+## 4. Primitives (only if the chain emits data)
+
+A fetched primitive's `primitive` field must equal a **registered primitive's
+instanceName**, which is the config primitive's `id` (= its `name`). The fetcher
+typically tags emitted primitives with `this.config.primitives[i].id`. The
+primitive class (built-in in `@effectstream/sm` or supplied via
+`StartConfig.userDefinedPrimitives`) turns raw data into `primitive_accounting`
+rows and optional scheduled STF inputs.
+
+## Gotchas / learnings
+
+- **One network → many sync protocols** is allowed (Cardano, `test`). `FlipObject`
+  unions them, so `addMain`/`addParallel` narrow correctly.
+- **Resume is currently chunk-granular** (a known issue — CLAUDE.md finding #2):
+  on restart a chain resumes from the *end* of its oldest retained page chunk,
+  which can silently skip an un-committed tail. A block-accurate-resume fix is
+  planned; until then, avoid relying on exact restart positions mid-chunk.
+- **Merge boundary gate**: a parallel chain only merges into a root block at
+  timestamp `T` once its own page is *strictly* past `T`. If the main clock runs
+  to the same height as a parallel chain's fetched tip, the merge stalls at that
+  boundary — keep the main clock at/behind the parallel tips.
+- **`finalizedBlockStream` is unbuffered**: a message sent with no active
+  subscriber is dropped. The merge is spawned before the consumer loop
+  subscribes, so a very fast producer could in principle drop early blocks
+  (RPC-paced chains don't hit this); a subscribe-before-spawn hardening is a
+  planned follow-up.
+- **`isPresync`** is currently ~always false (`genInputRange` TODO) — the
+  historical-presync path may not trigger as intended.
+
+## Verify
+
+Build a `ConfigBuilder` config that declares the chain (see
+`packages/node-sdk/runtime/test/reproduction/sanity.test.ts` for the `test`-chain
+config), then `toSyncProtocolWithNetwork(config)` + `start({...})`, or run
+`bun test packages/node-sdk/runtime/test/reproduction/`.
+
+## Testing a new chain (in-process harness)
+
+`packages/node-sdk/runtime/test/reproduction/harness.ts` is the reusable
+template — it boots the real `start()` in-process against an in-process PGLite
+server and the synthetic `test` chain. Reuse its patterns for any chain:
+
+- **Env is lazy** (`ENV.*` reads `process.env` at access), so set
+  `PGLITE`/`DB_*`/`EFFECTSTREAM_API_PORT` per run before `start()`. With multiple
+  harnesses in one file, re-assert DB env in `runNode` (shared `process.env`).
+- **Determinism**: drive the synthetic chain's tip via the in-memory
+  `TestChainControl` registry (no real clock); poll with
+  `waitForHeight`/`waitUntilStable` (fixed tips → a well-defined stable state).
+- **Observe live state** via the test-only `StartConfig.dev.onStarted` hook
+  (exposes the `AllSyncProtocols[]`, e.g. for `bufferedData.size()` assertions)
+  and assert effects against DB tables (`primitive_accounting`,
+  `rollup_input_result`, `effectstream_blocks`, `sync_protocol_pagination`).
+- **Simulate a restart** by halting the node task while keeping PGLite alive
+  (state persists), then booting again.
+- Set `MQTT_BROKER=false` (it binds fixed ports that aren't freed on halt).

--- a/packages/node-sdk/sync/src/sync-protocols/mod.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/mod.ts
@@ -19,6 +19,10 @@ export * from "./utxorpc/state.ts";
 export * from "./celestia/fetcher.ts";
 export * from "./celestia/state.ts";
 
+export * from "./test/fetcher.ts";
+export * from "./test/state.ts";
+export * from "./test/control.ts";
+
 export type * from "./base/fetcher.ts";
 export type * from "./base/state.ts";
 export * from "./orchestration/merge.ts";

--- a/packages/node-sdk/sync/src/sync-protocols/test/control.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/control.ts
@@ -1,0 +1,27 @@
+/**
+ * Test-only control plane for the synthetic `test` sync protocol.
+ *
+ * The chain tip ("latest block") is held in a process-wide registry keyed by
+ * sync-protocol name, rather than in config, so a single test can advance it
+ * deterministically between simulated restarts. (Immutable config fields like
+ * `startTime` cannot change across a restart, so they can't drive this.)
+ *
+ * When no tip is registered for a protocol, the fetcher falls back to a
+ * wall-clock tip derived from `startTime`/`blockTimeMS` (see fetcher.ts).
+ */
+const tips = new Map<string, number>();
+
+export const TestChainControl = {
+  /** Set the current chain tip (latest available block) for a protocol. */
+  setTip(protocolName: string, tip: number): void {
+    tips.set(protocolName, tip);
+  },
+  /** Get the manually-controlled tip, or undefined to fall back to wall-clock. */
+  getTip(protocolName: string): number | undefined {
+    return tips.get(protocolName);
+  },
+  /** Reset all tips (call between tests). */
+  clear(): void {
+    tips.clear();
+  },
+};

--- a/packages/node-sdk/sync/src/sync-protocols/test/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/fetcher.ts
@@ -1,0 +1,175 @@
+import {
+  BaseDataFetcher,
+  type DataFetched,
+  type PaginatedFetcher,
+} from "../base/fetcher.ts";
+import type { RootOutput, RootPage } from "../types.ts";
+import type { Operation } from "effection";
+import { bound } from "@effectstream/utils";
+import { blockNumberRelation } from "../common/utils.ts";
+import type { Input, Output, Page, PrimitiveType } from "./types.ts";
+import {
+  fetchNewestPage,
+  type PageRange,
+  type PageRequest,
+} from "../base/page.ts";
+import type { PrimitiveFetcher } from "../base/primitive.ts";
+import type { OutputAndCleanup, RootConversion } from "../base/state.ts";
+import {
+  ConfigSyncProtocolType,
+  type ConfigNetworkType,
+  type PrimitiveEntry,
+  type SyncProtocolWithNetwork,
+} from "@effectstream/config";
+import { TestChainControl } from "./control.ts";
+
+type TestConfig = Extract<
+  SyncProtocolWithNetwork,
+  { networkType: ConfigNetworkType.TEST }
+>;
+
+type TestEvent = { atBlock: number; payload: Record<string, unknown> };
+
+/**
+ * Synthetic chain fetcher. Blocks are computed arithmetically (no RPC):
+ *   timestamp(page) = startTime + blockTimeMS * page
+ * The chain tip comes from {@link TestChainControl} when set (deterministic
+ * tests), otherwise from the wall clock. Configured `events` are emitted as
+ * primitives when their `atBlock` is reached.
+ */
+export class TestFetcher
+  extends BaseDataFetcher<Input, Output, RootOutput, Page, RootPage>
+  implements
+    PrimitiveFetcher<
+      Input,
+      Page,
+      { blockNumber: number; timestamp: bigint; hash: string },
+      PrimitiveType,
+      ConfigSyncProtocolType.TEST_PARALLEL
+    >,
+    PaginatedFetcher<Page> {
+  constructor(
+    readonly config: TestConfig,
+  ) {
+    super(config.syncProtocol.name);
+  }
+
+  private blockOf(page: Page): Output["raw"] {
+    const timestamp = BigInt(this.config.network.startTime) +
+      BigInt(this.config.network.blockTimeMS) * BigInt(page);
+    return {
+      blockNumber: page,
+      timestamp,
+      hash: `0x${timestamp.toString(16)}`,
+    };
+  }
+
+  @bound
+  override *readData(
+    data: Input,
+    rootConversion: RootConversion<Output, RootOutput, RootPage>,
+  ): Operation<DataFetched<Output, Page, RootPage>> {
+    // Events are declared on the (parallel) sync protocol config. The primitive
+    // instance name to tag them with is the first declared primitive's id.
+    const events: TestEvent[] =
+      (this.config.syncProtocol as { events?: TestEvent[] }).events ?? [];
+    const primitiveId = this.config.primitives[0]?.id;
+
+    const output: OutputAndCleanup<Output>[] = [];
+    for (let page = data.from; page <= data.to; page++) {
+      const raw = this.blockOf(page);
+      const primitives: PrimitiveType[] = [];
+      if (primitiveId != null) {
+        for (const ev of events) {
+          if (ev.atBlock === page) {
+            primitives.push({
+              syncProtocol: {
+                name: ConfigSyncProtocolType.TEST_PARALLEL,
+                blockNumber: page,
+                transactionHash: `0x${page.toString(16)}`,
+                contractAddress: "0x0",
+              },
+              primitive: primitiveId,
+              output: { payloadType: "test-event", payload: ev.payload },
+            });
+          }
+        }
+      }
+      output.push({
+        output: { raw, primitives, blockHashes: [raw.hash] },
+        cleanup: () => {},
+      });
+    }
+
+    return {
+      output,
+      lastPage: {
+        own: Number(data.to),
+        ownBlockNumber: Number(data.to),
+        root: rootConversion.toRootPage({
+          raw: this.blockOf(Number(data.to)),
+          primitives: [],
+          blockHashes: [],
+        }),
+      },
+    };
+  }
+
+  @bound
+  groupByPage(
+    _primitives: PrimitiveType[],
+  ): Record<string, PrimitiveType[]> {
+    // Primitives are attached inline in readData; not used.
+    return {};
+  }
+
+  @bound
+  *readPrimitives(
+    _data: Input,
+    _pageRequest: PageRequest<Page, { timestamp: bigint; hash: string }>,
+    _primitiveEntries: Extract<
+      PrimitiveEntry,
+      { syncProtocol: ConfigSyncProtocolType.TEST_PARALLEL }
+    >[],
+  ): Operation<PrimitiveType[]> {
+    return [];
+  }
+
+  @bound
+  *getLatestPage(
+    knownLastPage: undefined | Page,
+  ): Operation<Page> {
+    const self = this;
+    return yield* fetchNewestPage<Page>(
+      blockNumberRelation,
+      function* (): Operation<Page> {
+        const manual = TestChainControl.getTip(self.config.syncProtocol.name);
+        if (manual != null) return manual;
+        const diff = Date.now() - self.config.network.startTime;
+        return Math.floor(diff / self.config.network.blockTimeMS);
+      },
+      knownLastPage,
+      this.config.syncProtocol.pollingInterval,
+    );
+  }
+
+  @bound
+  previousInterval(nextIntervalStart: Page): PageRange<Page> {
+    return this.intervalFromStart(
+      nextIntervalStart - this.config.syncProtocol.stepSize - 1,
+    );
+  }
+
+  @bound
+  nextInterval(prevIntervalEnd: Page): PageRange<Page> {
+    return this.intervalFromStart(prevIntervalEnd + 1);
+  }
+
+  @bound
+  intervalFromStart(start: Page): PageRange<Page> {
+    return {
+      from: start,
+      to: start + this.config.syncProtocol.stepSize,
+    };
+  }
+}

--- a/packages/node-sdk/sync/src/sync-protocols/test/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/state.ts
@@ -1,0 +1,142 @@
+import { applyDelay, blockNumberRelation } from "../common/utils.ts";
+import type { Operation } from "effection";
+import { call } from "effection";
+import { getPage } from "@effectstream/db";
+import type { PoolClient } from "pg";
+import { bound, type BlockNumber } from "@effectstream/utils";
+import { type LastPage, SyncState } from "../base/state.ts";
+import type { RootOutput, RootPage } from "../types.ts";
+import type { TestFetcher } from "./fetcher.ts";
+import { genInputRange } from "../common/page-helpers.ts";
+import type { Input, Output, Page } from "./types.ts";
+import { toMsTimestamp } from "./types.ts";
+import type {
+  ConfigNetworkType,
+  SyncProtocolWithNetwork,
+} from "@effectstream/config";
+
+type TestConfig = Extract<
+  SyncProtocolWithNetwork,
+  { networkType: ConfigNetworkType.TEST }
+>;
+
+/**
+ * Synthetic test chain state. Implements BOTH roles:
+ * - as a TEST_MAIN clock, `toRootOutput` produces root blocks;
+ * - as a TEST_PARALLEL source, `mergeDatum` folds its primitives into the root.
+ * The merge only calls the method appropriate to the chain's position (main at
+ * index 0), so implementing both is safe.
+ */
+export class TestSyncState extends SyncState<
+  Input,
+  Output,
+  Page,
+  RootOutput,
+  RootPage,
+  TestFetcher
+> {
+  constructor(
+    lastPage: LastPage<Page, RootPage>,
+    readonly config: TestConfig,
+    fetcher: TestFetcher,
+    dbConn: PoolClient,
+  ) {
+    super(
+      config.syncProtocol.name,
+      lastPage,
+      fetcher,
+      blockNumberRelation,
+      dbConn,
+    );
+  }
+
+  @bound
+  override toRootOutput(data: Output): RootOutput {
+    return {
+      blockInfo: data.blockHashes.map((h) => ({
+        protocol_name: this.config.syncProtocol.name,
+        block_number: Number(data.raw.blockNumber),
+        blockHash: h,
+      })),
+      blockNumber: Number(data.raw.blockNumber),
+      timestamp: this.toRootPage(data),
+      primitives: data.primitives.map((p) => ({
+        ...p,
+        source: this.config.syncProtocol.name,
+      })),
+    };
+  }
+
+  @bound
+  override toRootPage(data: Output): RootPage {
+    return applyDelay(
+      toMsTimestamp(data.raw.timestamp),
+      (this.config.syncProtocol as { delayMs?: number }).delayMs ?? 0,
+    );
+  }
+
+  @bound
+  override *stateToInput(): Operation<Input | undefined> {
+    return yield* genInputRange(
+      this as TestSyncState,
+      this.config.syncProtocol.startBlockHeight as BlockNumber,
+      {
+        name: this.config.syncProtocol.name,
+        startPage: this.config.syncProtocol.startBlockHeight as BlockNumber,
+      },
+      this.getNamespace(),
+    );
+  }
+
+  @bound
+  override toPage(
+    _input: Input,
+    _data: Output[],
+  ): Page {
+    return Number(_input.to);
+  }
+
+  @bound
+  override mergeDatum(
+    ourOutput: Output,
+    rootOutput: RootOutput,
+  ): void {
+    const primitives = ourOutput.primitives.map((p) => ({
+      ...p,
+      source: this.config.syncProtocol.name,
+    }));
+    const blockInfo = ourOutput.blockHashes.map((h) => ({
+      protocol_name: this.config.syncProtocol.name,
+      block_number: Number(ourOutput.raw.blockNumber),
+      blockHash: h,
+    }));
+    rootOutput.primitives.push(...primitives);
+    rootOutput.blockInfo.push(...blockInfo);
+  }
+
+  @bound
+  override getNamespace(): string[] {
+    return [this.config.network.name, this.config.syncProtocol.name];
+  }
+
+  static *restoreState(
+    dbConn: PoolClient,
+    config: TestConfig,
+    fetcher: TestFetcher,
+  ): Operation<TestSyncState> {
+    const [result] = yield* call(async () =>
+      await getPage.run({
+        protocol_name: config.syncProtocol.name,
+      }, dbConn)
+    );
+    const page: any = result
+      ? result.page as unknown as LastPage<Page, RootPage>
+      : undefined;
+    return new TestSyncState(
+      page,
+      config,
+      fetcher,
+      dbConn,
+    );
+  }
+}

--- a/packages/node-sdk/sync/src/sync-protocols/test/types.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/types.ts
@@ -1,0 +1,36 @@
+import type { BlockNumber, TimestampMs } from "@effectstream/utils";
+import type { PageSyncRange } from "../common/page-helpers.ts";
+import type {
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+  FlattenSyncProtocolIOFor,
+  SyncProtocolWithNetwork,
+} from "@effectstream/config";
+
+export type Page = BlockNumber;
+
+export type ConfigType = Extract<
+  SyncProtocolWithNetwork,
+  { networkType: ConfigNetworkType.TEST }
+>;
+
+/** Primitives a TEST_PARALLEL chain emits (one per configured event in range). */
+export type PrimitiveType = FlattenSyncProtocolIOFor<
+  ConfigSyncProtocolType.TEST_PARALLEL
+>;
+
+export type Input = PageSyncRange<Page>;
+
+export type Output = {
+  raw: {
+    timestamp: bigint;
+    hash: string;
+    blockNumber: number;
+  };
+  primitives: PrimitiveType[];
+  blockHashes: string[];
+};
+
+export function toMsTimestamp(timestamp: bigint): TimestampMs {
+  return Number(timestamp);
+}

--- a/packages/node-sdk/sync/src/sync-protocols/types.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/types.ts
@@ -10,6 +10,7 @@ import type { AvailSyncState } from "./avail/state.ts";
 import type { BitcoinSyncState } from "./bitcoin/state.ts";
 import type { CelestiaSyncState } from "./celestia/state.ts";
 import type { NearSyncState } from "./near/state.ts";
+import type { TestSyncState } from "./test/state.ts";
 
 // TODO: move folders
 export type RootOutput = ChainBlock;
@@ -24,7 +25,8 @@ export type AllSyncProtocols =
   | AvailSyncState
   | BitcoinSyncState
   | CelestiaSyncState
-  | NearSyncState;
+  | NearSyncState
+  | TestSyncState;
 export type ISyncProtocol = UnionToIntersection<AllSyncProtocols>;
 
 type toPaginated<T> = T extends { fetcher: PaginatedFetcher<infer Page> } ? T

--- a/packages/node-sdk/sync/src/syncProtocolFactory.ts
+++ b/packages/node-sdk/sync/src/syncProtocolFactory.ts
@@ -31,6 +31,8 @@ import { CelestiaFetcher } from "./sync-protocols/celestia/fetcher.ts";
 import { CelestiaSyncState } from "./sync-protocols/celestia/state.ts";
 import { NearFetcher } from "./sync-protocols/near/fetcher.ts";
 import { NearSyncState } from "./sync-protocols/near/state.ts";
+import { TestFetcher } from "./sync-protocols/test/fetcher.ts";
+import { TestSyncState } from "./sync-protocols/test/state.ts";
 
 export function* genSyncProtocols(
   dbConn: PoolClient,
@@ -144,6 +146,17 @@ export function* genSyncProtocols(
     ) {
       const fetcher = new NearFetcher(entry);
       const state = yield* NearSyncState.restoreState(
+        dbConn,
+        entry,
+        fetcher,
+      );
+      result.push(state);
+    } else if (
+      entry.networkType === ConfigNetworkType.TEST
+    ) {
+      // Synthetic test chain (TEST_MAIN clock or TEST_PARALLEL source).
+      const fetcher = new TestFetcher(entry);
+      const state = yield* TestSyncState.restoreState(
         dbConn,
         entry,
         fetcher,


### PR DESCRIPTION
## What

First of a series. This PR lands the **foundation** — a synthetic `test` chain, an in-process test harness, and documentation — with **no behavior fixes** (those follow, each with its reproduction test).

### Test sync protocol (`test`)
A first-class, fully in-memory chain registered across `@effectstream/config` and `@effectstream/sync`:
- `TEST_MAIN` (clock / root producer) + `TEST_PARALLEL` (data source that emits config-declared events as primitives)
- blocks are arithmetic (no RPC); chain tip is controllable via `TestChainControl` for deterministic tests
- lets us emulate any scenario/params/events without a real node

### Harness + e2e
- `packages/node-sdk/runtime/test/reproduction/harness.ts` — boots the real runtime (`start()`) against an in-process PGLite server
- `sanity.test.ts` — **green** end-to-end test: the chain syncs, a configured event reaches `effectstream.primitive_accounting`, and committed state survives a restart
- registered as the `sync-repro` suite in `e2e/runner.ts` (so CI's `bun run e2e/runner.ts` runs it)

### Docs
- `packages/node-sdk/sync/CLAUDE.md` — how the (effection-based) sync service works + findings
- `packages/node-sdk/sync/docs/ADDING-A-SYNC-PROTOCOL.md` — reusable end-to-end "add a chain" checklist + archetypes + gotchas (foundation for a scaffolding skill)

## What's NOT here (follow-up PRs)
The CLAUDE.md documents three findings during catch-up:
1. unbounded in-memory buffering (OOM risk)
2. silent data gap on restart (chunk-granular resume)
3. slow serial replay

Each fix + its deterministic reproduction test ships in its own follow-up PR, kept out of this one so the foundation can land + go green on its own.

## Verify
```
bun test packages/node-sdk/runtime/test/reproduction/   # sanity: green
bun run e2e/runner.ts sync-repro
```
No new `tsc` errors vs base; shared block-processing/commit paths are unchanged.