### PR TITLE
Feature: Consistency tests and fixes

### DIFF
--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -7,12 +7,8 @@
  * database survives — the production restart condition).
  *
  * Runs in the default PGLite mode; the Postgres-only consistency tests skip
- * unless invoked with `PGLITE=false` (which needs `postgresql@18` installed).
+ * unless invoked with `PGLITE=false` (which needs `postgresql` installed).
  *
- * The resume-reproduction case (consistency.test.ts) is declared `test.failing`:
- * it reproduces the block-accurate-resume gap (Fix D, see
- * packages/node-sdk/sync/CLAUDE.md) and so counts as an expected failure today,
- * flipping the suite red once Fix D lands.
  */
 import { join } from "node:path";
 

--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -1,14 +1,18 @@
 /**
  * E2E suite: deterministic sync-service reproductions.
  *
- * Unlike the other suites, this one needs no orchestrator/chains — it runs the
- * in-process reproduction tests (real runtime + PGLite + the synthetic `test`
- * chain) that reproduce the unbounded-buffering and restart-resume issues.
+ * Unlike the other suites, this one needs no orchestrator/chains. Each node runs
+ * in its own subprocess over the synthetic `test` chain (so a restart is a
+ * genuine new OS process whose in-memory Deque is gone while the committed
+ * database survives — the production restart condition).
  *
- * NOTE: these tests assert the FIXED behaviour, so they are expected to FAIL
- * until the backpressure (C) and block-accurate-resume (D) fixes are applied.
- * See packages/node-sdk/sync/CLAUDE.md and
- * packages/node-sdk/runtime/test/reproduction/RESULTS.md.
+ * Runs in the default PGLite mode; the Postgres-only consistency tests skip
+ * unless invoked with `PGLITE=false` (which needs `postgresql@18` installed).
+ *
+ * The resume-reproduction case (consistency.test.ts) is declared `test.failing`:
+ * it reproduces the block-accurate-resume gap (Fix D, see
+ * packages/node-sdk/sync/CLAUDE.md) and so counts as an expected failure today,
+ * flipping the suite red once Fix D lands.
  */
 import { join } from "node:path";
 

--- a/packages/node-sdk/runtime/conciseinputhash-determinism.md
+++ b/packages/node-sdk/runtime/conciseinputhash-determinism.md
@@ -1,0 +1,114 @@
+# Bug Report: non-deterministic `effectstream_tx_hash` (`conciseInputHash`)
+
+**Package:** `@effectstream/node-sdk` — runtime
+**Location:** `runtime/src/process-blocks.ts` (scheduled-input loop, STEP 5)
+**Severity:** Medium — silent cross-node state divergence in a derived column; not (currently) consensus-relevant
+**Status:** Open
+
+---
+
+## Summary
+
+When the runtime records the result of a **scheduled** STF input, it fabricates the
+`effectstream_tx_hash` with `Math.random()`. The value is therefore different on every run
+and on every node, so two nodes that replay the exact same source blocks produce **different
+`rollup_input_result.effectstream_tx_hash` values** for the same input. For a framework whose
+core promise is "the database is a pure function of the source blocks," this is a determinism
+hole.
+
+## The code
+
+`runtime/src/process-blocks.ts`, inside the loop over `scheduledData` (STEP 5):
+
+```ts
+const conciseInputHash = `0x${
+  Array(64).fill(0).map(() => Math.floor(Math.random() * 16).toString(16)).join("")
+}`;
+yield* until(
+  insertGameInputResult.run({
+    id: data.id,
+    success,
+    effectstream_tx_hash: Buffer.from(conciseInputHash),
+    index_in_block,
+    block_height: value.blockNumber,
+  }, dbConn),
+);
+```
+
+This runs only for **scheduled** inputs (engine-queued timers / derived inputs that have no
+real on-chain transaction), so the engine has to synthesize a hash. It does so randomly.
+
+## Why it matters / why it's currently masked
+
+- **Block hash is unaffected.** `generateEffectstreamBlockHash` (`@effectstream/crypto`) hashes
+  `blockInfo[].blockHash` (source-chain hashes) + the previous block hash — never
+  `effectstream_tx_hash`. So the block-hash chain stays deterministic; the divergence is
+  confined to the `rollup_input_result.effectstream_tx_hash` column and anything that reads it.
+- **Masked in tests.** The reproduction tests use a no-op STF (`stateMachinePayload: null`),
+  which schedules no STF inputs, so this branch never executes. That is exactly why
+  `consistency-snapshot.ts` lists `effectstream_tx_hash` in `VOLATILE_COLUMNS` and excludes it
+  — the snapshot would otherwise diff on every run once real STFs are involved.
+
+## Two existing quirks to fix alongside
+
+1. **Encoding bug.** `Buffer.from(conciseInputHash)` is given the *string* `"0x" + 64 hex`
+   with no encoding, so it stores 66 **UTF-8** bytes, not the 32 decoded bytes. Whatever
+   derivation replaces `Math.random()`, encode it deliberately (`Buffer.from(hex, "hex")`, or
+   commit to the `0x`-string form consistently).
+
+2. **Ordering prerequisite (the real root).** The hash inputs that give uniqueness
+   (`index_in_block`, and the STF execution order itself) are only deterministic if the
+   `scheduledData` order is deterministic. Today it is not fully:
+   ```ts
+   // TODO What should be the order of the scheduled data - per id?
+   const scheduledData = [...scheduledData1, ...scheduledData2];
+   ```
+   - `scheduledData1` (block-scheduled) is `ORDER BY id ASC` → deterministic given a
+     deterministic scheduling history.
+   - `scheduledData2` (timestamp-scheduled) is `ORDER BY future_ms_timestamp ASC` **only** —
+     **same-timestamp rows have no tiebreak**, so their order is arbitrary.
+
+   This is bigger than the hash: the same order drives **STF execution** and the
+   **`randomGenerator` (Prando) draw sequence**. If it isn't pinned, game state itself can
+   diverge; the random tx-hash is just the most visible symptom.
+
+## Suggested fixes (in order)
+
+### 1. Pin the scheduled-input order (prerequisite, do first)
+Give the queries a total deterministic sort and a deterministic merge:
+- timestamp list → `ORDER BY future_ms_timestamp ASC, id ASC` (break ties by `id`);
+- keep block-scheduled before timestamp-scheduled (or merge both by a single deterministic
+  key). This is required for deterministic STFs regardless of the hash, and it makes
+  `index_in_block` deterministic.
+
+### 2. Derive the hash deterministically (recommended)
+Replace `Math.random()` with a content-addressed hash over the input's identity + position,
+reusing the `sha512` already used for the block hash:
+
+```
+effectstream_tx_hash =
+  sha512(block_height ‖ index_in_block ‖ input_data ‖ from_address ‖ from_address_type)
+```
+
+- `block_height` + `index_in_block` give **uniqueness** (one result per position; needs fix #1).
+- `input_data` + `from_address` + `from_address_type` make it **content-addressed**
+  (tx-hash-like, collision-resistant). All are non-null columns already on the scheduled row.
+
+### Alternatives considered
+- **Reuse the seeded `Prando` (`new Prando(blockHash)`):** smallest change and deterministic,
+  but the shared `randomGenerator` is also consumed by the STFs — drawing hash bytes from it
+  would shift the RNG stream every later STF sees. Would require a *separate*
+  `new Prando(blockHash + ":txhash")`. Produces opaque (non-content) hashes.
+- **`H(data.id, block_height)`:** `id` is a global SERIAL counter — a weaker determinism
+  guarantee than the block-scoped `index_in_block`, and `block_height` adds nothing once `id`
+  is unique. Prefer `index_in_block`.
+- **Provenance: `H(origin_tx_hash, …)`:** ties to the originating real tx, but
+  `origin_tx_hash` is `null` for timestamp-scheduled inputs, so it needs a fallback.
+
+## Verification
+- Add a determinism test with a **real** STF (one that schedules a derived input) and assert
+  two from-scratch syncs produce identical `rollup_input_result.effectstream_tx_hash` —
+  i.e. drop `effectstream_tx_hash` from `VOLATILE_COLUMNS` once fixed and confirm
+  `consistency.test.ts` Test A still passes.
+- Cover the timestamp-tie case explicitly: schedule ≥2 inputs at the same `future_ms_timestamp`
+  and assert identical ordering / hashes across runs.

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -22,7 +22,6 @@ import { startMerge, startSync } from "@effectstream/sync";
 import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import {
   createChannel,
-  each,
   type Operation,
   sleep,
   spawn,
@@ -95,6 +94,14 @@ export function* start(config: StartConfig): Operation<void> {
 
   const finalizedBlockStream = createChannel<ChainBlock>();
 
+  // Subscribe BEFORE spawning the merge: effection channels drop sends with no
+  // active subscriber, so a fast restart (in-memory state, no RPC wait) could
+  // emit blocks before we subscribe and silently stall at the pre-restart height.
+  const finalizedBlocks = yield* finalizedBlockStream;
+  // NOTE: this subscriber's queue is unbounded. During deep catch-up the merge
+  // can outpace the per-block processing below and grow it without bound — the
+  // downstream side of the Fix C backpressure issue (see sync/CLAUDE.md).
+
   yield* spawn(() => startMerge(syncProtocols, finalizedBlockStream));
 
   const heartbeatIntervalMs = 60_000;
@@ -137,7 +144,9 @@ export function* start(config: StartConfig): Operation<void> {
     yield* spawn(() => runSnapshotLoop(config.snapshotConfig!));
   }
 
-  for (const value of yield* each(finalizedBlockStream)) {
+  let nextBlock = yield* finalizedBlocks.next();
+  for (; !nextBlock.done; nextBlock = yield* finalizedBlocks.next()) {
+    const value = nextBlock.value;
     // We request a dbClient for a non-shared dbConn object.
     // For PGLite, this is not enough, as the can only be one connection at a time.
     // So we request a DBMutex as well.
@@ -218,7 +227,6 @@ export function* start(config: StartConfig): Operation<void> {
           }...${lagSuffix} | ${JSON.stringify(contentBlocksForProtocol)}`,
         ),
     );
-    yield* each.next();
   }
 }
 

--- a/packages/node-sdk/runtime/src/process-blocks.ts
+++ b/packages/node-sdk/runtime/src/process-blocks.ts
@@ -17,11 +17,12 @@ import {
   insertGameInputResult,
   removePages,
   saveLastBlock,
+  upsertPage,
 } from "@effectstream/db";
 import { Buffer } from "node:buffer";
 import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import type { StartConfig } from "./types.ts";
-import type { BlockNumber, EffectstreamBlockHash } from "@effectstream/utils";
+import type { EffectstreamBlockHash } from "@effectstream/utils";
 import { generateEffectstreamBlockHash, Prando } from "@effectstream/crypto";
 import { applyUserMigrations } from "./version-migrations.ts";
 import type { EventPathAndDef } from "@effectstream/event-client";
@@ -308,28 +309,24 @@ export function* processFinalizedBlock(
       }, dbConn)
     );
 
-    /* STEP 7: Update page state for all sync protocols consumed
-    *          This is to mark what blocks where consumed by this specific
-    *          block, to avoid re-processing the same blocks more than once
-    *          if the sync protocol is restarted.
+    /* STEP 7: Persist the block-accurate resume marker per protocol, inside this
+    *          block's transaction (the runtime is the sole writer of the resume
+    *          position). Upsert at page_number = ownBlockNumber, then prune
+    *          everything below → one row per protocol = the committed watermark.
+    *          Full mechanism: @effectstream/sync CLAUDE.md, design idea #5.
     */
-
-    // Get latest block for each sync protocol.
-    const latestBlocks: Record<string, BlockNumber> = {};
-    for (const blockInfo of value.blockInfo) {
-      if (
-        !latestBlocks[blockInfo.protocol_name] ||
-        latestBlocks[blockInfo.protocol_name] < blockInfo.block_number
-      ) {
-        latestBlocks[blockInfo.protocol_name] = blockInfo.block_number;
-      }
-    }
-
-    for (const [protocolName, blockNumber] of Object.entries(latestBlocks)) {
+    for (const { protocol_name, lastPage } of value.resumePages) {
+      yield* until(
+        upsertPage.run({
+          protocol_name,
+          page_number: lastPage.ownBlockNumber,
+          page: JSON.stringify(lastPage),
+        }, dbConn),
+      );
       yield* until(
         removePages.run({
-          protocol_name: protocolName,
-          page_number: blockNumber,
+          protocol_name,
+          page_number: lastPage.ownBlockNumber,
         }, dbConn),
       );
     }

--- a/packages/node-sdk/runtime/test/reproduction/consistency-snapshot.ts
+++ b/packages/node-sdk/runtime/test/reproduction/consistency-snapshot.ts
@@ -1,0 +1,168 @@
+/**
+ * In-memory DB *content fingerprints* for test comparison.
+ *
+ * NOT to be confused with `@effectstream/db`'s snapshot-handler.ts, which does
+ * `pg_dump`-style snapshots for retention/recovery. These snapshots never touch
+ * disk: they hash every row of every table so two databases can be compared
+ * table-by-table, row-by-row (a file hash of the on-disk data dir is useless —
+ * the physical layout churns with background-writer / vacuum activity and is
+ * not a pure function of the committed rows).
+ *
+ * Used by consistency.test.ts to assert the engine builds the *same* database
+ * regardless of how it got there (one clean run, or stop/restart).
+ */
+import { createHash } from "node:crypto";
+import type pg from "pg";
+
+const md5 = (s: string) => createHash("md5").update(s).digest("hex");
+
+const DEFAULT_SCHEMAS = ["effectstream", "public", "primitives"];
+
+/**
+ * `rollup_input_result.effectstream_tx_hash` is filled from `Math.random()`
+ * (runtime/src/process-blocks.ts), so it differs between two otherwise-identical
+ * runs. It is only written for scheduled STF inputs (never on the noop-STF test
+ * path), so excluding it is a no-op for the current tests — but it keeps the
+ * helper correct if reused against a config that runs real STFs.
+ */
+export const VOLATILE_COLUMNS = ["effectstream_tx_hash"];
+
+/**
+ * Sync-internal bookkeeping. The page queue legitimately differs after a
+ * restart even in a correct engine, and the version/migration/config-snapshot
+ * tables are engine plumbing rather than observable app state. Excluded when
+ * asserting "the resumed DB reaches the same *state* as a clean sync".
+ */
+export const SYNC_BOOKKEEPING_TABLES = [
+  "sync_protocol_pagination",
+  "effectstream_version_history",
+  "effectstream_expected_version",
+  "effectstream_migration_history",
+  "sync_protocol_config_snapshot",
+];
+
+export type TableFingerprint = {
+  rowCount: number;
+  /** md5 over the ascending-sorted per-row hashes (order-independent). */
+  fingerprint: string;
+  /** Ascending-sorted per-row md5s; kept for richer diffs if ever needed. */
+  rowHashes: string[];
+};
+
+/** Keyed by `"<schema>.<table>"`. */
+export type ConsistencySnapshot = Map<string, TableFingerprint>;
+
+export type SnapshotOpts = {
+  /** Schemas to enumerate. Default: effectstream, public, primitives. */
+  schemas?: string[];
+  /** Bare table names (any schema) to skip entirely. */
+  excludeTables?: string[];
+  /** Column names to drop before hashing rows (merged with VOLATILE_COLUMNS). */
+  excludeColumns?: string[];
+};
+
+const quoteIdent = (id: string) => `"${id.replace(/"/g, '""')}"`;
+
+/**
+ * Hash the full content of every base table in the given schemas.
+ *
+ * Each row is hashed as `md5(concat_ws(',', quote_nullable(col::text), …))` over
+ * its included columns. Each column is cast to text individually (bytea → `\x…`
+ * hex, json/jsonb → canonical text), wrapped in `quote_nullable` so a SQL NULL
+ * (rendered as the bare token `NULL`) is distinguishable from the literal string
+ * `'NULL'`, and joined with a separator — deterministic given identical inserts.
+ * Rows are sorted by their hash before folding into the table fingerprint, so
+ * insertion order / serial id ordering does not matter.
+ *
+ * NB: we hash per-column rather than via a composite `ROW(<cols>)::text` cast so
+ * NULL handling is explicit — `quote_nullable` renders a SQL NULL as the bare
+ * token `NULL`, distinct from the literal string `'NULL'`, which the composite
+ * cast conflates. Per-column casts also keep the rendering of each scalar type
+ * (bytea → `\x…` hex, json/jsonb → canonical text) under our direct control.
+ */
+export async function dumpConsistencySnapshot(
+  pool: pg.Pool,
+  opts: SnapshotOpts = {},
+): Promise<ConsistencySnapshot> {
+  const schemas = opts.schemas ?? DEFAULT_SCHEMAS;
+  const excludeTables = new Set(opts.excludeTables ?? []);
+  const excludeColumns = new Set([
+    ...VOLATILE_COLUMNS,
+    ...(opts.excludeColumns ?? []),
+  ]);
+
+  const tablesRes = await pool.query<{ table_schema: string; table_name: string }>(
+    `SELECT table_schema, table_name
+       FROM information_schema.tables
+      WHERE table_schema = ANY($1)
+        AND table_type = 'BASE TABLE'
+      ORDER BY table_schema, table_name`,
+    [schemas],
+  );
+
+  const snapshot: ConsistencySnapshot = new Map();
+  for (const { table_schema, table_name } of tablesRes.rows) {
+    if (excludeTables.has(table_name)) continue;
+
+    const colsRes = await pool.query<{ column_name: string }>(
+      `SELECT column_name
+         FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = $2
+        ORDER BY ordinal_position`,
+      [table_schema, table_name],
+    );
+    const cols = colsRes.rows
+      .map((r) => r.column_name)
+      .filter((c) => !excludeColumns.has(c));
+    if (cols.length === 0) continue;
+
+    const rowExpr = `concat_ws(',', ${
+      cols.map((c) => `quote_nullable(${quoteIdent(c)}::text)`).join(", ")
+    })`;
+    const rowsRes = await pool.query<{ h: string }>(
+      `SELECT md5(${rowExpr}) AS h
+         FROM ${quoteIdent(table_schema)}.${quoteIdent(table_name)}
+        ORDER BY h`,
+    );
+    const rowHashes = rowsRes.rows.map((r) => r.h);
+    snapshot.set(`${table_schema}.${table_name}`, {
+      rowCount: rowHashes.length,
+      fingerprint: md5(rowHashes.join("")),
+      rowHashes,
+    });
+  }
+  return snapshot;
+}
+
+export type SnapshotDiff = {
+  table: string;
+  reason: "only-in-a" | "only-in-b" | "row-count" | "content";
+  aRows: number | null;
+  bRows: number | null;
+};
+
+/** Compare two snapshots table-by-table. `equal` ⇔ `diffs` is empty. */
+export function compareConsistencySnapshots(
+  a: ConsistencySnapshot,
+  b: ConsistencySnapshot,
+): { equal: boolean; diffs: SnapshotDiff[] } {
+  const diffs: SnapshotDiff[] = [];
+  const tables = [...new Set([...a.keys(), ...b.keys()])].sort();
+  for (const table of tables) {
+    const fa = a.get(table);
+    const fb = b.get(table);
+    if (fa && !fb) {
+      diffs.push({ table, reason: "only-in-a", aRows: fa.rowCount, bRows: null });
+    } else if (!fa && fb) {
+      diffs.push({ table, reason: "only-in-b", aRows: null, bRows: fb.rowCount });
+    } else if (fa && fb && fa.fingerprint !== fb.fingerprint) {
+      diffs.push({
+        table,
+        reason: fa.rowCount !== fb.rowCount ? "row-count" : "content",
+        aRows: fa.rowCount,
+        bRows: fb.rowCount,
+      });
+    }
+  }
+  return { equal: diffs.length === 0, diffs };
+}

--- a/packages/node-sdk/runtime/test/reproduction/consistency.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/consistency.test.ts
@@ -1,0 +1,203 @@
+/**
+ * E2E database-consistency checks over the synthetic `test` chain.
+ *
+ * The database the engine builds must be a pure function of the source blocks —
+ * independent of *how* it got there. Two scenarios:
+ *
+ *   A. Determinism baseline — two from-scratch syncs to the same height produce
+ *      identical databases. Expected to PASS (proves reproducibility).
+ *
+ *   B. Resume reproduction — a sync that stops mid-chunk and resumes to N must
+ *      match a clean sync to N. Expected to FAIL today: it reproduces the
+ *      block-accurate-resume gap (Fix D, see packages/node-sdk/sync/CLAUDE.md),
+ *      where a restart silently skips source blocks in (committed, chunk_end].
+ *      Declared `test.failing`, so it counts as an expected failure now and
+ *      flips the suite red (prompting "make me a real `test`") once Fix D lands.
+ *
+ * Each node runs in its own subprocess (see harness.ts / node-runner.ts): a
+ * restart is a genuine new OS process whose in-memory Deque is gone while the
+ * database keeps every committed row — exactly the production restart condition.
+ *
+ * These tests assert a property of the **production** database path, so they run
+ * only against real Postgres — i.e. only when `PGLITE=false` and `postgresql@18`
+ * is installed. In the default PGLite mode (or if Postgres isn't installed) they
+ * skip rather than run, since PGLite is not the backend whose fidelity these
+ * guarantees are about.
+ */
+import { expect, test } from "bun:test";
+import { postgresAvailable, setupHarness } from "./harness.ts";
+import {
+  compareConsistencySnapshots,
+  type ConsistencySnapshot,
+  dumpConsistencySnapshot,
+  type SnapshotDiff,
+  type SnapshotOpts,
+  SYNC_BOOKKEEPING_TABLES,
+} from "./consistency-snapshot.ts";
+
+// Postgres-only: run only when PGLITE=false and Postgres is present.
+const canRun = process.env.PGLITE === "false" && postgresAvailable();
+const it = canRun ? test : test.skip;
+const itFailing = canRun ? test.failing : test.skip;
+
+/** "<n> tables, <m> rows". */
+function summarize(snap: ConsistencySnapshot): string {
+  let rows = 0;
+  for (const f of snap.values()) rows += f.rowCount;
+  return `${snap.size} tables, ${rows} rows`;
+}
+
+/** e.g. "effectstream.primitive_accounting [row-count A=1 B=0]". */
+function formatDiffs(diffs: SnapshotDiff[]): string {
+  return diffs
+    .map((d) => `${d.table} [${d.reason} A=${d.aRows ?? "—"} B=${d.bRows ?? "—"}]`)
+    .join(", ");
+}
+
+/** Log the two snapshots and their comparison result. */
+function logComparison(
+  tag: string,
+  label: string,
+  aLabel: string,
+  a: ConsistencySnapshot,
+  bLabel: string,
+  b: ConsistencySnapshot,
+  diffs: SnapshotDiff[],
+): void {
+  console.log(`${tag} ${label}`);
+  console.log(`${tag}   ${aLabel}: ${summarize(a)}`);
+  console.log(`${tag}   ${bLabel}: ${summarize(b)}`);
+  console.log(
+    diffs.length === 0
+      ? `${tag}   → IDENTICAL (0 differences)`
+      : `${tag}   → ${diffs.length} difference(s): ${formatDiffs(diffs)}`,
+  );
+}
+
+it("two from-scratch syncs to the same height produce identical databases", async () => {
+  const events = [
+    { atBlock: 25, marker: "e25" },
+    { atBlock: 50, marker: "e50" },
+    { atBlock: 75, marker: "e75" },
+  ];
+
+  // A fresh harness == a fresh database == "syncing again from scratch".
+  const runFromScratch = async (
+    apiPort: number,
+  ): Promise<ConsistencySnapshot> => {
+    const h = await setupHarness({ backend: "postgres" });
+    try {
+      await h.runToHeight({
+        events,
+        tips: { mainClock: 100, parallelP: 200 },
+        target: 100,
+        apiPort,
+      });
+      return await dumpConsistencySnapshot(h.pool);
+    } finally {
+      await h.teardown();
+    }
+  };
+
+  const snapA = await runFromScratch(19140);
+  const snapB = await runFromScratch(19141);
+
+  const { diffs } = compareConsistencySnapshots(snapA, snapB);
+  logComparison(
+    "[consistency A]",
+    "two from-scratch syncs to height 100:",
+    "run A",
+    snapA,
+    "run B",
+    snapB,
+    diffs,
+  );
+  expect(diffs).toEqual([]);
+}, 120_000);
+
+itFailing(
+  "a mid-chunk restart resumes to the same database as a clean sync",
+  async () => {
+    // One event inside the gap the restart will skip: it must fall in
+    // (phase-1 committed height 10, parallel page 50] AND be ≤ the phase-2 main
+    // tip 30, so a *correct* engine would re-fetch and commit it after resume.
+    const events = [{ atBlock: 20, marker: "gap20" }];
+    // Large parallel stepSize => the whole tip is fetched as ONE chunk, so its
+    // page row persists at page_number = tip (the chunk-granular watermark that
+    // Fix D wrongly resumes from).
+    const parallelStepSize = 1000;
+    // Sync bookkeeping (page queue, version/migration history) legitimately
+    // differs after a restart even in a correct engine; compare observable
+    // state only.
+    const dumpOpts: SnapshotOpts = { excludeTables: SYNC_BOOKKEEPING_TABLES };
+
+    // Reference: one clean sync straight to height 30. Parallel stays ahead of
+    // the main clock so the final main block can finalize (the merge gates block
+    // T on the parallel page advancing past T). Contains the block-20 event.
+    const ref = await setupHarness({ backend: "postgres" });
+    let refSnap: ConsistencySnapshot;
+    try {
+      await ref.runToHeight({
+        events,
+        parallelStepSize,
+        tips: { mainClock: 30, parallelP: 50 },
+        target: 30,
+        apiPort: 19150,
+      });
+      refSnap = await dumpConsistencySnapshot(ref.pool, dumpOpts);
+    } finally {
+      await ref.teardown();
+    }
+
+    // Resumed: one database, two subprocess runs (= a real restart).
+    const resumed = await setupHarness({ backend: "postgres" });
+    let resumeSnap: ConsistencySnapshot;
+    try {
+      // Phase 1: the parallel fetcher (no backpressure) races to its own tip
+      // (50) and persists page_number=50, but the main clock only drives commits
+      // to height 10 — so parallel blocks 11..50 (incl. the event at 20) sit
+      // unmerged in the in-memory Deque, never committed. waitPages guarantees
+      // the page-50 row is durable before the process exits.
+      await resumed.runToHeight({
+        events,
+        parallelStepSize,
+        tips: { mainClock: 10, parallelP: 50 },
+        target: 10,
+        apiPort: 19151,
+        waitPages: { parallelP: 50 },
+      });
+
+      // Phase 2 (restart): a new process boots against the same database. Its
+      // Deque is empty; restoreState reads the oldest retained page (50) and
+      // resumes parallel from 51, silently skipping (10,50]. The main clock now
+      // advances to 30, so the parallel blocks it needs (11..30, including the
+      // event at 20) are never re-fetched — those slots go empty.
+      await resumed.runToHeight({
+        events,
+        parallelStepSize,
+        tips: { mainClock: 30, parallelP: 50 },
+        target: 30,
+        apiPort: 19152,
+      });
+      resumeSnap = await dumpConsistencySnapshot(resumed.pool, dumpOpts);
+    } finally {
+      await resumed.teardown();
+    }
+
+    // FAILS today: resumeSnap is missing the block-20 event
+    // (primitive_accounting) and block 20 differs in effectstream_blocks.
+    // Passes once Fix D lands.
+    const { diffs } = compareConsistencySnapshots(refSnap, resumeSnap);
+    logComparison(
+      "[consistency B]",
+      "clean sync vs mid-chunk restart, both to height 30:",
+      "clean ref",
+      refSnap,
+      "resumed  ",
+      resumeSnap,
+      diffs,
+    );
+    expect(diffs).toEqual([]);
+  },
+  120_000,
+);

--- a/packages/node-sdk/runtime/test/reproduction/consistency.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/consistency.test.ts
@@ -7,12 +7,10 @@
  *   A. Determinism baseline — two from-scratch syncs to the same height produce
  *      identical databases. Expected to PASS (proves reproducibility).
  *
- *   B. Resume reproduction — a sync that stops mid-chunk and resumes to N must
- *      match a clean sync to N. Expected to FAIL today: it reproduces the
- *      block-accurate-resume gap (Fix D, see packages/node-sdk/sync/CLAUDE.md),
- *      where a restart silently skips source blocks in (committed, chunk_end].
- *      Declared `test.failing`, so it counts as an expected failure now and
- *      flips the suite red (prompting "make me a real `test`") once Fix D lands.
+ *   B. Resume guarantee — a sync that stops mid-chunk and resumes to N must
+ *      match a clean sync to N. Regression test for block-accurate resume
+ *      (see @effectstream/sync CLAUDE.md, design idea #5): a restart must
+ *      re-fetch (committed, chunk_end] instead of silently skipping it.
  *
  * Each node runs in its own subprocess (see harness.ts / node-runner.ts): a
  * restart is a genuine new OS process whose in-memory Deque is gone while the
@@ -38,7 +36,6 @@ import {
 // Postgres-only: run only when PGLITE=false and Postgres is present.
 const canRun = process.env.PGLITE === "false" && postgresAvailable();
 const it = canRun ? test : test.skip;
-const itFailing = canRun ? test.failing : test.skip;
 
 /** "<n> tables, <m> rows". */
 function summarize(snap: ConsistencySnapshot): string {
@@ -115,7 +112,7 @@ it("two from-scratch syncs to the same height produce identical databases", asyn
   expect(diffs).toEqual([]);
 }, 120_000);
 
-itFailing(
+it(
   "a mid-chunk restart resumes to the same database as a clean sync",
   async () => {
     // One event inside the gap the restart will skip: it must fall in
@@ -154,24 +151,24 @@ itFailing(
     let resumeSnap: ConsistencySnapshot;
     try {
       // Phase 1: the parallel fetcher (no backpressure) races to its own tip
-      // (50) and persists page_number=50, but the main clock only drives commits
-      // to height 10 — so parallel blocks 11..50 (incl. the event at 20) sit
-      // unmerged in the in-memory Deque, never committed. waitPages guarantees
-      // the page-50 row is durable before the process exits.
+      // (50) into the in-memory Deque, but the main clock only drives commits to
+      // height 10 — so parallel blocks 11..50 (incl. the event at 20) are fetched
+      // but never committed, and the in-memory Deque is lost when the process
+      // exits. The runtime persists a block-accurate resume marker at the last
+      // COMMITTED parallel block (≤ 10), not the fetched-ahead tip.
       await resumed.runToHeight({
         events,
         parallelStepSize,
         tips: { mainClock: 10, parallelP: 50 },
         target: 10,
         apiPort: 19151,
-        waitPages: { parallelP: 50 },
       });
 
       // Phase 2 (restart): a new process boots against the same database. Its
-      // Deque is empty; restoreState reads the oldest retained page (50) and
-      // resumes parallel from 51, silently skipping (10,50]. The main clock now
-      // advances to 30, so the parallel blocks it needs (11..30, including the
-      // event at 20) are never re-fetched — those slots go empty.
+      // Deque is empty; restoreState reads the persisted resume marker (the last
+      // committed parallel block ≤ 10) and resumes parallel from there. The main
+      // clock now advances to 30, so the parallel blocks it needs (11..30,
+      // including the event at 20) are re-fetched and committed.
       await resumed.runToHeight({
         events,
         parallelStepSize,
@@ -184,9 +181,6 @@ itFailing(
       await resumed.teardown();
     }
 
-    // FAILS today: resumeSnap is missing the block-20 event
-    // (primitive_accounting) and block 20 differs in effectstream_blocks.
-    // Passes once Fix D lands.
     const { diffs } = compareConsistencySnapshots(refSnap, resumeSnap);
     logComparison(
       "[consistency B]",

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -21,7 +21,7 @@
 import net from "node:net";
 import pg from "pg";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type PgliteHandle, startPglite } from "@effectstream/db/start-pglite";
@@ -42,7 +42,10 @@ export {
 type Cluster = { port: number; dataDir: string };
 
 let clusterPromise: Promise<Cluster> | undefined;
+let clusterBin: string | undefined;
 let dbCounter = 0;
+let activeHarnessCount = 0;
+let clusterStopped = false;
 
 /** Resolve the postgresql@18 bin dir (Homebrew default, or REPRO_PG_BINDIR). */
 function pgBinDir(): string {
@@ -84,18 +87,62 @@ function freePort(): Promise<number> {
 }
 
 /**
+ * Kill orphaned `repro-pg-*` clusters left behind by test processes that
+ * exited without hitting their `exit` handler (SIGKILL, IDE stop, etc.).
+ *
+ * PostgreSQL writes the postmaster PID into `<dataDir>/postmaster.pid`.  We
+ * also write our own owner PID into `<dataDir>/repro-owner.pid` so we can
+ * distinguish our clusters from unrelated `repro-pg-*` dirs.  A directory is
+ * considered orphaned when the owner process is dead; we then `pg_ctl stop`
+ * and `rm -rf` it.
+ */
+function cleanupOrphanedClusters(bin: string, env: Record<string, string | undefined>): void {
+  const tmp = tmpdir();
+  let entries: string[];
+  try { entries = readdirSync(tmp); } catch { return; }
+
+  for (const name of entries) {
+    if (!name.startsWith("repro-pg-")) continue;
+    const dataDir = join(tmp, name);
+
+    const ownerFile = join(dataDir, "repro-owner.pid");
+    let ownerPid: number | undefined;
+    try { ownerPid = parseInt(readFileSync(ownerFile, "utf8").trim(), 10); } catch { /* no owner file */ }
+
+    if (ownerPid == null || Number.isNaN(ownerPid)) continue;
+
+    try { process.kill(ownerPid, 0); } catch {
+      // Owner is dead — orphaned cluster.
+      spawnSync(join(bin, "pg_ctl"), ["-D", dataDir, "stop", "-m", "immediate"], {
+        env, stdio: "ignore",
+      });
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
  * Boot a fresh cluster the first time it's needed and reuse it for the rest of
  * the process. initdb with C locale + trust auth (mirrors e2e_postgres.sh; the
  * C locale dodges the macOS "postmaster became multithreaded during startup"
  * fatal). Stopped synchronously on process exit.
+ *
+ * Before booting, any orphaned clusters from prior crashed runs are cleaned up
+ * so they don't accumulate and exhaust system resources.
  */
 function ensureCluster(): Promise<Cluster> {
   if (clusterPromise) return clusterPromise;
   clusterPromise = (async () => {
     const bin = pgBinDir();
+    clusterBin = bin;
+    const env = { ...process.env, LC_ALL: "C" };
+
+    cleanupOrphanedClusters(bin, env);
+
     const dataDir = mkdtempSync(join(tmpdir(), "repro-pg-"));
     const port = await freePort();
-    const env = { ...process.env, LC_ALL: "C" };
+
+    writeFileSync(join(dataDir, "repro-owner.pid"), String(process.pid));
 
     execFileSync(join(bin, "initdb"), [
       "-D", dataDir,
@@ -113,17 +160,34 @@ function ensureCluster(): Promise<Cluster> {
       "start",
     ], { env, stdio: "ignore" });
 
+    clusterStopped = false;
+
     const stop = () => {
       spawnSync(join(bin, "pg_ctl"), ["-D", dataDir, "stop", "-m", "immediate"], {
         env,
         stdio: "ignore",
       });
       rmSync(dataDir, { recursive: true, force: true });
+      clusterStopped = true;
     };
     process.once("exit", stop);
     return { port, dataDir };
   })();
   return clusterPromise;
+}
+
+/** Stop the shared cluster if it's running (called when last harness tears down). */
+async function stopCluster(): Promise<void> {
+  if (!clusterPromise || clusterStopped) return;
+  const cluster = await clusterPromise;
+  if (clusterStopped || !clusterBin) return;
+  const env = { ...process.env, LC_ALL: "C" };
+  spawnSync(join(clusterBin, "pg_ctl"), ["-D", cluster.dataDir, "stop", "-m", "immediate"], {
+    env,
+    stdio: "ignore",
+  });
+  rmSync(cluster.dataDir, { recursive: true, force: true });
+  clusterStopped = true;
 }
 
 // ── Harness ──────────────────────────────────────────────────────────────────
@@ -226,6 +290,7 @@ export async function setupHarness(
 async function setupPostgresHarness(): Promise<Harness> {
   const cluster = await ensureCluster();
   const dbName = `repro_${process.pid}_${dbCounter++}`;
+  activeHarnessCount++;
 
   // CREATE DATABASE on the maintenance db, then point everything at it.
   const admin = new pg.Pool({
@@ -278,9 +343,14 @@ async function setupPostgresHarness(): Promise<Harness> {
       );
       await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
     } catch {
-      // Best-effort: the cluster is torn down wholesale on process exit.
+      // Best-effort: the cluster is torn down wholesale below.
     } finally {
       await admin.end().catch(() => {});
+    }
+
+    activeHarnessCount--;
+    if (activeHarnessCount <= 0) {
+      await stopCluster();
     }
   };
 

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -21,9 +21,9 @@
 import net from "node:net";
 import pg from "pg";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { appendFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { appendFileSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { type PgliteHandle, startPglite } from "@effectstream/db/start-pglite";
 import type { EventSpec } from "./scenario.ts";
 
@@ -47,31 +47,51 @@ let dbCounter = 0;
 let activeHarnessCount = 0;
 let clusterStopped = false;
 
-/** Resolve the postgresql@18 bin dir (Homebrew default, or REPRO_PG_BINDIR). */
-function pgBinDir(): string {
+/** Resolve a Postgres bin dir. Tries, in order: env var, Homebrew, pg_config, PATH, Linux conventions. */
+function resolvePgBinDir(): string | undefined {
   const override = process.env.REPRO_PG_BINDIR;
   if (override) return override;
-  try {
-    const prefix = execFileSync("brew", ["--prefix", "postgresql@18"], {
-      encoding: "utf8",
-    }).trim();
-    return join(prefix, "bin");
-  } catch {
-    throw new Error(
-      "postgresql@18 not found. Install it (`brew install postgresql@18`) " +
-        "or set REPRO_PG_BINDIR to a Postgres bin dir that bundles pg_ivm.",
-    );
+
+  // macOS + Homebrew
+  if (platform() === "darwin") {
+    try {
+      const prefix = execFileSync("brew", ["--prefix", "postgresql@18"], {
+        encoding: "utf8",
+      }).trim();
+      return join(prefix, "bin");
+    } catch { /* not installed via Homebrew */ }
   }
+
+  // pg_config — standard on most systems with PostgreSQL dev packages
+  try {
+    const dir = execFileSync("pg_config", ["--bindir"], { encoding: "utf8" }).trim();
+    if (dir) return dir;
+  } catch { /* not available */ }
+
+  // PATH probe — initdb directly accessible
+  try {
+    const which = platform() === "win32" ? "where" : "which";
+    const p = execFileSync(which, ["initdb"], { encoding: "utf8" }).trim();
+    if (p) return resolve(p, "..");
+  } catch { /* not on PATH */ }
+
+  // Linux convention (Debian/Ubuntu layout)
+  if (platform() === "linux") {
+    for (const ver of [18, 17, 16]) {
+      const dir = `/usr/lib/postgresql/${ver}/bin`;
+      try {
+        readdirSync(dir);
+        return dir;
+      } catch { /* not installed */ }
+    }
+  }
+
+  return undefined;
 }
 
-/** True if the Postgres backend can boot (postgresql@18 resolvable). */
+/** True if a Postgres binary is available on this system. */
 export function postgresAvailable(): boolean {
-  try {
-    pgBinDir();
-    return true;
-  } catch {
-    return false;
-  }
+  return resolvePgBinDir() !== undefined;
 }
 
 /** Grab a free TCP port by binding to :0 and reading the assigned port. */
@@ -133,7 +153,7 @@ function cleanupOrphanedClusters(bin: string, env: Record<string, string | undef
 function ensureCluster(): Promise<Cluster> {
   if (clusterPromise) return clusterPromise;
   clusterPromise = (async () => {
-    const bin = pgBinDir();
+    const bin = resolvePgBinDir()!;
     clusterBin = bin;
     const env = { ...process.env, LC_ALL: "C" };
 

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -1,327 +1,336 @@
 /**
- * Deterministic, in-process harness for reproducing sync-service issues.
+ * Deterministic harness for reproducing sync-service issues. Two backends behind
+ * one {@link setupHarness} API:
  *
- * - Runs a real PGLite server in-process (state survives a simulated restart
- *   because the server stays alive while the node task is halted/restarted).
- * - Boots the real runtime (`start()`) over a synthetic `test` chain whose tip
- *   is controlled via {@link TestChainControl}, so scenarios are deterministic
- *   (fixed tips → a well-defined "stable" state we can poll for).
+ * - **PGLite** (default) — in-memory WASM Postgres behind a `startPglite`
+ *   gateway, the production PGLite wire path (`PGLITE=true`). Dependency-free.
+ * - **Postgres** (opt-in via `PGLITE=false`) — a throwaway Homebrew
+ *   `postgresql@18` cluster per test process (it bundles `pg_ivm`), each
+ *   {@link setupHarness} getting a fresh database. Higher fidelity; needs
+ *   `postgresql@18` on PATH (override the bin dir with `REPRO_PG_BINDIR`, probe
+ *   with {@link postgresAvailable}).
  *
- * Lives in the runtime package because it imports `start()` (the sync package
- * must not depend on runtime). See ./buffering.test.ts and ./resume.test.ts,
- * and RESULTS.md for measurements.
+ * Each node runs in its own subprocess ({@link ./node-runner.ts}) booting the
+ * real runtime over a synthetic `test` chain, so a "restart" is a genuine new OS
+ * process: the in-memory Deque is gone while the database keeps every committed
+ * row. (Booting `start()` twice in one process stalls the sync loops under
+ * `bun test`, so we never do it.)
+ *
+ * Lives in the runtime package because the subprocess imports `start()`.
  */
+import net from "node:net";
 import pg from "pg";
-import { type PgliteHandle, startPglite } from "@effectstream/db/start-pglite";
-import { run, type Task } from "effection";
-import {
-  ConfigBuilder,
-  toSyncProtocolWithNetwork,
-  withEffectstreamStaticConfig,
-} from "@effectstream/config";
-import { init, start } from "../../src/main.ts";
-import type { StartConfigGameStateTransitions } from "../../src/types.ts";
-import { type AllSyncProtocols, TestChainControl } from "@effectstream/sync";
-import { Primitive } from "@effectstream/sm";
-import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { type PgliteHandle, startPglite } from "@effectstream/db/start-pglite";
+import type { EventSpec } from "./scenario.ts";
 
-// ── A minimal user-defined primitive ─────────────────────────────────────────
-// Writes one row to effectstream.primitive_accounting per event (no STF needed:
-// stateMachinePayload is null). Tests assert on that table.
-export const TEST_PRIMITIVE_TYPE = "TEST:EVENT";
+// Re-export the bits the test files assert with, so they import from one place.
+export { TEST_PRIMITIVE_TYPE } from "./scenario.ts";
+export type { EventSpec } from "./scenario.ts";
+export {
+  countEventRows,
+  latestFinalizedHeight,
+  maxPage,
+  pageRows,
+} from "./poll.ts";
 
-export class TestEventPrimitive extends Primitive<any, any> {
-  readonly internalTypeName = TEST_PRIMITIVE_TYPE as any;
-  override grammar = [] as any;
-  constructor(config: any) {
-    super(config);
-  }
-  // deno-lint-ignore require-yield
-  override *getPayload(_height: any, primitiveTransactionData: any): any {
-    const payload = primitiveTransactionData.output.payload;
-    return {
-      isBatched: false,
-      data: [
-        {
-          fromAddressAndType: { type: "none", address: "0x0" },
-          accountingPayload: payload,
-          stateMachinePayload: null,
-        },
-      ],
-    };
-  }
-  override getConfig(): any {
-    return {
-      name: this.instanceName,
-      type: this.internalTypeName,
-      startBlockHeight: this.startBlockHeight,
-      scheduledPrefix: this.stateMachinePrefix,
-    };
+// ── Throwaway PostgreSQL cluster (one per test process) ──────────────────────
+
+type Cluster = { port: number; dataDir: string };
+
+let clusterPromise: Promise<Cluster> | undefined;
+let dbCounter = 0;
+
+/** Resolve the postgresql@18 bin dir (Homebrew default, or REPRO_PG_BINDIR). */
+function pgBinDir(): string {
+  const override = process.env.REPRO_PG_BINDIR;
+  if (override) return override;
+  try {
+    const prefix = execFileSync("brew", ["--prefix", "postgresql@18"], {
+      encoding: "utf8",
+    }).trim();
+    return join(prefix, "bin");
+  } catch {
+    throw new Error(
+      "postgresql@18 not found. Install it (`brew install postgresql@18`) " +
+        "or set REPRO_PG_BINDIR to a Postgres bin dir that bundles pg_ivm.",
+    );
   }
 }
 
-const noopStf: StartConfigGameStateTransitions = function* () {};
+/** True if the Postgres backend can boot (postgresql@18 resolvable). */
+export function postgresAvailable(): boolean {
+  try {
+    pgBinDir();
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-// ── Env / DB lifecycle ───────────────────────────────────────────────────────
+/** Grab a free TCP port by binding to :0 and reading the assigned port. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
 
-let portCounter = 5544;
+/**
+ * Boot a fresh cluster the first time it's needed and reuse it for the rest of
+ * the process. initdb with C locale + trust auth (mirrors e2e_postgres.sh; the
+ * C locale dodges the macOS "postmaster became multithreaded during startup"
+ * fatal). Stopped synchronously on process exit.
+ */
+function ensureCluster(): Promise<Cluster> {
+  if (clusterPromise) return clusterPromise;
+  clusterPromise = (async () => {
+    const bin = pgBinDir();
+    const dataDir = mkdtempSync(join(tmpdir(), "repro-pg-"));
+    const port = await freePort();
+    const env = { ...process.env, LC_ALL: "C" };
+
+    execFileSync(join(bin, "initdb"), [
+      "-D", dataDir,
+      "-U", "postgres",
+      "--auth=trust",
+      "--locale=C",
+      "--encoding=UTF8",
+      "--no-instructions",
+    ], { env, stdio: "ignore" });
+    appendFileSync(join(dataDir, "postgresql.conf"), `\nport = ${port}\n`);
+    execFileSync(join(bin, "pg_ctl"), [
+      "-D", dataDir,
+      "-l", join(dataDir, "server.log"),
+      "-w",
+      "start",
+    ], { env, stdio: "ignore" });
+
+    const stop = () => {
+      spawnSync(join(bin, "pg_ctl"), ["-D", dataDir, "stop", "-m", "immediate"], {
+        env,
+        stdio: "ignore",
+      });
+      rmSync(dataDir, { recursive: true, force: true });
+    };
+    process.once("exit", stop);
+    return { port, dataDir };
+  })();
+  return clusterPromise;
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
 
 export type Harness = {
-  pglite: PgliteHandle;
+  /** Query pool against this harness's database (for assertions). */
   pool: pg.Pool;
-  dataDir: string;
-  runNode: (opts: RunNodeOpts) => Promise<RunningNode>;
   /**
-   * Simulate a full process restart: close the PGLite server (severing the
-   * stopped node's lingering pool, which otherwise holds PGLite's single
-   * connection) and reopen it on the SAME data dir (state persists on disk).
+   * Boot one node in a subprocess, sync it to `target` height (+ optional page
+   * watermarks), then let it exit. Resolves once the child exits cleanly; the
+   * database keeps everything it committed. Rejects if the child fails.
    */
-  simulateRestart: () => Promise<void>;
+  runToHeight: (opts: RunToHeightOpts) => Promise<void>;
   teardown: () => Promise<void>;
 };
 
-export type RunNodeOpts = {
-  config: ReturnType<ConfigBuilder["build"]> | any;
+export type RunToHeightOpts = {
+  events: EventSpec[];
+  parallelStepSize?: number;
+  /** Manual chain tips, e.g. { mainClock: 100, parallelP: 200 }. */
+  tips: Record<string, number>;
+  /** Finalized height the node must reach before exiting. */
+  target: number;
   /** Unique per boot so the (test-only) HTTP server never collides. */
   apiPort: number;
+  /** Optional per-protocol page watermarks to also wait for before exiting. */
+  waitPages?: Record<string, number>;
+  securityNamespace?: string;
 };
 
-export type RunningNode = {
-  task: Task<unknown>;
-  /** Live sync protocols (captured via the dev.onStarted hook). */
-  syncProtocols: () => AllSyncProtocols[];
-  /** Boot error, if start() threw. */
-  bootError: () => unknown;
-  stop: () => Promise<void>;
-};
+const RUNNER = join(import.meta.dir, "node-runner.ts");
+
+export type Backend = "pglite" | "postgres";
+
+/** Backend keyed off the engine's `PGLITE` flag: `PGLITE=false` → real Postgres. */
+function defaultBackend(): Backend {
+  return process.env.PGLITE === "false" ? "postgres" : "pglite";
+}
+
+/** `runToHeight` closure shared by both backends; only needs the child's dbEnv. */
+function makeRunToHeight(
+  dbEnv: Record<string, string>,
+): (opts: RunToHeightOpts) => Promise<void> {
+  return (opts: RunToHeightOpts): Promise<void> => {
+    const spec = {
+      securityNamespace: opts.securityNamespace ?? "sync-repro",
+      events: opts.events,
+      parallelStepSize: opts.parallelStepSize,
+      tips: opts.tips,
+      target: opts.target,
+      apiPort: opts.apiPort,
+      waitPages: opts.waitPages,
+    };
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn("bun", [RUNNER, JSON.stringify(spec)], {
+        env: { ...process.env, ...dbEnv },
+        stdio: process.env.REPRO_DEBUG
+          ? ["ignore", "inherit", "inherit"]
+          : ["ignore", "ignore", "pipe"],
+      });
+      // Keep only a tail of stderr so the MQTT-publish flood doesn't pile up;
+      // surface it only if the child fails.
+      const tail: string[] = [];
+      child.stderr?.on("data", (b: Buffer) => {
+        for (const line of b.toString().split("\n")) {
+          if (line && !line.includes("publish")) tail.push(line);
+        }
+        if (tail.length > 40) tail.splice(0, tail.length - 40);
+      });
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        if (code === 0) resolve();
+        else {
+          reject(
+            new Error(
+              `node subprocess exited ${code}\n${tail.join("\n")}`,
+            ),
+          );
+        }
+      });
+    });
+  };
+}
 
 /**
- * Start a PGLite server + connect a query pool. Sets the lazily-read ENV the
- * runtime uses (DB_*, PGLITE). Keep one Harness per test; reuse across the
- * simulated restart so the page queue persists.
+ * Fresh harness on the chosen backend (default {@link defaultBackend}, override
+ * with `{ backend }`). One Harness per node lineage: its database outlives a
+ * restart, so committed state persists exactly as in production.
  */
-export async function setupHarness(): Promise<Harness> {
-  const dbPort = portCounter++;
-  const dataDir = mkdtempSync(join(tmpdir(), "sync-repro-"));
+export async function setupHarness(
+  opts: { backend?: Backend } = {},
+): Promise<Harness> {
+  const backend = opts.backend ?? defaultBackend();
+  return backend === "postgres"
+    ? setupPostgresHarness()
+    : setupPgliteHarness();
+}
 
-  process.env.PGLITE = "true";
-  process.env.PGLITE_DATA_DIR = dataDir;
-  process.env.DB_HOST = "localhost";
-  process.env.DB_PORT = String(dbPort);
-  process.env.DB_NAME = "postgres";
-  process.env.DB_USER = "postgres";
-  // No MQTT broker in tests: it binds fixed ports (8883/9883) that aren't freed
-  // by halt(), so it would collide on restart. Event publishes are
-  // fire-and-forget and swallowed when no broker is present.
-  process.env.MQTT_BROKER = "false";
+/** Real Postgres backend — a fresh database on the shared throwaway cluster. */
+async function setupPostgresHarness(): Promise<Harness> {
+  const cluster = await ensureCluster();
+  const dbName = `repro_${process.pid}_${dbCounter++}`;
 
-  const makePool = (port: number) =>
-    new pg.Pool({
-      host: "localhost",
-      port,
+  // CREATE DATABASE on the maintenance db, then point everything at it.
+  const admin = new pg.Pool({
+    host: "127.0.0.1",
+    port: cluster.port,
+    user: "postgres",
+    database: "postgres",
+    max: 1,
+  });
+  await admin.query(`CREATE DATABASE "${dbName}"`);
+  await admin.end();
+
+  // Parent assertions go through poll.ts's `q`; PGLITE=false → plain queries.
+  process.env.PGLITE = "false";
+
+  const dbEnv = {
+    PGLITE: "false",
+    ALLOW_NO_PG_IVM: "true",
+    DB_HOST: "127.0.0.1",
+    DB_PORT: String(cluster.port),
+    DB_NAME: dbName,
+    DB_USER: "postgres",
+    DB_PW: "",
+    MQTT_BROKER: "false",
+  };
+
+  const pool = new pg.Pool({
+    host: "127.0.0.1",
+    port: cluster.port,
+    user: "postgres",
+    database: dbName,
+    max: 10,
+  });
+
+  const teardown = async (): Promise<void> => {
+    await pool.end().catch(() => {});
+    const admin = new pg.Pool({
+      host: "127.0.0.1",
+      port: cluster.port,
       user: "postgres",
       database: "postgres",
       max: 1,
     });
-
-  let pglite = await startPglite(dbPort);
-  let pool = makePool(dbPort);
-
-  const runNode = async (opts: RunNodeOpts): Promise<RunningNode> => {
-    // Re-assert THIS harness's DB env before booting. Tests may create multiple
-    // harnesses (each calls setupHarness, which mutates the shared process.env);
-    // without this the node would connect to whichever harness ran setup last.
-    process.env.PGLITE = "true";
-    process.env.PGLITE_DATA_DIR = dataDir;
-    process.env.DB_HOST = "localhost";
-    process.env.DB_PORT = String(dbPort);
-    process.env.DB_NAME = "postgres";
-    process.env.DB_USER = "postgres";
-    process.env.MQTT_BROKER = "false";
-    process.env.EFFECTSTREAM_API_PORT = String(opts.apiPort);
-    // The PrimitiveRegistry is a process-global singleton. A real restart gets
-    // a fresh process; here we clear it in place so primitives re-register
-    // cleanly (otherwise "Primitive ... already exists").
-    const reg = (globalThis as { EFFECTSTREAM_REGISTRY?: Record<string, unknown> })
-      .EFFECTSTREAM_REGISTRY;
-    if (reg) for (const k of Object.keys(reg)) delete reg[k];
-    let captured: AllSyncProtocols[] = [];
-    let bootErr: unknown = undefined;
-    const cfg = opts.config;
-    const task = run(function* () {
-      yield* init();
-      yield* withEffectstreamStaticConfig(cfg, function* () {
-        yield* start({
-          appName: "sync-repro",
-          appVersion: "1.0.0",
-          syncInfo: toSyncProtocolWithNetwork(cfg),
-          gameStateTransitions: noopStf,
-          userDefinedPrimitives: { [TEST_PRIMITIVE_TYPE]: TestEventPrimitive },
-          dev: {
-            resetPublicData: false,
-            onStarted: ({ syncProtocols }) => {
-              captured = syncProtocols;
-            },
-          },
-        });
-      });
-    });
-    // start() runs forever; surface boot failures instead of an unhandled
-    // reject. `halted` is the expected rejection from stop()/task.halt().
-    Promise.resolve(task).catch((e) => {
-      if (String(e).includes("halted")) return;
-      bootErr = e;
-    });
-    return {
-      task,
-      syncProtocols: () => captured,
-      bootError: () => bootErr,
-      stop: async () => {
-        await task.halt();
-      },
-    };
+    try {
+      // Drop lingering backends so DROP DATABASE isn't blocked by open conns.
+      await admin.query(
+        `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+          WHERE datname = $1 AND pid <> pg_backend_pid()`,
+        [dbName],
+      );
+      await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    } catch {
+      // Best-effort: the cluster is torn down wholesale on process exit.
+    } finally {
+      await admin.end().catch(() => {});
+    }
   };
 
-  const harness: Harness = {
-    pglite,
-    pool,
-    dataDir,
-    runNode,
-    simulateRestart: async () => {
-      // Keep the PGLite server alive (closing/reopening it is WASM-fragile and
-      // loses state). State persists in the live instance; the node task is
-      // halted/rebooted by the test. The stopped node's pool lingers but the
-      // gateway multiplexes sockets over the one PGLite db.
-    },
-    teardown: async () => {
-      TestChainControl.clear();
-      await pool.end().catch(() => {});
-      await pglite.close().catch(() => {});
-      rmSync(dataDir, { recursive: true, force: true });
-    },
-  };
-  return harness;
-}
-
-// ── Polling helpers ──────────────────────────────────────────────────────────
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-/** Latest finalized effectstream block height (incl. empty blocks). */
-export async function latestFinalizedHeight(pool: pg.Pool): Promise<number> {
-  try {
-    const res = await pool.query(
-      `SELECT MAX(block_height)::int AS h FROM effectstream.effectstream_blocks
-       WHERE effectstream_block_hash IS NOT NULL`,
-    );
-    return res.rows[0]?.h ?? 0;
-  } catch (e) {
-    // The system migrations may not have created the table yet during boot.
-    if ((e as { code?: string })?.code === "42P01") return 0;
-    throw e;
-  }
-}
-
-/** Wait until finalized height reaches `target` (or timeout). */
-export async function waitForHeight(
-  node: RunningNode,
-  pool: pg.Pool,
-  target: number,
-  timeoutMs = 30_000,
-): Promise<number> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    const err = node.bootError();
-    if (err) throw new Error(`node boot failed: ${String(err)}`);
-    const h = await latestFinalizedHeight(pool);
-    if (h >= target) return h;
-    await sleep(50);
-  }
-  throw new Error(
-    `waitForHeight(${target}) timed out at ${await latestFinalizedHeight(pool)}`,
-  );
+  return { pool, runToHeight: makeRunToHeight(dbEnv), teardown };
 }
 
 /**
- * Wait until the finalized height stops advancing for `quietMs` (the system
- * has reached its deterministic stable state given fixed tips).
+ * PGLite backend — in-memory WASM Postgres behind a `startPglite` gateway. The
+ * single WASM backend tolerates no overlapping queries, so the subprocess routes
+ * its polls through the global DB mutex (node-runner.ts / poll.ts) and both
+ * pools cap at one connection. `startPglite` reads its config from ENV.
  */
-export async function waitUntilStable(
-  node: RunningNode,
-  pool: pg.Pool,
-  { quietMs = 800, timeoutMs = 30_000 } = {},
-): Promise<number> {
-  const startedAt = Date.now();
-  let last = -1;
-  let lastChange = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    const err = node.bootError();
-    if (err) throw new Error(`node boot failed: ${String(err)}`);
-    const h = await latestFinalizedHeight(pool);
-    if (h !== last) {
-      last = h;
-      lastChange = Date.now();
-    } else if (Date.now() - lastChange >= quietMs) {
-      return h;
-    }
-    await sleep(50);
-  }
-  return last;
-}
+async function setupPgliteHarness(): Promise<Harness> {
+  const port = await freePort();
+  const dbName = "postgres";
 
-/** Count primitive_accounting rows whose payload carries the given marker. */
-export async function countEventRows(
-  pool: pg.Pool,
-  marker: string,
-): Promise<number> {
-  const res = await pool.query(
-    `SELECT COUNT(*)::int AS c FROM effectstream.primitive_accounting
-     WHERE payload->>'marker' = $1`,
-    [marker],
-  );
-  return res.rows[0]?.c ?? 0;
-}
+  // startPglite reads these from ENV at construction; a fresh `memory://`
+  // instance is isolated per harness. PGLITE=true mutex-guards parent asserts.
+  process.env.PGLITE_DATA_DIR = "memory://";
+  process.env.DB_USER = "postgres";
+  process.env.DB_NAME = dbName;
+  process.env.PGLITE = "true";
 
-/** Page-queue rows for a protocol (the durable per-chunk queue). */
-export async function pageRows(
-  pool: pg.Pool,
-  protocolName: string,
-): Promise<{ page_number: number }[]> {
-  const res = await pool.query(
-    `SELECT page_number FROM effectstream.sync_protocol_pagination
-     WHERE protocol_name = $1 ORDER BY page_number ASC`,
-    [protocolName],
-  );
-  return res.rows;
-}
+  const handle: PgliteHandle = await startPglite(port);
+  handle.server.unref(); // don't let a leaked gateway keep the process alive
 
-/** Hex of the most-recent non-empty (non-"0x0") effectstream block hash. */
-export async function lastNonEmptyBlockHash(
-  pool: pg.Pool,
-): Promise<string | null> {
-  try {
-    const res = await pool.query(
-      `SELECT encode(effectstream_block_hash, 'hex') AS h
-       FROM effectstream.effectstream_blocks
-       WHERE effectstream_block_hash IS NOT NULL
-         AND effectstream_block_hash != '\\x307830'::bytea
-       ORDER BY block_height DESC LIMIT 1`,
-    );
-    return res.rows[0]?.h ?? null;
-  } catch {
-    return null;
-  }
-}
+  const dbEnv = {
+    PGLITE: "true",
+    DB_HOST: "127.0.0.1",
+    DB_PORT: String(port),
+    DB_NAME: dbName,
+    DB_USER: "postgres",
+    DB_PW: "",
+    PGLITE_DATA_DIR: "memory://",
+    MQTT_BROKER: "false",
+  };
 
-/** Sample a protocol's in-memory buffered-data size now. */
-export function bufferSize(
-  node: RunningNode,
-  protocolName: string,
-): number {
-  const sp = node.syncProtocols().find((p) => p.name === protocolName);
-  return sp ? sp.bufferedData.size() : 0;
-}
+  // One connection: the gateway is a single WASM backend.
+  const pool = new pg.Pool({
+    host: "127.0.0.1",
+    port,
+    user: "postgres",
+    database: dbName,
+    max: 1,
+  });
 
-export { sleep };
+  const teardown = async (): Promise<void> => {
+    await pool.end().catch(() => {});
+    await handle.close().catch(() => {});
+  };
+
+  return { pool, runToHeight: makeRunToHeight(dbEnv), teardown };
+}

--- a/packages/node-sdk/runtime/test/reproduction/node-runner.ts
+++ b/packages/node-sdk/runtime/test/reproduction/node-runner.ts
@@ -1,0 +1,152 @@
+/**
+ * One-node subprocess entry point.
+ *
+ * A real engine restart is a new OS process whose in-memory state (notably the
+ * sync Deque) is gone while PostgreSQL keeps every committed row. We model that
+ * literally: each node runs here, in its own `bun` process, against a database
+ * the parent harness created. Booting the runtime twice *in one process* is not
+ * how production works and proved unreliable (a second in-process `start()`
+ * stalls the sync loops under `bun test`), so the harness spawns this instead.
+ *
+ * Invocation (by the harness):
+ *   bun node-runner.ts '<json-RunSpec>'
+ * with DB_* / PGLITE env already set (by the harness) to point at the target
+ * database — a real Postgres server or a PGLite gateway.
+ *
+ * Exit 0 once the node has synced to the requested height (and, for the resume
+ * scenario, the requested page watermarks); exit 1 on boot failure.
+ */
+import pg from "pg";
+import { run, type Task } from "effection";
+import {
+  toSyncProtocolWithNetwork,
+  withEffectstreamStaticConfig,
+} from "@effectstream/config";
+import { TestChainControl } from "@effectstream/sync";
+import { init, start } from "../../src/main.ts";
+import type { StartConfigGameStateTransitions } from "../../src/types.ts";
+import {
+  buildConfig,
+  type EventSpec,
+  TEST_PRIMITIVE_TYPE,
+  TestEventPrimitive,
+} from "./scenario.ts";
+import { waitForHeight, waitForPage, waitUntilStable } from "./poll.ts";
+
+export type RunSpec = {
+  securityNamespace: string;
+  events: EventSpec[];
+  parallelStepSize?: number;
+  /** Manual chain tips, e.g. { mainClock: 100, parallelP: 200 }. */
+  tips: Record<string, number>;
+  /** Finalized height to reach before exiting. */
+  target: number;
+  apiPort: number;
+  /**
+   * Optional per-protocol page watermarks to also wait for before exiting.
+   * Used by the resume scenario to guarantee the parallel fetcher has raced
+   * ahead and persisted its page row before we kill the process.
+   */
+  waitPages?: Record<string, number>;
+};
+
+const noopStf: StartConfigGameStateTransitions = function* () {};
+
+async function main() {
+  const spec: RunSpec = JSON.parse(process.argv[2] ?? "{}");
+
+  // DB_* and PGLITE are set by the harness (real Postgres or a PGLite gateway);
+  // do NOT override them here. Only force the bits every run shares: no MQTT
+  // broker (it binds fixed ports and isn't freed on halt) and a per-run API port.
+  process.env.MQTT_BROKER = "false";
+  process.env.EFFECTSTREAM_API_PORT = String(spec.apiPort);
+  const isPglite = process.env.PGLITE === "true";
+
+  for (const [name, tip] of Object.entries(spec.tips)) {
+    TestChainControl.setTip(name, tip);
+  }
+
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USER,
+    database: process.env.DB_NAME,
+    password: process.env.DB_PW || undefined,
+    // PGLite is a single WASM backend: cap polls at one connection (they're also
+    // mutex-serialized against the engine — see poll.ts).
+    max: isPglite ? 1 : 10,
+  });
+
+  const cfg = buildConfig({
+    securityNamespace: spec.securityNamespace,
+    events: spec.events,
+    parallelStepSize: spec.parallelStepSize,
+  });
+
+  let bootErr: unknown;
+  let started = false;
+  let live: any[] = [];
+  const task: Task<unknown> = run(function* () {
+    yield* init();
+    yield* withEffectstreamStaticConfig(cfg, function* () {
+      yield* start({
+        appName: "sync-repro",
+        appVersion: "1.0.0",
+        syncInfo: toSyncProtocolWithNetwork(cfg),
+        gameStateTransitions: noopStf,
+        userDefinedPrimitives: { [TEST_PRIMITIVE_TYPE]: TestEventPrimitive },
+        dev: {
+          resetPublicData: false,
+          onStarted: ({ syncProtocols }: any) => {
+            live = syncProtocols;
+            started = true;
+          },
+        },
+      });
+    });
+  });
+  // start() runs forever; capture a genuine boot failure (not the expected
+  // "halted" rejection from our own task.halt() below).
+  Promise.resolve(task).catch((e) => {
+    if (!String(e).includes("halted")) bootErr = e;
+  });
+
+  const guard = async <T>(p: Promise<T>): Promise<T> => {
+    const r = await p;
+    if (bootErr) throw new Error(`node boot failed: ${String(bootErr)}`);
+    return r;
+  };
+
+  // Don't poll until `onStarted` fires: init()'s migrations and startup() run
+  // before it and aren't mutex-guarded, so on PGLite a poll could overlap them
+  // and corrupt the single WASM backend. Steady-state queries after this are.
+  while (!started) {
+    if (bootErr) throw new Error(`node boot failed: ${String(bootErr)}`);
+    await new Promise((r) => setTimeout(r, 20));
+  }
+
+  try {
+    await guard(waitForHeight(pool, spec.target));
+    await guard(waitUntilStable(pool));
+    for (const [name, page] of Object.entries(spec.waitPages ?? {})) {
+      await guard(waitForPage(pool, name, page));
+    }
+  } catch (e) {
+    const probe = live.map((p) =>
+      `${p.name}: lastPage=${JSON.stringify(p.lastPage)} buf=${p.bufferedData.size()} errs=${p.consecutiveErrors}`
+    );
+    console.error("PROBE:\n  " + probe.join("\n  "));
+    throw e;
+  } finally {
+    await task.halt().catch(() => {});
+    await pool.end().catch(() => {});
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    console.error(String(e instanceof Error ? e.stack ?? e.message : e));
+    process.exit(1);
+  },
+);

--- a/packages/node-sdk/runtime/test/reproduction/poll.ts
+++ b/packages/node-sdk/runtime/test/reproduction/poll.ts
@@ -1,0 +1,160 @@
+/**
+ * pg.Pool query helpers shared by the test harness (parent process, used for
+ * assertions) and {@link ./node-runner.ts} (child process, used to decide when a
+ * node has finished syncing). No cluster / runtime imports.
+ *
+ * On PGLite every query is serialized through the engine's process-global DB
+ * mutex — see {@link q}. On a real Postgres server that mutex is a no-op and
+ * these are plain pooled queries.
+ */
+import type pg from "pg";
+import { run } from "effection";
+import { ENV } from "@effectstream/utils/node-env";
+import { acquireDBMutex, releaseDBMutex } from "@effectstream/db";
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run a query, serialized through the engine's process-global DB mutex on PGLite
+ * (a single WASM backend that two overlapping queries corrupt). node-runner
+ * polls while the engine syncs in the SAME process, so taking the same mutex the
+ * engine uses guarantees no overlap — they share the module-global lock even
+ * across separate `run()` roots. On real Postgres the mutex is a no-op.
+ */
+async function q<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  pool: pg.Pool,
+  sql: string,
+  params?: unknown[],
+): Promise<T[]> {
+  if (!ENV.PGLITE) {
+    return (await pool.query<T>(sql, params)).rows;
+  }
+  const lock = "repro-poll";
+  await run(() => acquireDBMutex(lock));
+  try {
+    return (await pool.query<T>(sql, params)).rows;
+  } finally {
+    releaseDBMutex(lock);
+  }
+}
+
+/** Latest finalized effectstream block height (incl. empty blocks). 0 if none. */
+export async function latestFinalizedHeight(pool: pg.Pool): Promise<number> {
+  try {
+    const rows = await q<{ h: number | null }>(
+      pool,
+      `SELECT MAX(block_height)::int AS h FROM effectstream.effectstream_blocks
+       WHERE effectstream_block_hash IS NOT NULL`,
+    );
+    return rows[0]?.h ?? 0;
+  } catch (e) {
+    // The system migrations may not have created the table yet during boot.
+    if ((e as { code?: string })?.code === "42P01") return 0;
+    throw e;
+  }
+}
+
+/** Highest persisted page-queue number for a protocol (-1 if none yet). */
+export async function maxPage(
+  pool: pg.Pool,
+  protocolName: string,
+): Promise<number> {
+  try {
+    const rows = await q<{ p: number | null }>(
+      pool,
+      `SELECT MAX(page_number)::int AS p FROM effectstream.sync_protocol_pagination
+       WHERE protocol_name = $1`,
+      [protocolName],
+    );
+    return rows[0]?.p ?? -1;
+  } catch (e) {
+    if ((e as { code?: string })?.code === "42P01") return -1;
+    throw e;
+  }
+}
+
+/** Wait until finalized height reaches `target` (or throw on timeout). */
+export async function waitForHeight(
+  pool: pg.Pool,
+  target: number,
+  timeoutMs = 30_000,
+): Promise<number> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const h = await latestFinalizedHeight(pool);
+    if (h >= target) return h;
+    await sleep(50);
+  }
+  throw new Error(
+    `waitForHeight(${target}) timed out at ${await latestFinalizedHeight(pool)}`,
+  );
+}
+
+/**
+ * Wait until the finalized height stops advancing for `quietMs` (the system has
+ * reached its deterministic stable state given fixed tips).
+ */
+export async function waitUntilStable(
+  pool: pg.Pool,
+  { quietMs = 800, timeoutMs = 30_000 } = {},
+): Promise<number> {
+  const startedAt = Date.now();
+  let last = -1;
+  let lastChange = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const h = await latestFinalizedHeight(pool);
+    if (h !== last) {
+      last = h;
+      lastChange = Date.now();
+    } else if (Date.now() - lastChange >= quietMs) {
+      return h;
+    }
+    await sleep(50);
+  }
+  return last;
+}
+
+/** Wait until a protocol's persisted page reaches `target` (or throw). */
+export async function waitForPage(
+  pool: pg.Pool,
+  protocolName: string,
+  target: number,
+  timeoutMs = 30_000,
+): Promise<number> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const p = await maxPage(pool, protocolName);
+    if (p >= target) return p;
+    await sleep(50);
+  }
+  throw new Error(
+    `waitForPage(${protocolName}, ${target}) timed out at ${await maxPage(pool, protocolName)}`,
+  );
+}
+
+/** Count primitive_accounting rows whose payload carries the given marker. */
+export async function countEventRows(
+  pool: pg.Pool,
+  marker: string,
+): Promise<number> {
+  const rows = await q<{ c: number | null }>(
+    pool,
+    `SELECT COUNT(*)::int AS c FROM effectstream.primitive_accounting
+     WHERE payload->>'marker' = $1`,
+    [marker],
+  );
+  return rows[0]?.c ?? 0;
+}
+
+/** Page-queue rows for a protocol (the durable per-chunk queue). */
+export async function pageRows(
+  pool: pg.Pool,
+  protocolName: string,
+): Promise<{ page_number: number }[]> {
+  return await q<{ page_number: number }>(
+    pool,
+    `SELECT page_number FROM effectstream.sync_protocol_pagination
+     WHERE protocol_name = $1 ORDER BY page_number ASC`,
+    [protocolName],
+  );
+}

--- a/packages/node-sdk/runtime/test/reproduction/resume.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/resume.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Resume-marker position over the synthetic `test` chain.
+ *
+ * Companion to consistency.test.ts (which proves a mid-chunk restart re-fetches
+ * uncommitted data instead of skipping it). This file pins down *where* the
+ * persisted resume marker lands for a chain whose data is sparse — the property
+ * that bounds restart re-scan (see @effectstream/sync CLAUDE.md, design idea #5).
+ *
+ * The marker is the highest datum merged into the committed block, and because
+ * each fetched chunk's boundary page is buffered and consumed even when empty, it
+ * tracks the **committed frontier** — NOT the last block that happened to carry
+ * data. So a chain that produced one event long ago and has been quiet since
+ * still resumes near the frontier, re-fetching at most ~stepSize blocks, never
+ * its whole quiet tail. Here: data lives only at block 5, yet the marker must sit
+ * at the frontier (height 50 / 60), not stuck back at 5.
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+  countEventRows,
+  type Harness,
+  latestFinalizedHeight,
+  maxPage,
+  setupHarness,
+} from "./harness.ts";
+
+let h: Harness;
+
+beforeAll(async () => {
+  h = await setupHarness();
+});
+
+afterAll(async () => {
+  await h?.teardown();
+});
+
+test(
+  "a sparse chain's resume marker tracks the frontier, not its last data block",
+  async () => {
+    // Data lives ONLY at parallel block 5; everything after is quiet. Block 5 is
+    // the marker a naive "resume from last data" scheme would persist.
+    const events = [{ atBlock: 5, marker: "evt5" }];
+
+    // Phase 1 — sync the main clock to 50 (parallel tip stays ahead so the merge
+    // can finalize). The block-5 event is merged early; the chain is quiet after.
+    await h.runToHeight({
+      events,
+      tips: { mainClock: 50, parallelP: 200 },
+      target: 50,
+      apiPort: 19161,
+    });
+
+    expect(await latestFinalizedHeight(h.pool)).toBe(50);
+    expect(await countEventRows(h.pool, "evt5")).toBe(1);
+
+    // The crux: the parallel marker tracks the committed frontier (50), NOT the
+    // last data block (5). A restart therefore resumes from ~51 and re-scans only
+    // the bounded gap up to the frontier — never blocks 6..50 from scratch.
+    expect(await maxPage(h.pool, "parallelP")).toBe(50);
+    expect(await maxPage(h.pool, "parallelP")).not.toBe(5);
+
+    // Phase 2 (restart) — boot a fresh process against the same DB and sync on to
+    // 60. The parallel chain resumes from the frontier (51), not from block 5.
+    await h.runToHeight({
+      events,
+      tips: { mainClock: 60, parallelP: 200 },
+      target: 60,
+      apiPort: 19162,
+    });
+
+    expect(await latestFinalizedHeight(h.pool)).toBe(60);
+    // Marker advanced with the new frontier...
+    expect(await maxPage(h.pool, "parallelP")).toBe(60);
+    // ...and block 5 was neither re-fetched (resume started past it) nor lost.
+    expect(await countEventRows(h.pool, "evt5")).toBe(1);
+  },
+  120_000,
+);

--- a/packages/node-sdk/runtime/test/reproduction/sanity.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/sanity.test.ts
@@ -2,89 +2,25 @@
  * Sanity end-to-end test for the synthetic `test` chain (no fixes required).
  *
  * Proves the foundation this PR adds works: a TEST_MAIN clock + a TEST_PARALLEL
- * chain sync through the real runtime (`start()` + PGLite), a config-declared
- * event is processed into `effectstream.primitive_accounting`, and committed
- * state survives a restart.
+ * chain sync through the real runtime (`start()`), a config-declared event is
+ * processed into `effectstream.primitive_accounting`, and committed state
+ * survives a restart.
+ *
+ * Runs on whichever backend `setupHarness` picks: the default in-memory PGLite
+ * (no external dependency) or real Postgres when `PGLITE=false`. Either way
+ * each node runs in its own subprocess (see harness.ts / node-runner.ts), so a
+ * restart is a genuine new OS process booting against the same database.
  *
  * (The buffering / resume / fast-catchup reproduction tests land alongside their
  * fixes in follow-up PRs — they assert behaviour that only those fixes provide.)
  */
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import {
-  ConfigBuilder,
-  ConfigNetworkType,
-  ConfigSyncProtocolType,
-} from "@effectstream/config";
-import { TestChainControl } from "@effectstream/sync";
-import {
   countEventRows,
   type Harness,
   latestFinalizedHeight,
   setupHarness,
-  TEST_PRIMITIVE_TYPE,
-  waitForHeight,
-  waitUntilStable,
 } from "./harness.ts";
-
-const START_TIME = 1_700_000_000_000;
-const BLOCK_TIME_MS = 1000;
-
-function buildConfig() {
-  return new ConfigBuilder()
-    .setNamespace((b) => b.setSecurityNamespace("sync-sanity"))
-    .buildNetworks((b) =>
-      b
-        .addNetwork({
-          name: "clock",
-          type: ConfigNetworkType.TEST,
-          startTime: START_TIME,
-          blockTimeMS: BLOCK_TIME_MS,
-        })
-        .addNetwork({
-          name: "chainP",
-          type: ConfigNetworkType.TEST,
-          startTime: START_TIME,
-          blockTimeMS: BLOCK_TIME_MS,
-        })
-    )
-    .buildDeployments((b) => b)
-    .buildSyncProtocols((b) =>
-      b
-        .addMain(
-          (n) => n.clock,
-          () => ({
-            name: "mainClock",
-            type: ConfigSyncProtocolType.TEST_MAIN,
-            startBlockHeight: 1,
-            pollingInterval: 30,
-            stepSize: 1000,
-          }),
-        )
-        .addParallel(
-          (n) => (n as any).chainP,
-          () => ({
-            name: "parallelP",
-            type: ConfigSyncProtocolType.TEST_PARALLEL,
-            startBlockHeight: 1,
-            pollingInterval: 30,
-            stepSize: 1000,
-            delayMs: 0,
-            events: [{ atBlock: 50, payload: { marker: "evt50" } }],
-          }),
-        )
-    )
-    .buildPrimitives((b) =>
-      b.addPrimitive(
-        (sp) => (sp as any).parallelP,
-        () => ({
-          name: "testEvt",
-          type: TEST_PRIMITIVE_TYPE,
-          startBlockHeight: 1,
-        }),
-      )
-    )
-    .build();
-}
 
 let h: Harness;
 
@@ -97,29 +33,42 @@ afterAll(async () => {
 });
 
 test("test chain syncs, processes a configured event, and survives restart", async () => {
+  const events = [{ atBlock: 50, marker: "evt50" }];
+
   // Parallel tip (200) stays ahead of the main clock (100) so the merge is not
   // gated at the chunk boundary.
-  TestChainControl.setTip("mainClock", 100);
-  TestChainControl.setTip("parallelP", 200);
+  await h.runToHeight({
+    events,
+    tips: { mainClock: 100, parallelP: 200 },
+    target: 100,
+    apiPort: 19131,
+  });
 
-  const n1 = await h.runNode({ config: buildConfig(), apiPort: 19131 });
-  await waitForHeight(n1, h.pool, 100);
-  await waitUntilStable(n1, h.pool);
-
-  expect(await latestFinalizedHeight(h.pool)).toBe(100);
+  const height1 = await latestFinalizedHeight(h.pool);
+  const events1 = await countEventRows(h.pool, "evt50");
+  console.log(
+    `[sanity] after sync:    height ${height1} (expect 100), ` +
+      `evt50 rows ${events1} (expect 1)`,
+  );
+  expect(height1).toBe(100);
   // The event declared at block 50 was processed into primitive_accounting.
-  expect(await countEventRows(h.pool, "evt50")).toBe(1);
-  await n1.stop();
+  expect(events1).toBe(1);
 
-  // Restart: committed state must persist (chain already fully caught up).
-  await h.simulateRestart();
-  TestChainControl.setTip("mainClock", 100);
-  TestChainControl.setTip("parallelP", 200);
+  // Restart: a new process boots against the same database. Committed state must
+  // persist; the chain is already fully caught up, so nothing new is produced.
+  await h.runToHeight({
+    events,
+    tips: { mainClock: 100, parallelP: 200 },
+    target: 100,
+    apiPort: 19132,
+  });
 
-  const n2 = await h.runNode({ config: buildConfig(), apiPort: 19132 });
-  await waitUntilStable(n2, h.pool);
-
-  expect(await latestFinalizedHeight(h.pool)).toBe(100);
-  expect(await countEventRows(h.pool, "evt50")).toBe(1);
-  await n2.stop();
+  const height2 = await latestFinalizedHeight(h.pool);
+  const events2 = await countEventRows(h.pool, "evt50");
+  console.log(
+    `[sanity] after restart: height ${height2} (expect 100, was ${height1}), ` +
+      `evt50 rows ${events2} (expect 1, was ${events1})`,
+  );
+  expect(height2).toBe(100);
+  expect(events2).toBe(1);
 }, 60_000);

--- a/packages/node-sdk/runtime/test/reproduction/scenario.ts
+++ b/packages/node-sdk/runtime/test/reproduction/scenario.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared scenario building blocks for the reproduction tests.
+ *
+ * Both the in-process test files and the out-of-process {@link ./node-runner.ts}
+ * subprocess build the *same* synthetic `test`-chain config from these helpers,
+ * so a node booted in a child process is identical to one a test would describe.
+ * Keeping the config + primitive here (no DB, no cluster imports) lets the
+ * subprocess import it cheaply.
+ */
+import {
+  ConfigBuilder,
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+} from "@effectstream/config";
+import { Primitive } from "@effectstream/sm";
+
+/** Fixed wall-clock origin so block timestamps are pure arithmetic. */
+export const START_TIME = 1_700_000_000_000;
+export const BLOCK_TIME_MS = 1000;
+
+export type EventSpec = { atBlock: number; marker: string };
+
+export type ScenarioOpts = {
+  events: EventSpec[];
+  /** Parallel-chain page size. Large (default 1000) => whole tip is one chunk. */
+  parallelStepSize?: number;
+  /** Security namespace; distinct per test keeps databases independent. */
+  securityNamespace?: string;
+};
+
+export function buildConfig(opts: ScenarioOpts) {
+  const stepSize = opts.parallelStepSize ?? 1000;
+  const namespace = opts.securityNamespace ?? "sync-repro";
+  return new ConfigBuilder()
+    .setNamespace((b) => b.setSecurityNamespace(namespace))
+    .buildNetworks((b) =>
+      b
+        .addNetwork({
+          name: "clock",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+        .addNetwork({
+          name: "chainP",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+    )
+    .buildDeployments((b) => b)
+    .buildSyncProtocols((b) =>
+      b
+        .addMain(
+          (n) => n.clock,
+          () => ({
+            name: "mainClock",
+            type: ConfigSyncProtocolType.TEST_MAIN,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: 1000,
+          }),
+        )
+        .addParallel(
+          (n) => (n as any).chainP,
+          () => ({
+            name: "parallelP",
+            type: ConfigSyncProtocolType.TEST_PARALLEL,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize,
+            delayMs: 0,
+            events: opts.events.map((e) => ({
+              atBlock: e.atBlock,
+              payload: { marker: e.marker },
+            })),
+          }),
+        )
+    )
+    .buildPrimitives((b) =>
+      b.addPrimitive(
+        (sp) => (sp as any).parallelP,
+        () => ({
+          name: "testEvt",
+          type: TEST_PRIMITIVE_TYPE,
+          startBlockHeight: 1,
+        }),
+      )
+    )
+    .build();
+}
+
+// ── A minimal user-defined primitive ─────────────────────────────────────────
+// Writes one row to effectstream.primitive_accounting per event (no STF needed:
+// stateMachinePayload is null). Tests assert on that table.
+export const TEST_PRIMITIVE_TYPE = "TEST:EVENT";
+
+export class TestEventPrimitive extends Primitive<any, any> {
+  readonly internalTypeName = TEST_PRIMITIVE_TYPE as any;
+  override grammar = [] as any;
+  constructor(config: any) {
+    super(config);
+  }
+  // deno-lint-ignore require-yield
+  override *getPayload(_height: any, primitiveTransactionData: any): any {
+    const payload = primitiveTransactionData.output.payload;
+    return {
+      isBatched: false,
+      data: [
+        {
+          fromAddressAndType: { type: "none", address: "0x0" },
+          accountingPayload: payload,
+          stateMachinePayload: null,
+        },
+      ],
+    };
+  }
+  override getConfig(): any {
+    return {
+      name: this.instanceName,
+      type: this.internalTypeName,
+      startBlockHeight: this.startBlockHeight,
+      scheduledPrefix: this.stateMachinePrefix,
+    };
+  }
+}

--- a/packages/node-sdk/sync/CLAUDE.md
+++ b/packages/node-sdk/sync/CLAUDE.md
@@ -35,7 +35,7 @@ config (syncProtocols.main + syncProtocols.parallel)
 │  PER-CHAIN FETCH LOOPS              one spawn per protocol             │
 │  startSync(state):  stateToInput → readData → updateState             │
 │    → push Output to bufferedData (Deque)  + wake newData/newPageCondVar│
-│    → upsertPage(page_number = chunk_end) into sync_protocol_pagination │
+│    → lastPage kept IN-MEMORY only (no DB write; runtime owns resume)   │
 │    → producerChannel.send(...)  ← NOTE: nothing consumes this today    │
 └────────────────────────────────────────┬─────────────────────────────┘
                                           ▼
@@ -47,8 +47,9 @@ config (syncProtocols.main + syncProtocols.parallel)
 └────────────────────────────────────────┬─────────────────────────────┘
                                           ▼
    runtime/src/main.ts:  for (block of each(finalizedBlockStream))
-     acquire DB mutex → processFinalizedBlock (STF) → COMMIT
-     → removePages(< merged block) → fire-and-forget MQTT events → each.next()
+     acquire DB mutex → processFinalizedBlock (STF)
+     → upsertPage(block.resumePages) + removePages(< committed) [in txn] → COMMIT
+     → fire-and-forget MQTT events → each.next()
 ```
 
 ## The three per-chain abstractions (`src/sync-protocols/<chain>/`)
@@ -112,12 +113,34 @@ iteration it walks protocols in order:
    a parallel chain's timestamp so older blocks merge into more-recent root slots.
 4. **Mutate-after-commit.** `OutputAndCleanup` keeps data in the Deque until the block is
    safely produced; the consumer commits to Postgres *before* emitting events.
-5. **Durable, resumable page queue.** `effectstream.sync_protocol_pagination` is keyed
-   `(protocol_name, page_number)`. Fetch appends a row per chunk (`upsertPage`,
-   `page_number = chunk_end`); on commit the consumer deletes consumed chunks
-   (`removePages(page_number < merged_block)`, `runtime/process-blocks.ts:328`); on boot
-   `restoreState` resumes from `getPage` = `ORDER BY page_number ASC LIMIT 1` (oldest
-   remaining chunk).
+5. **Durable, block-accurate resume queue.** *(Single source of truth for how restart/resume
+   works — code comments point here; see also Finding #2 for the bug this fixes.)*
+
+   `effectstream.sync_protocol_pagination` is keyed `(protocol_name, page_number)` and the
+   **runtime is the sole writer** of the resume position (Fix D). End to end:
+   - **Fetch loop** (`base/state.ts:updateState`) keeps `lastPage` in memory only — it does
+     **not** persist (it runs ahead of commits, so its chunk-end page is not a safe resume
+     point).
+   - **Merge** (`orchestration/merge.ts`) tags every `ChainBlock` with `resumePages`: one
+     marker per protocol = `outputToLastPage(lastConsumed)`, the `LastPage`
+     (`{ own, ownBlockNumber, root }`) of the **highest datum merged into the block**. Each
+     protocol implements `outputToLastPage` (`base/state.ts` + per-chain `state.ts`) because
+     `own` is a structured page for object-paged chains and can't be rebuilt from the block
+     number. Pending data above the committed timestamp is **not** marked, so it is always
+     re-fetched, never skipped.
+   - **Commit** (`runtime/process-blocks.ts`, STEP 7) writes each marker **inside the block's
+     transaction**: `upsertPage(page_number = ownBlockNumber)` then
+     `removePages(page_number < ownBlockNumber)` — leaving exactly one row per protocol = the
+     committed watermark, atomic with the block.
+   - **Boot** (`restoreState`) reads `getPage` = `ORDER BY page_number ASC LIMIT 1` and
+     resumes from `nextInterval(own).from` = the next uncommitted block.
+
+   **Re-scan on restart is bounded by `stepSize`, not a chain's whole quiet tail.** Every
+   fetched chunk's boundary page (`data.to`) is buffered and consumed even when empty, so the
+   marker advances to within one `stepSize` of the committed frontier — and reaches the
+   fetched tip exactly at full catch-up. So a long-quiet chain re-fetches at most ~`stepSize`
+   blocks after a restart, regardless of how long ago its last data was. Trade-off:
+   `getSyncAndLastPage` now reports `synced_page == fetched_page`.
 
 ---
 
@@ -146,24 +169,20 @@ Consequences during catch-up:
 
 → Fix: **(C) backpressure** — cap `bufferedData` and pause the fetch loop until the merge drains.
 
-### 2. Silent data gap on restart (correctness)
+### 2. Silent data gap on restart (correctness) — ✅ FIXED (D)
 
-The page queue is **chunk-granular** but commits are **single-block-granular**:
-- fetch persists `upsertPage(page_number = chunk_end)` (`base/state.ts:132`; `own = ownBlockNumber = Number(data.to)`),
-- commit deletes `removePages(page_number < merged_block_N)` (`process-blocks.ts:328`),
-- restart resumes from `getPage` = oldest remaining chunk, at `nextInterval(own).from = chunk_end + 1`.
+**The bug (historical).** The page queue was **chunk-granular** but commits are
+**single-block-granular**: the fetch loop persisted `upsertPage(page_number = chunk_end)`,
+commit deleted `removePages(page_number < merged_block_N)`, and restart resumed from
+`getPage` = oldest remaining chunk at `nextInterval(own).from = chunk_end + 1`. During
+catch-up chunks are full `stepSize`, so the committed watermark `N` sat **inside** the
+oldest retained chunk `[start, end]` (`end ≥ N ⇒ not deleted`); resume jumped to `end + 1`,
+**silently skipping `(N, end]`** → missing primitives → divergent app state, with no error.
 
-During catch-up chunks are full `stepSize`, so at restart the committed watermark `N` sits
-**inside** the oldest retained chunk `[start, end]` (`start ≤ N < end ⇒ end ≥ N ⇒ not deleted`).
-Resume jumps to `end + 1`, **silently skipping source blocks `(N, end]`** (up to
-`stepSize - 1`). The in-memory Deque held them; they're gone on restart; the effectstream
-height continues seamlessly with **missing primitives → divergent app state**. There is
-**no error** and **no restart/resume test** (the only tests in `test/examples.test.ts` are
-export smoke-checks). The existing `getSyncAndLastPage` `synced_page` (`MIN(page_number)`)
-is itself chunk-granular and does not reflect the true committed block.
-
-→ Fix: **(D) block-accurate resume** — persist the committed per-protocol watermark and
-resume from `watermark + 1`, reconciling stale fetched-ahead page rows.
+**The fix (D) — block-accurate resume, runtime is the sole writer.** The runtime persists a
+block-accurate marker per protocol on commit instead of the fetch loop persisting chunk-end
+pages. Full mechanism in **design idea #5** above. Regression test: the
+`consistency.test.ts` "mid-chunk restart" case (Postgres-only).
 
 ### 3. Serial replay is the catch-up bottleneck
 
@@ -182,6 +201,6 @@ block-hash chain.
 > survives a restart. See `docs/ADDING-A-SYNC-PROTOCOL.md` for how to add a chain
 > (with `test` as the worked example).
 >
-> Deterministic reproductions of #1/#2/#3 and their fixes land in **follow-up
-> PRs**, each test alongside its fix: #1 → fetch backpressure; #2 →
-> block-accurate resume; #3 → opt-in empty-block commit batching during catch-up.
+> Deterministic reproductions of #1/#2/#3 and their fixes land alongside each fix:
+> **#2 → block-accurate resume is DONE** (`consistency.test.ts`). Still in follow-up
+> PRs: #1 → fetch backpressure; #3 → opt-in empty-block commit batching during catch-up.

--- a/packages/node-sdk/sync/src/sync-protocols/avail/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/state.ts
@@ -100,6 +100,15 @@ export class AvailSyncState extends SyncState<
   }
 
   @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    return {
+      own: { height: data.raw.number, hash: data.raw.hash },
+      ownBlockNumber: data.raw.number,
+      root: this.toRootPage(data),
+    };
+  }
+
+  @bound
   override getNamespace(): string[] {
     return [this.config.network.name, this.config.syncProtocol.name];
   }

--- a/packages/node-sdk/sync/src/sync-protocols/base/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/base/state.ts
@@ -1,4 +1,4 @@
-import { type Operation, until } from "effection";
+import { type Operation } from "effection";
 import Deque from "denque";
 import {
   type BlockNumber,
@@ -11,7 +11,6 @@ import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import type { BaseDataFetcher, DataFetched } from "./fetcher.ts";
 import type { PageRelation } from "./page.ts";
 import type { PoolClient } from "pg";
-import { acquireDBMutex, releaseDBMutex, upsertPage } from "@effectstream/db";
 
 export type LastPage<Page, RootPage> = {
   own: Page;
@@ -106,6 +105,12 @@ export abstract class SyncState<
    */
   abstract mergeDatum(ourOutput: Output, rootOutput: RootOutput): void;
 
+  /**
+   * Build the resume marker for a single output: the {@link LastPage} to resume
+   * fetching *after* it. See CLAUDE.md design idea #5 (restart/resume).
+   */
+  abstract outputToLastPage(data: Output): LastPage<Page, RootPage>;
+
   @bound
   *updateState(
     _input: Input,
@@ -129,13 +134,8 @@ export abstract class SyncState<
           ),
       );
 
-      yield* acquireDBMutex(`update-state-${this.name}`);
-      yield* until(upsertPage.run({
-        protocol_name: this.name,
-        page_number: data.lastPage.ownBlockNumber,
-        page: JSON.stringify(data.lastPage),
-      }, this.dbConn as any)); // Client,
-      releaseDBMutex(`update-state-${this.name}`);
+      // lastPage is in-memory only; the runtime is the sole writer of the
+      // persisted resume marker (see CLAUDE.md design idea #5).
       this.lastPage = data.lastPage;
       this.newPageCondVar.wake();
     }

--- a/packages/node-sdk/sync/src/sync-protocols/bitcoin/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/bitcoin/state.ts
@@ -58,6 +58,7 @@ export class BitcoinSyncState extends SyncState<
         block_number: Number(data.raw.height),
         blockHash: hash,
       })),
+      resumePages: [],
       primitives: data.primitives.map((primitive) => ({
         ...primitive,
         source: this.config.syncProtocol.name,
@@ -110,6 +111,16 @@ export class BitcoinSyncState extends SyncState<
     }));
     rootOutput.primitives.push(...primitives);
     rootOutput.blockInfo.push(...blockInfo);
+  }
+
+  @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    const block = Number(data.raw.height);
+    return {
+      own: block,
+      ownBlockNumber: block,
+      root: this.toRootPage(data),
+    };
   }
 
   @bound

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/state.ts
@@ -100,6 +100,15 @@ export class CelestiaSyncState extends SyncState<
   }
 
   @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    return {
+      own: { height: data.height, hash: data.hash },
+      ownBlockNumber: data.height,
+      root: this.toRootPage(data),
+    };
+  }
+
+  @bound
   override getNamespace(): string[] {
     return [this.config.network.name, this.config.syncProtocol.name];
   }

--- a/packages/node-sdk/sync/src/sync-protocols/common/root.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/common/root.ts
@@ -5,6 +5,7 @@ import type {
   TimestampMs,
 } from "@effectstream/utils";
 import type { PageRelation } from "../base/page.ts";
+import type { LastPage } from "../base/state.ts";
 import type {
   ConfigSyncProtocolType,
   FlattenSyncProtocolIOFor,
@@ -18,6 +19,14 @@ export type ChainBlock = {
     protocol_name: string;
     block_number: BlockNumber;
     blockHash: BlockHash;
+  }[];
+  /**
+   * Per-protocol block-accurate resume markers the runtime persists on commit.
+   * See `@effectstream/sync` CLAUDE.md, design idea #5 (restart/resume).
+   */
+  resumePages: {
+    protocol_name: string;
+    lastPage: LastPage<unknown, unknown>;
   }[];
   primitives: (
     & FlattenSyncProtocolIOFor<

--- a/packages/node-sdk/sync/src/sync-protocols/evm/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/evm/state.ts
@@ -91,6 +91,16 @@ export class EvmSyncState extends SyncState<
   }
 
   @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    const block = Number(data.raw.number);
+    return {
+      own: block,
+      ownBlockNumber: block,
+      root: this.toRootPage(data),
+    };
+  }
+
+  @bound
   override getNamespace(): string[] {
     return [this.config.network.name, this.config.syncProtocol.name];
   }

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/state.ts
@@ -111,6 +111,15 @@ export class MidnightSyncState extends SyncState<
   }
 
   @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    return {
+      own: { height: data.raw.height, hash: data.raw.hash },
+      ownBlockNumber: data.raw.height,
+      root: this.toRootPage(data),
+    };
+  }
+
+  @bound
   override getNamespace(): string[] {
     return [this.config.network.name, this.config.syncProtocol.name];
   }

--- a/packages/node-sdk/sync/src/sync-protocols/near/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/near/state.ts
@@ -99,6 +99,15 @@ export class NearSyncState extends SyncState<
   }
 
   @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    return {
+      own: { height: data.height, hash: data.hash },
+      ownBlockNumber: data.height,
+      root: this.toRootPage(data),
+    };
+  }
+
+  @bound
   override getNamespace(): string[] {
     return [this.config.network.name, this.config.syncProtocol.name];
   }

--- a/packages/node-sdk/sync/src/sync-protocols/ntp/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/ntp/state.ts
@@ -48,6 +48,7 @@ export class NtpSyncState extends SyncState<
       })),
       blockNumber: Number(data.raw.blockNumber),
       timestamp: this.toRootPage(data),
+      resumePages: [],
       primitives: [],
     };
   }
@@ -84,6 +85,16 @@ export class NtpSyncState extends SyncState<
     rootOutput: RootOutput,
   ): void {
     throw new Error("Only parallel chains merge into root");
+  }
+
+  @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    const block = Number(data.raw.blockNumber);
+    return {
+      own: block,
+      ownBlockNumber: block,
+      root: this.toRootPage(data),
+    };
   }
 
   @bound

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/merge.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/merge.ts
@@ -124,6 +124,11 @@ export function* mergeIntoRoot<SyncProtocol extends AllSyncProtocols>(
     }
     const output = iState.bufferedData.peekAt(0)!;
     const newRoot = iState.toRootOutput(output.output);
+    // Resume marker: the single datum this root block is built from (CLAUDE.md #5).
+    newRoot.resumePages.push({
+      protocol_name: state.name,
+      lastPage: iState.outputToLastPage(output.output),
+    });
     return {
       updateCache: () => {
         output.cleanup();
@@ -167,6 +172,17 @@ export function* mergeIntoRoot<SyncProtocol extends AllSyncProtocols>(
     rootInfo.comparePage,
     iState.mergeDatum,
   );
+
+  // Resume marker: the last (highest) datum merged this iteration, still in the
+  // Deque at `cleanups.length - 1` (cleanup runs after send). Nothing consumed →
+  // no marker. See CLAUDE.md #5.
+  if (cleanups.length > 0) {
+    const lastConsumed = iState.bufferedData.peekAt(cleanups.length - 1)!;
+    rootInfo.value.resumePages.push({
+      protocol_name: state.name,
+      lastPage: iState.outputToLastPage(lastConsumed.output),
+    });
+  }
 
   return {
     updateCache: () => {

--- a/packages/node-sdk/sync/src/sync-protocols/test/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/state.ts
@@ -60,6 +60,7 @@ export class TestSyncState extends SyncState<
       })),
       blockNumber: Number(data.raw.blockNumber),
       timestamp: this.toRootPage(data),
+      resumePages: [],
       primitives: data.primitives.map((p) => ({
         ...p,
         source: this.config.syncProtocol.name,
@@ -112,6 +113,16 @@ export class TestSyncState extends SyncState<
     }));
     rootOutput.primitives.push(...primitives);
     rootOutput.blockInfo.push(...blockInfo);
+  }
+
+  @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    const block = Number(data.raw.blockNumber);
+    return {
+      own: block,
+      ownBlockNumber: block as BlockNumber,
+      root: this.toRootPage(data),
+    };
   }
 
   @bound

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/state.ts
@@ -158,6 +158,22 @@ export class UtxoRpcSyncState extends SyncState<
   }
 
   @bound
+  override outputToLastPage(data: Output): LastPage<Page, RootPage> {
+    // Mirror the fetcher's `own`: slot/height from the block header, and the
+    // block hash from `blockHashes` (the fetcher builds it as `[completed.hash]`,
+    // the same value it stored in `own.hash`).
+    return {
+      own: {
+        slot: Number(data.raw.header!.slot),
+        height: Number(data.raw.header!.height),
+        hash: data.blockHashes[0],
+      },
+      ownBlockNumber: Number(data.raw.header!.height),
+      root: this.toRootPage(data),
+    };
+  }
+
+  @bound
   override getNamespace(): string[] {
     return [this.config.network.name, this.config.syncProtocol.name];
   }


### PR DESCRIPTION
## Summary
- Runtime is now the sole writer of resume markers. Previously each sync-protocol `SyncState` wrote its own `pages` row inside `updateState`, racing with the runtime's per-block transaction. The sync layer now keeps `lastPage` in-memory only; the runtime upserts and prunes the resume marker inside the block's own transaction (STEP 7 of processFinalizedBlock). This eliminates the race where a partially-committed block could leave a resume cursor pointing past uncommitted data, causing a silent re-process skip on restart.

- `resumePages` propagated through the merge. The `mergeIntoRoot` / `mergeIntoNonRoot` orchestration now collects one `{ protocol_name, lastPage }` entry per protocol per finalized block. Each concrete `SyncState` subclass implements `outputToLastPage()` to build that marker.

- Block-accurate resume fix (each → explicit subscriber). Subscribing to `finalizedBlockStream` now happens before the merge fiber is spawned. Effection drops sends with no active subscriber, so a fast in-memory restart (no RPC wait, i.e test chain) could emit blocks before the consumer subscribed and silently stall. The fix uses an explicit `yield* finalizedBlockStream` subscription, held across the loop.

- New test infrastructure (reproduction/ suite). The existing `harness.ts` / `sanity.test.ts` were refactored and three new modules added:
  - `node-runner.ts` — runs the sync node as a real subprocess (genuine restart: in-memory state gone, DB survives).
  - `scenario.ts` — declarative block/event definitions for synthetic test chains.
  - `poll.ts` — retry helpers for async node state.
  - `consistency-snapshot.ts` — dumps the full database into a comparable `Map<table, { rowCount, checksum }>`, excluding known-volatile columns.
- `consistency.test.ts` — two Postgres-backed determinism properties:
  - Determinism baseline: two independent from-scratch syncs to the same height produce identical databases.
  - Resume guarantee: a sync that stops mid-chunk and resumes must match a clean sync — regression test for the block-accurate resume fix.
- `resume.test.ts` — pins the resume-marker position for a sparse chain: data at block 5 only, yet the marker must sit at the committed frontier (~50–60), not stuck at 5.

- **Bug report**: `conciseInputHash` nondeterminism (`conciseinputhash-determinism.md`). Documents that scheduled-input `effectstream_tx_hash` is currently synthesized with `Math.random()`, producing different values on every node/run. The block-hash chain is unaffected (does not cover `effectstream_tx_hash`), and the reproduction tests deliberately avoid triggering this branch, but it is a determinism hole in `rollup_input_result` for any app that schedules STF inputs. A follow-up fix is tracked in the report.

## Test plan
- [x] bun test packages/node-sdk/runtime/test/reproduction/ — all sanity + resume tests pass in PGLite mode
- [x] PGLITE=false bun test packages/node-sdk/runtime/test/reproduction/ — consistency tests pass with Postgres
- [x] bun run e2e/runner.ts (or a subset) — no regressions in the chain E2E suites