### PR TITLE
fix(ci): make Chromium discoverable to template Phase C tests via CHROME_PATH

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -121,6 +121,18 @@ RUN /app/patch.sh
 # floating version could fetch a mismatched browser revision).
 RUN cd /app/e2e/wallets-ui && bunx playwright install --with-deps chromium
 
+# Make the Chromium installed above discoverable to the template Phase C frontend
+# tests. Those tests launch Chromium via playwright-core through findChrome(),
+# which probes CHROME_PATH first; without this it fell through to a non-existent
+# /usr/bin/google-chrome and the template-tests job threw at chromium.launch().
+# Pointing CHROME_PATH at the Playwright browser keeps it version-matched to the
+# playwright-core the templates launch it with.
+RUN CHROME_BIN="$(find /root/.cache/ms-playwright -type f -name chrome -path '*chrome-linux*' | head -1)" \
+ && test -n "$CHROME_BIN" \
+ && ln -sf "$CHROME_BIN" /usr/local/bin/chromium-test \
+ && /usr/local/bin/chromium-test --version
+ENV CHROME_PATH=/usr/local/bin/chromium-test
+
 # ── Common environment ──────────────────────────────────────────────────────
 ENV EFFECTSTREAM_STDOUT=true
 ENV POLKADOTJS_DISABLE_ESM_CJS_WARNING=1


### PR DESCRIPTION
## Summary
The path-aware `template-tests` CI job (added in #747) runs each template's `run-template-tests.ts` **including Phase C frontend tests**, which launch Chromium via `playwright-core` through `findChrome()`. `findChrome()` probes `CHROME_PATH` first, then a list of system paths. Neither exists in the testing image, so it fell through to a non-existent `/usr/bin/google-chrome` and `chromium.launch()` **threw**, failing `template-tests` for every EVM template (dice, rps, generic, paima-dice, nft-lvlup, gamemaker) **and the already-merged `world-map-2d`** — even though Phase A + Phase B (chain, deploy, STM, DB, API) all pass.

## Fix
The image already installs Playwright's Chromium (for the wallets-ui suite). Symlink it to a stable path and set `CHROME_PATH`, so the template tests launch the exact browser `playwright-core` is version-matched to. One line of real change in `.github/Dockerfile`; no template code touched, and Phase C now **runs** in CI instead of throwing.

## Validation
Built the image locally from a clean `git archive` (CI-equivalent) and ran the exact CI command, network-isolated (no `-p`):
```
docker run --rm es-image bash -lc "bun run templates/run-template-tests.ts generic --skip-disabled"
→ Results: 18 passed, 0 failed → [PASS] generic
   incl. "Local-JS wallet connects in headless Chromium" + the full EvmViem Phase C e2e (previously the only failing step)
```

## Scope / notes
- Fixes failure mode **A (Chrome)** for the 6 EVM template PRs + `world-map-2d`.
- Does **not** address the separate `web-2.5`/`hex-battle` hardhat-startup or `trading-cards` sync `25P02` failures (tracked separately; likely flaky/sync-related).
- Follow-ups worth doing: harden `findChrome()` (its `Bun.file(candidate)` existence check is always truthy) and tighten `.dockerignore` (its `**/evm/build` patterns don't match the new flat `contracts-evm/` dirs).