### PR TITLE
ci: scope feature-branch push diff to the branch delta vs default

### DIFF
--- a/.github/ci-changes.test.ts
+++ b/.github/ci-changes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { classify } from "./ci-changes.ts";
+import { classify, diffArgs } from "./ci-changes.ts";
 
 // A fixed enabled set so these assertions don't shift as templates are
 // enabled/disabled in run-template-tests.ts.
@@ -73,6 +73,34 @@ describe("classify — templates", () => {
       ENABLED,
     );
     expect(r.templates).toEqual(["preorder", "world-map-2d"]);
+  });
+});
+
+describe("diffArgs — diff range selection", () => {
+  const opts = { base: "B", head: "H", headRef: "feat/x", defaultBranch: "v-next" };
+
+  test("pull_request uses three-dot base...head (only what the PR adds)", () => {
+    expect(diffArgs({ ...opts, eventName: "pull_request" })).toEqual([
+      "diff",
+      "--name-only",
+      "B...H",
+    ]);
+  });
+
+  test("push to the default branch uses two-arg before..after", () => {
+    expect(
+      diffArgs({ ...opts, eventName: "push", headRef: "v-next" }),
+    ).toEqual(["diff", "--name-only", "B", "H"]);
+  });
+
+  test("push to a feature branch diffs the merge-base via FETCH_HEAD, not before", () => {
+    // FETCH_HEAD is the freshly-fetched default-branch tip; ...H selects only the
+    // branch's own delta, so a merge of the default branch in is excluded.
+    expect(diffArgs({ ...opts, eventName: "push" })).toEqual([
+      "diff",
+      "--name-only",
+      "FETCH_HEAD...H",
+    ]);
   });
 });
 

--- a/.github/ci-changes.ts
+++ b/.github/ci-changes.ts
@@ -13,9 +13,18 @@
  * single source of truth. Unknown / disabled templates drop out here, so a push
  * touching only those produces an empty list and the template job is skipped.
  *
- * Base/head come from BASE_SHA/HEAD_SHA env (injected by the workflow). If the
- * base is missing or all-zeros (new branch, force-push) or the diff fails, we
- * fall back to running everything — over-run rather than miss a real change.
+ * The diff range mirrors GitHub's PR "Files changed" view — only a branch's own
+ * delta, never code it merely merged in from the default branch:
+ *   - pull_request             → three-dot base...head
+ *   - push to a feature branch → three-dot vs the default branch's merge-base
+ *       (DEFAULT_BRANCH / HEAD_REF env). Diffing against `before` would be wrong
+ *       here: on a "merge default into branch" push `before` is an ancestor of
+ *       the merge commit, so before..after still contains everything the merge
+ *       pulled in.
+ *   - push to the default branch → two-arg before..after (BASE_SHA/HEAD_SHA).
+ * If the base is unusable (new branch, force-push) on a path that needs it, or
+ * any git call fails, we fall back to running everything — over-run rather than
+ * miss a real change.
  */
 import { ENABLED } from "../templates/run-template-tests.ts";
 
@@ -82,19 +91,60 @@ function baseIsUnusable(base: string | undefined): boolean {
   return !base || base === ZERO_SHA || /^0+$/.test(base);
 }
 
+/**
+ * Pick the `git` argv (everything after `git`) for collecting changed files.
+ * Pure — exported for unit testing.
+ *
+ *   - pull_request             → three-dot base...head: what the PR adds.
+ *   - push to a feature branch → three-dot against the default branch's fork
+ *       point, via FETCH_HEAD (the caller must fetch the default branch first).
+ *       Diffing against `before` would be wrong: on a "merge default into
+ *       branch" push `before` is an ancestor of the merge commit, so the
+ *       before..after range still contains everything the merge pulled in.
+ *   - push to the default branch → two-arg before..after: the commits that just
+ *       landed on mainline (no branch delta to isolate).
+ */
+export function diffArgs(opts: {
+  eventName: string;
+  base: string;
+  head: string;
+  headRef: string;
+  defaultBranch: string;
+}): string[] {
+  const { eventName, base, head, headRef, defaultBranch } = opts;
+  if (eventName === "pull_request") {
+    return ["diff", "--name-only", `${base}...${head}`];
+  }
+  if (headRef === defaultBranch) {
+    return ["diff", "--name-only", base, head];
+  }
+  return ["diff", "--name-only", `FETCH_HEAD...${head}`];
+}
+
 /** Collect the changed files via git, or return null if the diff can't be run. */
 function changedFiles(
   eventName: string,
   base: string,
   head: string,
+  headRef: string,
+  defaultBranch: string,
 ): string[] | null {
-  // PR: diff against the merge-base (three-dot) to get only what the PR adds.
-  // push: plain two-arg diff between the before/after commits.
-  const args =
-    eventName === "pull_request"
-      ? ["diff", "--name-only", `${base}...${head}`]
-      : ["diff", "--name-only", base, head];
+  // Feature-branch push: fetch the default branch so the three-dot diff has a
+  // FETCH_HEAD to resolve its merge-base against.
+  if (eventName !== "pull_request" && headRef !== defaultBranch) {
+    const fetched = Bun.spawnSync(
+      ["git", "fetch", "--no-tags", "origin", defaultBranch],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    if (fetched.exitCode !== 0) {
+      console.error(
+        `git fetch origin ${defaultBranch} failed:\n${fetched.stderr.toString().trim()}`,
+      );
+      return null;
+    }
+  }
 
+  const args = diffArgs({ eventName, base, head, headRef, defaultBranch });
   const proc = Bun.spawnSync(["git", ...args], { stdout: "pipe", stderr: "pipe" });
   if (proc.exitCode !== 0) {
     console.error(
@@ -109,17 +159,24 @@ if (import.meta.main) {
   const eventName = process.env.EVENT_NAME ?? "push";
   const base = process.env.BASE_SHA;
   const head = process.env.HEAD_SHA ?? "HEAD";
+  const headRef = process.env.HEAD_REF ?? "";
+  const defaultBranch = process.env.DEFAULT_BRANCH ?? "";
+
+  // A feature-branch push diffs against the default branch's merge-base, so it
+  // never reads `before` and the unusable-base fallback doesn't apply to it.
+  const featureBranchPush =
+    eventName !== "pull_request" && !!defaultBranch && headRef !== defaultBranch;
 
   let result: ChangeClassification;
   let files: string[] | null = null;
 
-  if (baseIsUnusable(base)) {
+  if (!featureBranchPush && baseIsUnusable(base)) {
     console.log(
       `No usable base SHA (BASE_SHA=${JSON.stringify(base)}) — running everything.`,
     );
     result = { core: true, templates: [...ENABLED].sort() };
   } else {
-    files = changedFiles(eventName, base!, head);
+    files = changedFiles(eventName, base ?? "", head, headRef, defaultBranch);
     if (files === null) {
       console.log("git diff failed — running everything to be safe.");
       result = { core: true, templates: [...ENABLED].sort() };

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          HEAD_REF: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: bun .github/ci-changes.ts
 
   # Existing Dockerized e2e suite — now gated on core changes.


### PR DESCRIPTION
## What

Stops the change classifier from re-running the e2e suite on a feature branch just because that branch merged `v-next` in.

The `e2e` job is gated on `core` (`packages/**` or `e2e/**` changed). On a push, the classifier diffed the literal `before..after` range. On a **\"merge `v-next` into branch\"** push, `before` is an ancestor of the merge commit, so `before..after` includes every file the merge pulled in from `v-next` — tripping `core=true` even when the branch's own work is templates-only.

Real example — [run 26720820302](https://github.com/effectstream/effectstream/actions/runs/26720820302) on `feat/template-hex-battle-port-to-0.100.18` ran the full e2e suite even though [PR #740's "Files changed"](https://github.com/effectstream/effectstream/pull/740/files) shows only `templates/hex-battle/**`. The merge of `v-next` brought in `packages/effectstream-sdk/wallets/src/midnight/local.{ts,test.ts}` (from #748), which the `before..after` diff counted as a change.

## How

Diff **feature-branch pushes** three-dot against the default branch's merge-base (via `FETCH_HEAD`), mirroring exactly what GitHub's PR "Files changed" tab shows — only the branch's own delta, never code merged in from `v-next`.

- `push` to a feature branch → `git fetch origin <default>` then `git diff FETCH_HEAD...HEAD`
- `push` to the default branch → unchanged (`before..after`: the commits that just landed)
- `pull_request` → unchanged (`base...head`)

> Note: diffing against `before` (the obvious first guess) is a **no-op** here — `before` is an ancestor of the merge commit, so `merge-base(before, head) == before`. The merge-base must be taken against the **default branch**.

### Files
- `.github/ci-changes.ts` — extract pure `diffArgs()`; feature-branch push fetches the default branch and diffs its merge-base; no longer reads `before` on that path (so the unusable-base fallback no longer over-runs new/force-pushed feature branches).
- `.github/workflows/main.yaml` — pass `HEAD_REF` (`github.ref_name`) and `DEFAULT_BRANCH` (`github.event.repository.default_branch`).
- `.github/ci-changes.test.ts` — 3 tests for `diffArgs`.

## Semantic shift (intentional)

Push classification moves from **incremental** (this push's commits) to **cumulative** (whole branch vs `v-next`). So a templates-only push still runs e2e if an *earlier* commit on the branch touched `packages/`. That's the safer, PR-matching model — it can't miss an earlier `packages/` change; it only stops re-running e2e for merged-in `v-next` code.

## Verification

- `bun test ./.github/ci-changes.test.ts` → 13 pass / 0 fail
- Replayed run 26720820302's SHAs: old diff → 2 `packages/` files → `core=true`; new diff (vs `v-next` merge-base `8a278483`) → 65 files, all `templates/` → **`core=false`, e2e skipped**
- Ran the full script with the push's env → emitted `core=false`
- `main.yaml` parses