### PR TITLE
feat(preorder): post-sale NFT minting via the batcher (EVM + Cardano)

### DIFF
--- a/templates/preorder/bun.lock
+++ b/templates/preorder/bun.lock
@@ -21,6 +21,16 @@
         "vite-plugin-wasm": "^3.6.0",
       },
     },
+    "packages/batcher": {
+      "name": "@preorder/batcher",
+      "version": "1.0.0",
+      "dependencies": {
+        "@effectstream/batcher-sdk": "0.100.14",
+        "@preorder/contracts-cardano": "workspace:*",
+        "effection": "^3.5.0",
+        "viem": "^2.37.0",
+      },
+    },
     "packages/contracts-cardano": {
       "name": "@preorder/contracts-cardano",
       "version": "1.0.0",
@@ -251,6 +261,8 @@
 
     "@effect/schema": ["@effect/schema@0.66.16", "", { "peerDependencies": { "effect": "^3.1.3", "fast-check": "^3.13.2" } }, "sha512-sT/k5NOgKslGPzs3DUaCFuM6g2JQoIIT8jpwEorAZooplPIMK2xIspr7ECz6pp6Dc7Wz/ppXGk7HVyGZQsIYEQ=="],
 
+    "@effectstream/batcher-sdk": ["@effectstream/batcher-sdk@0.100.14", "", { "dependencies": { "@effectstream/crypto": "0.100.14", "@effectstream/event-client": "0.100.14", "@effectstream/midnight-contracts": "0.100.14", "@effectstream/utils": "0.100.14", "@fastify/cors": "^11.0.1", "@fastify/swagger": "^9.5.1", "@fastify/swagger-ui": "^5.2.3", "@midnight-ntwrk/compact-js": "2.5.0", "@midnight-ntwrk/compact-runtime": "0.15.0", "@midnight-ntwrk/ledger-v8": "8.0.3", "@midnight-ntwrk/midnight-js-contracts": "4.0.2", "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.0.2", "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.0.2", "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.0.2", "@midnight-ntwrk/midnight-js-network-id": "4.0.2", "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.0.2", "@midnight-ntwrk/midnight-js-types": "4.0.2", "@midnight-ntwrk/midnight-js-utils": "4.0.2", "@midnight-ntwrk/onchain-runtime-v3": "3.0.0", "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0", "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0", "@midnight-ntwrk/wallet-sdk-dust-wallet": "3.0.0", "@midnight-ntwrk/wallet-sdk-facade": "3.0.0", "@midnight-ntwrk/wallet-sdk-hd": "3.0.1", "@midnight-ntwrk/wallet-sdk-shielded": "2.1.0", "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.1.0", "@midnight-ntwrk/zswap": "4.0.0", "@noble/hashes": "^2.2.0", "@noble/secp256k1": "^3.1.0", "@sinclair/typebox": "0.34.41", "bitcoinjs-lib": "^6.1.5", "ecpair": "^2.1.0", "effection": "^3.5.0", "fastify": "^5.4.0", "rxjs": "7.8.2", "tiny-secp256k1": "^2.2.1", "viem": "^2.21.3" } }, "sha512-4U9sIEKQJ71OYJnkYNfhwH2UwiePSCZnugRlZFlb161+fYJ+JWVuHKemnrTcrvCBfyR5CUZmMHS3M76Rf+T8Jg=="],
+
     "@effectstream/concise": ["@effectstream/concise@0.100.14", "", { "dependencies": { "@effectstream/crypto": "0.100.14", "@effectstream/utils": "0.100.14", "@sinclair/typebox": "0.34.41", "js-sha3": "^0.9.3", "viem": "2.37.3" } }, "sha512-OKpDhE4tIufE+a7F+tb+o5DyRGwrpLJB3PYcQutWmCLyHve3tjrwWQufVKrtvO5rNXcuk04TW5nYcRQaYfAa7g=="],
 
     "@effectstream/config": ["@effectstream/config@0.100.14", "", { "dependencies": { "@dcspark/carp-client": "^3.3.0", "@dcspark/cip34-js": "3.0.1", "@effectstream/utils": "0.100.14", "@midnight-ntwrk/onchain-runtime": "npm:@midnight-ntwrk/onchain-runtime-v2@2.0.0", "@sinclair/typebox": "0.34.41", "@utxorpc/spec": "^0.18.1", "abitype": "1.1.0", "assert-never": "^1.4.0", "buffer": "^6.0.3", "effection": "^3.5.0", "viem": "2.37.3" } }, "sha512-shlrKIWTbDF+CZ+Wn+YT0OMBjdd1i2PNam0lT7nugw2LQhknecznORxGKqxqRbWYuDlbrMTo6Uer/U6FWYMNHw=="],
@@ -272,6 +284,8 @@
     "@effectstream/explorer": ["@effectstream/explorer@0.3.99", "", { "dependencies": { "http-server": "^14.1.1" }, "bin": { "explorer": "cli.cjs" } }, "sha512-vFRToz5oqM9LWEnWR10pAkNCc5dssSDeHmdY9iV8h1tedor+y8/NjY9TCyXay88zdNYWdjEXuRtnNd7xFJYX9Q=="],
 
     "@effectstream/log": ["@effectstream/log@0.100.14", "", { "dependencies": { "@effectstream/utils": "0.100.14", "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "0.56.0", "@opentelemetry/exporter-logs-otlp-http": "0.56.0", "@opentelemetry/exporter-metrics-otlp-http": "0.56.0", "@opentelemetry/exporter-trace-otlp-http": "0.56.0", "@opentelemetry/resources": "1.29.0", "@opentelemetry/sdk-logs": "0.56.0", "@opentelemetry/sdk-metrics": "1.29.0", "@opentelemetry/sdk-trace-base": "1.29.0", "@opentelemetry/semantic-conventions": "1.28.0", "chalk": "5.4.1", "effection": "3.5.0", "material-chalk": "1.1.1", "superjson": "^2.2.1", "tslog": "^4.9.3" } }, "sha512-4MVDAK68a0LmUsnzGz8fGHD8sKzWX1PB1/TJFI7yiLWuJCW6o1jXiZtfzqSF6ON1N9Um4js49Tqsu0sj5TGnRg=="],
+
+    "@effectstream/midnight-contracts": ["@effectstream/midnight-contracts@0.100.14", "", { "dependencies": { "@effectstream/utils": "0.100.14", "@midnight-ntwrk/compact-js": "2.5.0", "@midnight-ntwrk/ledger": "4.0.0", "@midnight-ntwrk/ledger-v8": "8.0.3", "@midnight-ntwrk/midnight-js-contracts": "4.0.2", "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.0.2", "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.0.2", "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.0.2", "@midnight-ntwrk/midnight-js-network-id": "4.0.2", "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.0.2", "@midnight-ntwrk/midnight-js-types": "4.0.2", "@midnight-ntwrk/midnight-js-utils": "4.0.2", "@midnight-ntwrk/onchain-runtime-v3": "3.0.0", "@midnight-ntwrk/wallet": "5.0.0", "@midnight-ntwrk/wallet-api": "5.0.0", "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0", "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0", "@midnight-ntwrk/wallet-sdk-capabilities": "3.2.0", "@midnight-ntwrk/wallet-sdk-dust-wallet": "3.0.0", "@midnight-ntwrk/wallet-sdk-facade": "3.0.0", "@midnight-ntwrk/wallet-sdk-hd": "3.0.1", "@midnight-ntwrk/wallet-sdk-shielded": "2.1.0", "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.1.0", "@midnight-ntwrk/zswap": "4.0.0", "@scure/bip39": "^2.0.1", "dotenv": "^16.4.7", "rxjs": "^7.8.2" } }, "sha512-n/CC/FSThaQlqCeNhLOFwg2BsYR7gJXXF+kiX1P0JmXeCWwfMB4xU9UNqXWFG/AMP+Aift/5kTDSgxC1/laJrw=="],
 
     "@effectstream/orchestrator": ["@effectstream/orchestrator@0.100.14", "", { "dependencies": { "@effectstream/db": "0.100.14" }, "bin": { "orchestrator": "src/cli.ts" } }, "sha512-DSqUywLYhUqijgqdYsXn7u6WsxLoZh7O9AQP/ebRlkMlertOMsZ04G/Q9zOnWeuFFjfM3FAtGARaVvntivFmZA=="],
 
@@ -507,11 +521,21 @@
 
     "@midnight-ntwrk/compact-runtime": ["@midnight-ntwrk/compact-runtime@0.15.0", "", { "dependencies": { "@midnight-ntwrk/onchain-runtime-v3": "^3.0.0", "@types/object-inspect": "^1.8.1", "object-inspect": "^1.12.3" } }, "sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A=="],
 
+    "@midnight-ntwrk/ledger": ["@midnight-ntwrk/ledger@4.0.0", "", {}, "sha512-cnJisY8uQ4NO54miDnjs/ov6n102ZPfKEPxtiDKVEdlKijcc70jz/CI2yBCc0itlwwaqma7FM2Ou5N4pWpbwbg=="],
+
     "@midnight-ntwrk/ledger-v8": ["@midnight-ntwrk/ledger-v8@8.1.0", "", {}, "sha512-rwOVP5kBwACpYmmY6+oLeaiM3e5gHscRMjbZUOntOC5QdtqLdpeep6eQW1OngI+sxjjdVoGg2eE16sLf+DAHmQ=="],
+
+    "@midnight-ntwrk/midnight-js-contracts": ["@midnight-ntwrk/midnight-js-contracts@4.0.2", "", { "dependencies": { "@midnight-ntwrk/compact-js": "2.5.0", "@midnight-ntwrk/midnight-js-network-id": "4.0.2", "@midnight-ntwrk/midnight-js-types": "4.0.2", "@midnight-ntwrk/midnight-js-utils": "4.0.2" } }, "sha512-mzUmelrhWEKR+f0uThgQb6IfQK+9LzOlWXlh74LjwuqDAIQgAuZZIXLuC1U58uYCTXVdmkJlmtQdORzXphJKOg=="],
+
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": ["@midnight-ntwrk/midnight-js-http-client-proof-provider@4.0.2", "", { "dependencies": { "@midnight-ntwrk/midnight-js-contracts": "4.0.2", "@midnight-ntwrk/midnight-js-network-id": "4.0.2", "@midnight-ntwrk/midnight-js-types": "4.0.2", "@midnight-ntwrk/midnight-js-utils": "4.0.2", "cross-fetch": "^4.1.0", "fetch-retry": "^6.0.0", "lodash": "^4.17.23" } }, "sha512-TeqP4SDEqWsJCGn25C2+eJZ3/X5rZ1TNxi9c68eYu5wzjgUJKsdzMA0u3PreyUinQ5iCixhSUpuiKKmeB+LAjA=="],
 
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider": ["@midnight-ntwrk/midnight-js-indexer-public-data-provider@4.0.2", "", { "dependencies": { "@apollo/client": "^3.13.8", "@midnight-ntwrk/midnight-js-network-id": "4.0.2", "@midnight-ntwrk/midnight-js-types": "4.0.2", "@midnight-ntwrk/midnight-js-utils": "4.0.2", "buffer": "^6.0.3", "cross-fetch": "^4.1.0", "graphql": "^16.8.0", "graphql-ws": "^6.0.7", "isomorphic-ws": "^5.0.0", "rxjs": "^7.5.0", "ws": "^8.14.2", "zen-observable-ts": "^1.1.0" } }, "sha512-eFQ2BXlIACigA2AApB7vsngIwKGpJil4crmSKv7YY7ZZPr8WsxaehMB5iIwvMfYmABiQ8IWI01IjDRfM3R4EIQ=="],
 
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": ["@midnight-ntwrk/midnight-js-level-private-state-provider@4.0.2", "", { "dependencies": { "@midnight-ntwrk/midnight-js-types": "4.0.2", "abstract-level": "^3.0.0", "buffer": "^6.0.3", "fp-ts": "^2.16.1", "io-ts": "^2.2.20", "level": "^10.0.0", "superjson": "^2.0.0" } }, "sha512-V6XB67gxLHPgJOyL6k7MFbyh+xLbPhPO0IBus1lGQ/mJHSoxdUEOb/maZTgWzZLPYVj2NW2IxrdquOhk/mACsg=="],
+
     "@midnight-ntwrk/midnight-js-network-id": ["@midnight-ntwrk/midnight-js-network-id@4.0.2", "", {}, "sha512-6XYxm267tZ6ckgMxp337QJkycxX9XqZT+3HdQGvR24Z/K7XLV9sR6Qyv2aPKquEk7nn0JhF4yKbiODw6VjfbuA=="],
+
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": ["@midnight-ntwrk/midnight-js-node-zk-config-provider@4.0.2", "", { "dependencies": { "@midnight-ntwrk/midnight-js-types": "4.0.2" } }, "sha512-P1BmmKBYlQkpJGmgRjUpSGyt53aWzpuB2Rn1sK1zPUrvRD6hUiOmv4K5L+PV3tRQasi1GjUFj4y/qI9S17pcTw=="],
 
     "@midnight-ntwrk/midnight-js-types": ["@midnight-ntwrk/midnight-js-types@4.0.2", "", { "dependencies": { "@midnight-ntwrk/compact-js": "2.5.0", "@midnight-ntwrk/platform-js": "2.2.4", "rxjs": "^7.5.0" } }, "sha512-I8ztUcKvGy6n7gLGx45rTM+3D9v+UgZNoPLoIKNLn4R15a676TbJ+Xu28GLdUkmkypR7qmxyYCY4FDr5oBb3Pg=="],
 
@@ -523,7 +547,39 @@
 
     "@midnight-ntwrk/platform-js": ["@midnight-ntwrk/platform-js@2.2.4", "", { "dependencies": { "@effect/platform": "^0.95.0", "effect": "^3.20.0", "tslib": "^2.8.1" } }, "sha512-6mrYKSSE8kPgn/5rQ2xofDJk1yAZZRdLOO6Yelweuh5GOnOGz7Qw4venDG/c4TRqtV9ouFp+F5j7ta8aprMinw=="],
 
+    "@midnight-ntwrk/wallet": ["@midnight-ntwrk/wallet@5.0.0", "", { "dependencies": { "@midnight-ntwrk/wallet-api": "^5.0.0", "@midnight-ntwrk/wallet-sdk-address-format": "^2.0.0", "@midnight-ntwrk/wallet-sdk-capabilities": "^2.0.0", "@midnight-ntwrk/zswap": "4.0.0", "isomorphic-ws": "^5.0.0", "node-fetch": "3.3.2", "rxjs": "^7.5", "scale-ts": "^1.1.0", "ws": "^8.8.1" } }, "sha512-30NjR0w4lOtFrJmwrV0MiFg6QtoKLmCd3e0vy5RxKOvdE8Au6N7O9jiEyZc13c2pk4Pj9ShKL8qukybQhhCuTQ=="],
+
+    "@midnight-ntwrk/wallet-api": ["@midnight-ntwrk/wallet-api@5.0.0", "", { "dependencies": { "@midnight-ntwrk/zswap": "^4.0.0" }, "peerDependencies": { "rxjs": "7.x" } }, "sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-abstractions": ["@midnight-ntwrk/wallet-sdk-abstractions@2.0.0", "", { "dependencies": { "effect": "^3.19.19" } }, "sha512-urmdK+lpw/gmX3mKjN3p9rVUn6Ba3TyHVEYN5oAXc0na4NkHsvvhgxcn9t4Oh9FYoYWuUA0xDiiLJsAkO05b/A=="],
+
     "@midnight-ntwrk/wallet-sdk-address-format": ["@midnight-ntwrk/wallet-sdk-address-format@3.1.0", "", { "dependencies": { "@midnight-ntwrk/ledger-v8": "^8.0.2", "@scure/base": "^2.0.0", "@subsquid/scale-codec": "^4.0.1" } }, "sha512-X/MQnbyQQ1SoFVJrxhczkHza1SMJghp3Eo49nXXnHZw2qKUUmpiNa8Hx3MYFq36NXi3m3gsMH7rW0bilMFvdhw=="],
+
+    "@midnight-ntwrk/wallet-sdk-capabilities": ["@midnight-ntwrk/wallet-sdk-capabilities@3.2.0", "", { "dependencies": { "@midnight-ntwrk/ledger-v8": "^8.0.2", "@midnight-ntwrk/wallet-sdk-abstractions": "^2.0.0", "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.0", "@midnight-ntwrk/wallet-sdk-node-client": "^1.1.0", "@midnight-ntwrk/wallet-sdk-prover-client": "^1.2.0", "@midnight-ntwrk/wallet-sdk-utilities": "^1.1.0", "@midnight-ntwrk/zkir-v2": "^2.1.0", "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-3S06DbFJ/I+2Zn30jG98a9T3xPxtBwRjm4fCiYnsn8CEcNgH8XINhVimpItWLakeCAviGRA2x7M93phk9u7hbw=="],
+
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": ["@midnight-ntwrk/wallet-sdk-dust-wallet@3.0.0", "", { "dependencies": { "@midnight-ntwrk/ledger-v8": "^8.0.2", "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0", "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0", "@midnight-ntwrk/wallet-sdk-capabilities": "3.2.0", "@midnight-ntwrk/wallet-sdk-indexer-client": "1.2.0", "@midnight-ntwrk/wallet-sdk-runtime": "1.0.2", "@midnight-ntwrk/wallet-sdk-utilities": "1.1.0", "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-7xkaOyPby5uVPfZ16X06xj0Jct5oDjpzXCsTYb7JFYK0v3zaEoWeyQUI1O/3J8/EJBRIlQwCpKNnQWMBPvsOlA=="],
+
+    "@midnight-ntwrk/wallet-sdk-facade": ["@midnight-ntwrk/wallet-sdk-facade@3.0.0", "", { "dependencies": { "@midnight-ntwrk/ledger-v8": "^8.0.2", "@midnight-ntwrk/wallet-sdk-address-format": "^3.1.0", "@midnight-ntwrk/wallet-sdk-capabilities": "^3.2.0", "@midnight-ntwrk/wallet-sdk-dust-wallet": "^3.0.0", "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.2.0", "@midnight-ntwrk/wallet-sdk-shielded": "^2.1.0", "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^2.1.0", "rxjs": "^7.8.2" } }, "sha512-UrMHh0JI5eBKI6NcyWQ8r90CLAMF3cxnGWvChEpdTGYVQmK6LleBkXsFvfDJhORMjd+RB1aOt+oG5bEpY1o/9g=="],
+
+    "@midnight-ntwrk/wallet-sdk-hd": ["@midnight-ntwrk/wallet-sdk-hd@3.0.1", "", { "dependencies": { "@scure/bip32": "^2.0.1", "@scure/bip39": "^2.0.1" } }, "sha512-N2s4fPQofIHL9r+Wt4qvWGHQoBFjIO7pZhOALfKuAZEaDUZdwbwrw8NnfA4vKklfhEZ5wWrIBUeFgKFI9qD6hw=="],
+
+    "@midnight-ntwrk/wallet-sdk-indexer-client": ["@midnight-ntwrk/wallet-sdk-indexer-client@1.2.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@midnight-ntwrk/wallet-sdk-utilities": "1.1.0", "effect": "^3.19.19", "graphql": "^16.13.0", "graphql-http": "^1.22.4", "graphql-ws": "^6.0.7" } }, "sha512-VzwJ0LTBcUWqr5H4a56DhT6zpLYLjg/H6vRrwKYEz3EhQTKLGnQ7d2PKS0Z0QcKGEXOHzeeSmI41FsvG4FbTAQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client": ["@midnight-ntwrk/wallet-sdk-node-client@1.1.2", "", { "dependencies": { "@midnight-ntwrk/wallet-sdk-abstractions": "^2.1.0", "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0", "@polkadot/api": "^16.5.4", "@polkadot/types": "^16.5.4", "@polkadot/util": "^14.0.1", "@types/bn.js": "^5.2.0", "bn.js": "^5.2.3", "effect": "^3.19.19" } }, "sha512-nV6lg1M0QQOGss9JiofwO3+bcI+kQIoGV36F+KwyDMgUjAH2nT2/m3SbhLDGizwvJwgniWMuZQV6k/YZ7nCcWA=="],
+
+    "@midnight-ntwrk/wallet-sdk-prover-client": ["@midnight-ntwrk/wallet-sdk-prover-client@1.2.2", "", { "dependencies": { "@effect/platform": "^0.96.0", "@midnight-ntwrk/ledger-v8": "^8.1.0", "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0", "@midnight-ntwrk/zkir-v2": "^2.1.0", "effect": "^3.19.19", "web-worker": "^1.5.0" } }, "sha512-Xbniz3S/ab1uxiEJd3OaBxLkDfygPIAWgNZfApwAeac/U8yUVUjrqJ9aWyruztMY2MZHN7QxUjlcAWDK84hX3A=="],
+
+    "@midnight-ntwrk/wallet-sdk-runtime": ["@midnight-ntwrk/wallet-sdk-runtime@1.0.2", "", { "dependencies": { "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0", "@midnight-ntwrk/wallet-sdk-utilities": "1.1.0", "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-AcDNF2TsH8U/2twe/pYPAEyal9mOCr9TUkViODoaNzeoRSz2HPTO81wGEfD89t5Lf+GS8xkaT2ju3Il30goOtg=="],
+
+    "@midnight-ntwrk/wallet-sdk-shielded": ["@midnight-ntwrk/wallet-sdk-shielded@2.1.0", "", { "dependencies": { "@midnight-ntwrk/ledger-v8": "^8.0.2", "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0", "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0", "@midnight-ntwrk/wallet-sdk-capabilities": "3.2.0", "@midnight-ntwrk/wallet-sdk-indexer-client": "1.2.0", "@midnight-ntwrk/wallet-sdk-runtime": "1.0.2", "@midnight-ntwrk/wallet-sdk-utilities": "1.1.0", "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-Qy0jeBqFso0hc2clpv5GAqscKS2b/1JBqjBhJzamsiqaCbZauaD+CbhaxGdpyc0s+WBDBuc7UnkbVDVQadWG0g=="],
+
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": ["@midnight-ntwrk/wallet-sdk-unshielded-wallet@2.1.0", "", { "dependencies": { "@midnight-ntwrk/ledger-v8": "^8.0.2", "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0", "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0", "@midnight-ntwrk/wallet-sdk-capabilities": "3.2.0", "@midnight-ntwrk/wallet-sdk-indexer-client": "1.2.0", "@midnight-ntwrk/wallet-sdk-runtime": "1.0.2", "@midnight-ntwrk/wallet-sdk-utilities": "1.1.0", "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-d+IZLTAQ0rJzqvJraaixcFOg+AgDX/D/g+EAjTTrsaB+RCfU/E2jD8iWPIPl0NnG239p9uB0PuPcxbpGHlefNg=="],
+
+    "@midnight-ntwrk/wallet-sdk-utilities": ["@midnight-ntwrk/wallet-sdk-utilities@1.1.0", "", { "dependencies": { "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-iTxP+VKPGtjhZWVY4AmliYf1WYwRVaPJsvdub7/BZYXg7gOoH9H3DsXGY64aPYwA3ZXuUm/Cjiy0Ak6CnkB5XQ=="],
+
+    "@midnight-ntwrk/zkir-v2": ["@midnight-ntwrk/zkir-v2@2.1.0", "", {}, "sha512-UDMujjzCt0SA89uqOFWUL4LZTkxVAS8JjvOaYMAgxlSrWfN7m5th1R1qGlpDJuSH39rbWt6WwtuK3k08Mta6LA=="],
+
+    "@midnight-ntwrk/zswap": ["@midnight-ntwrk/zswap@4.0.0", "", {}, "sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -584,6 +640,8 @@
     "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@noble/secp256k1": ["@noble/secp256k1@3.1.0", "", {}, "sha512-+F7iS7tUMaNGXcc9X3PjmjvuQnXEuSjCRNzVVA2xAcKXgCaP0dHYz4SFyt4FKNHef7sOP//xihowcySSS7PK9g=="],
 
     "@nomicfoundation/edr": ["@nomicfoundation/edr@0.12.0-next.5", "", { "optionalDependencies": { "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.5", "@nomicfoundation/edr-darwin-x64": "0.12.0-next.5", "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.5", "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.5", "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.5", "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.5", "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.5" } }, "sha512-VhjH0OyKGtWqGeOMGICGsj2l0+7SyQWXp00wuY0hkG+vt1XH2G404L0CK9+qWEPcoZu9/LFcVGVs+Bb1XWvDPA=="],
 
@@ -831,7 +889,7 @@
 
     "@polkadot/rpc-provider": ["@polkadot/rpc-provider@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types": "15.10.2", "@polkadot/types-support": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "@polkadot/x-fetch": "^13.4.4", "@polkadot/x-global": "^13.4.4", "@polkadot/x-ws": "^13.4.4", "eventemitter3": "^5.0.1", "mock-socket": "^9.3.1", "nock": "^13.5.5", "tslib": "^2.8.1" }, "optionalDependencies": { "@substrate/connect": "0.8.11" } }, "sha512-kqpPW8U0stVW+uOZP8g5d87Xb8rbXJR5PUub6xgGG6AOMbbvvuCU3GSohu/iozo4p9uD7TGH90jvbxj1rjJVMA=="],
 
-    "@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+    "@polkadot/types": ["@polkadot/types@16.5.6", "", { "dependencies": { "@polkadot/keyring": "^14.0.3", "@polkadot/types-augment": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/types-create": "16.5.6", "@polkadot/util": "^14.0.3", "@polkadot/util-crypto": "^14.0.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw=="],
 
     "@polkadot/types-augment": ["@polkadot/types-augment@15.10.2", "", { "dependencies": { "@polkadot/types": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/util": "^13.4.4", "tslib": "^2.8.1" } }, "sha512-X/xh+Dzud6OIyr7q8xttAwn+Fb5hKImIWEO1oG8WcInqv+P0vRyu7Tds+2ut9t64sJi3ydJ7I+T+WxZYheCU7g=="],
 
@@ -872,6 +930,8 @@
     "@polkadot/x-textencoder": ["@polkadot/x-textencoder@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q=="],
 
     "@polkadot/x-ws": ["@polkadot/x-ws@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0", "ws": "^8.18.0" } }, "sha512-NKVgvACTIvKT8CjaQu9d0dERkZsWIZngX/4NVSjc01WHmln4F4y/zyBdYn/Z2V0Zw28cISx+lB4qxRmqTe7gbg=="],
+
+    "@preorder/batcher": ["@preorder/batcher@workspace:packages/batcher"],
 
     "@preorder/contracts-cardano": ["@preorder/contracts-cardano@workspace:packages/contracts-cardano"],
 
@@ -966,6 +1026,8 @@
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
     "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
+    "@scure/sr25519": ["@scure/sr25519@0.2.0", "", { "dependencies": { "@noble/curves": "~1.9.2", "@noble/hashes": "~1.8.0" } }, "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg=="],
 
     "@sentry/core": ["@sentry/core@9.47.1", "", {}, "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw=="],
 
@@ -1093,6 +1155,8 @@
 
     "abort-error": ["abort-error@1.0.2", "", {}, "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w=="],
 
+    "abstract-level": ["abstract-level@3.1.1", "", { "dependencies": { "buffer": "^6.0.3", "is-buffer": "^2.0.5", "level-supports": "^6.2.0", "level-transcoder": "^1.0.1", "maybe-combine-errors": "^1.0.0", "module-error": "^1.0.1" } }, "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw=="],
+
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -1157,7 +1221,11 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "bip174": ["bip174@2.1.1", "", {}, "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ=="],
+
     "bip39": ["bip39@3.1.0", "", { "dependencies": { "@noble/hashes": "^1.2.0" } }, "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A=="],
+
+    "bitcoinjs-lib": ["bitcoinjs-lib@6.1.7", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bech32": "^2.0.0", "bip174": "^2.1.1", "bs58check": "^3.0.1", "typeforce": "^1.11.3", "varuint-bitcoin": "^1.1.2" } }, "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg=="],
 
     "bl": ["bl@6.1.6", "", { "dependencies": { "@types/readable-stream": "^4.0.0", "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^4.2.0" } }, "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg=="],
 
@@ -1174,6 +1242,8 @@
     "broker-factory": ["broker-factory@3.1.14", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1", "worker-factory": "^7.0.49" } }, "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ=="],
 
     "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
+
+    "browser-level": ["browser-level@3.0.0", "", { "dependencies": { "abstract-level": "^3.1.0" } }, "sha512-kGXtLh29jMwqKaskz5xeDLtCtN1KBz/DbQSqmvH7QdJiyGRC7RAM8PPg6gvUiNMa+wVnaxS9eSmEtP/f5ajOVw=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -1217,6 +1287,8 @@
 
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
+    "classic-level": ["classic-level@3.0.0", "", { "dependencies": { "abstract-level": "^3.1.0", "module-error": "^1.0.1", "napi-macros": "^2.2.2", "node-gyp-build": "^4.3.0" } }, "sha512-yGy8j8LjPbN0Bh3+ygmyYvrmskVita92pD/zCoalfcC9XxZj6iDtZTAnz+ot7GG8p9KLTG+MZ84tSA4AhkgVZQ=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
@@ -1253,7 +1325,7 @@
 
     "create-hmac": ["create-hmac@1.1.7", "", { "dependencies": { "cipher-base": "^1.0.3", "create-hash": "^1.1.0", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "safe-buffer": "^5.0.1", "sha.js": "^2.4.8" } }, "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg=="],
 
-    "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
+    "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1288,6 +1360,8 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
+
+    "ecpair": ["ecpair@2.1.0", "", { "dependencies": { "randombytes": "^2.1.0", "typeforce": "^1.18.0", "wif": "^2.0.6" } }, "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw=="],
 
     "effect": ["effect@3.21.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg=="],
 
@@ -1361,6 +1435,8 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
+    "fetch-retry": ["fetch-retry@6.0.0", "", {}, "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag=="],
+
     "find-my-way": ["find-my-way@9.6.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
@@ -1410,6 +1486,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphql": ["graphql@16.14.0", "", {}, "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q=="],
+
+    "graphql-http": ["graphql-http@1.22.4", "", { "peerDependencies": { "graphql": ">=0.11 <=16" } }, "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA=="],
 
     "graphql-tag": ["graphql-tag@2.12.6", "", { "dependencies": { "tslib": "^2.1.0" }, "peerDependencies": { "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0" } }, "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg=="],
 
@@ -1475,6 +1553,8 @@
 
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
+    "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
+
     "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
 
     "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
@@ -1497,7 +1577,7 @@
 
     "iso-url": ["iso-url@1.2.1", "", {}, "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="],
 
-    "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
+    "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
 
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
@@ -1547,6 +1627,12 @@
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
+    "level": ["level@10.0.0", "", { "dependencies": { "abstract-level": "^3.1.0", "browser-level": "^3.0.0", "classic-level": "^3.0.0" } }, "sha512-aZJvdfRr/f0VBbSRF5C81FHON47ZsC2TkGxbBezXpGGXAUEL/s6+GP73nnhAYRSCIqUNsmJjfeOF4lzRDKbUig=="],
+
+    "level-supports": ["level-supports@6.2.0", "", {}, "sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w=="],
+
+    "level-transcoder": ["level-transcoder@1.0.1", "", { "dependencies": { "buffer": "^6.0.3", "module-error": "^1.0.1" } }, "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w=="],
+
     "libsodium-sumo": ["libsodium-sumo@0.7.16", "", {}, "sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA=="],
 
     "libsodium-wrappers-sumo": ["libsodium-wrappers-sumo@0.7.16", "", { "dependencies": { "libsodium-sumo": "^0.7.16" } }, "sha512-gR0JEFPeN3831lB9+ogooQk0KH4K5LSMIO5Prd5Q5XYR2wHFtZfPg0eP7t1oJIWq+UIzlU4WVeBxZ97mt28tXw=="],
@@ -1572,6 +1658,8 @@
     "material-chalk": ["material-chalk@1.1.1", "", { "dependencies": { "@material/material-color-utilities": "^0.3.0" }, "peerDependencies": { "chalk": "^5.3.0" }, "optionalPeers": ["chalk"] }, "sha512-GDO/69mS1vLQfX9T4THPCJb1vu0renYxfn4rtYDzldrKsXuXSZOin5VZTTlO5U4dDMRnXqPp0WdY320v6iwcdw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "maybe-combine-errors": ["maybe-combine-errors@1.0.0", "", {}, "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A=="],
 
     "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
 
@@ -1603,6 +1691,8 @@
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
+    "module-error": ["module-error@1.0.2", "", {}, "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="],
+
     "mongodb-uri": ["mongodb-uri@0.9.7", "", {}, "sha512-s6BdnqNoEYfViPJgkH85X5Nw5NpzxN8hoflKLweNa7vBxt2V7kaS06d74pAtqDxde8fn4r9h4dNdLiFGoNV0KA=="],
 
     "mqtt": ["mqtt@5.15.1", "", { "dependencies": { "@types/readable-stream": "^4.0.21", "@types/ws": "^8.18.1", "commist": "^3.2.0", "concat-stream": "^2.0.0", "debug": "^4.4.1", "help-me": "^5.0.0", "lru-cache": "^10.4.3", "minimist": "^1.2.8", "mqtt-packet": "^9.0.2", "number-allocator": "^1.0.14", "readable-stream": "^4.7.0", "rfdc": "^1.4.1", "socks": "^2.8.6", "split2": "^4.2.0", "worker-timers": "^8.0.23", "ws": "^8.18.3" }, "bin": { "mqtt_pub": "build/bin/pub.js", "mqtt_sub": "build/bin/sub.js", "mqtt": "build/bin/mqtt.js" } }, "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA=="],
@@ -1629,6 +1719,8 @@
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 
+    "napi-macros": ["napi-macros@2.2.2", "", {}, "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="],
+
     "ndjson": ["ndjson@2.0.0", "", { "dependencies": { "json-stringify-safe": "^5.0.1", "minimist": "^1.2.5", "readable-stream": "^3.6.0", "split2": "^3.0.0", "through2": "^4.0.0" }, "bin": { "ndjson": "cli.js" } }, "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ=="],
 
     "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
@@ -1639,7 +1731,9 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
 
@@ -1771,6 +1865,8 @@
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
     "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
 
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
@@ -1897,6 +1993,8 @@
 
     "through2": ["through2@4.0.2", "", { "dependencies": { "readable-stream": "3" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
 
+    "tiny-secp256k1": ["tiny-secp256k1@2.2.4", "", { "dependencies": { "uint8array-tools": "0.0.7" } }, "sha512-FoDTcToPqZE454Q04hH9o2EhxWsm7pOSpicyHkgTwKhdKWdsTUuqfP5MLq3g+VjAtl2vSx6JpXGdwA2qpYkI0Q=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
@@ -1935,9 +2033,13 @@
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
+    "typeforce": ["typeforce@1.18.0", "", {}, "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8-varint": ["uint8-varint@2.0.5", "", { "dependencies": { "uint8arraylist": "^2.0.0", "uint8arrays": "^5.0.0" } }, "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA=="],
+
+    "uint8array-tools": ["uint8array-tools@0.0.7", "", {}, "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ=="],
 
     "uint8arraylist": ["uint8arraylist@2.4.9", "", { "dependencies": { "uint8arrays": "^5.0.1" } }, "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA=="],
 
@@ -1963,6 +2065,8 @@
 
     "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
+    "varuint-bitcoin": ["varuint-bitcoin@1.1.2", "", { "dependencies": { "safe-buffer": "^5.1.1" } }, "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw=="],
+
     "viem": ["viem@2.49.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-nZQTExZDZfxdz2NZnl70t41Mb4/jENt3AkVsVcHO18Jkgcg1VytEpWxLkqp7OC1vW8a4h3CYZPfwnAq/E+gf4A=="],
 
     "vite": ["vite@7.1.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw=="],
@@ -1978,6 +2082,8 @@
     "web-encoding": ["web-encoding@1.1.5", "", { "dependencies": { "util": "^0.12.3" }, "optionalDependencies": { "@zxing/text-encoding": "0.9.0" } }, "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
     "web3-errors": ["web3-errors@1.3.1", "", { "dependencies": { "web3-types": "^1.10.0" } }, "sha512-w3NMJujH+ZSW4ltIZZKtdbkbyQEvBzyp3JRn59Ckli0Nz4VMsVq8aF1bLWM7A2kuQ+yVEm3ySeNU+7mSRwx7RQ=="],
 
@@ -1996,6 +2102,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "wif": ["wif@2.0.6", "", { "dependencies": { "bs58check": "<3.0.0" } }, "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ=="],
 
     "worker-factory": ["worker-factory@7.0.49", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1" } }, "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw=="],
 
@@ -2037,6 +2145,10 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@cardano-ogmios/client/cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
+
+    "@cardano-ogmios/client/isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
+
     "@cardano-ogmios/client/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@cardano-sdk/core/@foxglove/crc": ["@foxglove/crc@0.0.3", "", {}, "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA=="],
@@ -2046,6 +2158,10 @@
     "@connectrpc/connect-node/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "@dcspark/carp-client/axios": ["axios@0.27.2", "", { "dependencies": { "follow-redirects": "^1.14.9", "form-data": "^4.0.0" } }, "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ=="],
+
+    "@effectstream/batcher-sdk/@midnight-ntwrk/ledger-v8": ["@midnight-ntwrk/ledger-v8@8.0.3", "", {}, "sha512-2BLMfHnZyKAHZxaGWjlenhity096lZ9jvyp1qrQH5J3ogpy7H5ostCW8kRj70dGv5T55qDAC5nJ+wnU/8CGUcQ=="],
+
+    "@effectstream/batcher-sdk/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@effectstream/concise/viem": ["viem@2.37.3", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.3", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-hwoZqkFSy13GCFzIftgfIH8hNENvdlcHIvtLt73w91tL6rKmZjQisXWTahi1Vn5of8/JQ1FBKfwUus3YkDXwbw=="],
 
@@ -2060,6 +2176,10 @@
     "@effectstream/event-client/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
     "@effectstream/log/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
+
+    "@effectstream/midnight-contracts/@midnight-ntwrk/ledger-v8": ["@midnight-ntwrk/ledger-v8@8.0.3", "", {}, "sha512-2BLMfHnZyKAHZxaGWjlenhity096lZ9jvyp1qrQH5J3ogpy7H5ostCW8kRj70dGv5T55qDAC5nJ+wnU/8CGUcQ=="],
+
+    "@effectstream/midnight-contracts/@scure/bip39": ["@scure/bip39@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A=="],
 
     "@effectstream/runtime/pg": ["pg@8.17.2", "", { "dependencies": { "pg-connection-string": "^2.10.1", "pg-pool": "^3.11.0", "pg-protocol": "^1.11.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw=="],
 
@@ -2113,13 +2233,35 @@
 
     "@midnight-ntwrk/compact-js/@effect/platform": ["@effect/platform@0.95.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.20.0" } }, "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA=="],
 
-    "@midnight-ntwrk/midnight-js-indexer-public-data-provider/cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
-
-    "@midnight-ntwrk/midnight-js-indexer-public-data-provider/isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
-
     "@midnight-ntwrk/midnight-js-indexer-public-data-provider/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "@midnight-ntwrk/platform-js/@effect/platform": ["@effect/platform@0.95.0", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.20.0" } }, "sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA=="],
+
+    "@midnight-ntwrk/wallet/@midnight-ntwrk/wallet-sdk-address-format": ["@midnight-ntwrk/wallet-sdk-address-format@2.0.0", "", { "dependencies": { "@scure/base": "^1.1.9" }, "peerDependencies": { "@midnight-ntwrk/zswap": "4.0.0" } }, "sha512-S/3uIfXXUcklYocO0UPey+15uI095CFuCyJRYgxnTmkIXrgjOn8IfSHnReHDtE6JKkvdN2EXlYVt4ufRdCMuPA=="],
+
+    "@midnight-ntwrk/wallet/@midnight-ntwrk/wallet-sdk-capabilities": ["@midnight-ntwrk/wallet-sdk-capabilities@2.0.0", "", { "peerDependencies": { "@midnight-ntwrk/zswap": "4.0.0" } }, "sha512-zl1uZwy8bMlpNfze6rRTEMZiOCKr4dYBYoIVKLPkck1vKcz3nhsjFAkNfsYtFyND/K7/7mLZBtuHxGWX4gYxXQ=="],
+
+    "@midnight-ntwrk/wallet/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "@midnight-ntwrk/wallet-sdk-capabilities/@midnight-ntwrk/wallet-sdk-indexer-client": ["@midnight-ntwrk/wallet-sdk-indexer-client@1.2.2", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0", "effect": "^3.19.19", "graphql": "^16.13.0", "graphql-http": "^1.22.4", "graphql-ws": "^6.0.7" } }, "sha512-GokfgV1lOhF1h341cuglp1VoTT/+yEDuYIbiPex29JJkFrjOXdJfCKPoROySBtyIyI65lnEBAXBT0+AOBjPzhA=="],
+
+    "@midnight-ntwrk/wallet-sdk-facade/@midnight-ntwrk/wallet-sdk-indexer-client": ["@midnight-ntwrk/wallet-sdk-indexer-client@1.2.2", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@midnight-ntwrk/wallet-sdk-utilities": "^1.2.0", "effect": "^3.19.19", "graphql": "^16.13.0", "graphql-http": "^1.22.4", "graphql-ws": "^6.0.7" } }, "sha512-GokfgV1lOhF1h341cuglp1VoTT/+yEDuYIbiPex29JJkFrjOXdJfCKPoROySBtyIyI65lnEBAXBT0+AOBjPzhA=="],
+
+    "@midnight-ntwrk/wallet-sdk-hd/@scure/bip32": ["@scure/bip32@2.2.0", "", { "dependencies": { "@noble/curves": "2.2.0", "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg=="],
+
+    "@midnight-ntwrk/wallet-sdk-hd/@scure/bip39": ["@scure/bip39@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@midnight-ntwrk/wallet-sdk-abstractions": ["@midnight-ntwrk/wallet-sdk-abstractions@2.1.0", "", { "dependencies": { "effect": "^3.19.19" } }, "sha512-mMcHFBrNxlZhurknS9J979HhrHQ0EsKdm6Kwaq7SAk/tStLOU2/sAoQzLUzzxr8Y60PcilTJdIKhaCgaydPATg=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@midnight-ntwrk/wallet-sdk-utilities": ["@midnight-ntwrk/wallet-sdk-utilities@1.2.0", "", { "dependencies": { "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api": ["@polkadot/api@16.5.6", "", { "dependencies": { "@polkadot/api-augment": "16.5.6", "@polkadot/api-base": "16.5.6", "@polkadot/api-derive": "16.5.6", "@polkadot/keyring": "^14.0.3", "@polkadot/rpc-augment": "16.5.6", "@polkadot/rpc-core": "16.5.6", "@polkadot/rpc-provider": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/types-augment": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/types-create": "16.5.6", "@polkadot/types-known": "16.5.6", "@polkadot/util": "^14.0.3", "@polkadot/util-crypto": "^14.0.3", "eventemitter3": "^5.0.1", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/util": ["@polkadot/util@14.0.3", "", { "dependencies": { "@polkadot/x-bigint": "14.0.3", "@polkadot/x-global": "14.0.3", "@polkadot/x-textdecoder": "14.0.3", "@polkadot/x-textencoder": "14.0.3", "@types/bn.js": "^5.1.6", "bn.js": "^5.2.1", "tslib": "^2.8.0" } }, "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw=="],
+
+    "@midnight-ntwrk/wallet-sdk-prover-client/@effect/platform": ["@effect/platform@0.96.1", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.2" } }, "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A=="],
+
+    "@midnight-ntwrk/wallet-sdk-prover-client/@midnight-ntwrk/wallet-sdk-utilities": ["@midnight-ntwrk/wallet-sdk-utilities@1.2.0", "", { "dependencies": { "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw=="],
 
     "@nomicfoundation/hardhat-verify/@nomicfoundation/hardhat-errors": ["@nomicfoundation/hardhat-errors@3.0.12", "", { "dependencies": { "@nomicfoundation/hardhat-utils": "^4.1.0" } }, "sha512-2viEq1D19FHWKpfB2vVeL0R6d+iZR2E5h0EhKQQMc1ukDUV2fel/7fRjlWuCOx2CFC+5mHL2saRcN8KlYsX8hg=="],
 
@@ -2141,15 +2283,45 @@
 
     "@polkadot-api/substrate-bindings/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
-    "@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+    "@polkadot/api/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
 
-    "@polkadot/x-fetch/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "@polkadot/api-augment/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/api-base/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/api-derive/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/rpc-augment/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/rpc-core/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/rpc-provider/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/types/@polkadot/keyring": ["@polkadot/keyring@14.0.3", "", { "dependencies": { "@polkadot/util": "14.0.3", "@polkadot/util-crypto": "14.0.3", "tslib": "^2.8.0" } }, "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA=="],
+
+    "@polkadot/types/@polkadot/types-augment": ["@polkadot/types-augment@16.5.6", "", { "dependencies": { "@polkadot/types": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g=="],
+
+    "@polkadot/types/@polkadot/types-codec": ["@polkadot/types-codec@16.5.6", "", { "dependencies": { "@polkadot/util": "^14.0.3", "@polkadot/x-bigint": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw=="],
+
+    "@polkadot/types/@polkadot/types-create": ["@polkadot/types-create@16.5.6", "", { "dependencies": { "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w=="],
+
+    "@polkadot/types/@polkadot/util": ["@polkadot/util@14.0.3", "", { "dependencies": { "@polkadot/x-bigint": "14.0.3", "@polkadot/x-global": "14.0.3", "@polkadot/x-textdecoder": "14.0.3", "@polkadot/x-textencoder": "14.0.3", "@types/bn.js": "^5.1.6", "bn.js": "^5.2.1", "tslib": "^2.8.0" } }, "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw=="],
+
+    "@polkadot/types/@polkadot/util-crypto": ["@polkadot/util-crypto@14.0.3", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "14.0.3", "@polkadot/util": "14.0.3", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "14.0.3", "@polkadot/x-randomvalues": "14.0.3", "@scure/base": "^1.1.7", "@scure/sr25519": "^0.2.0", "tslib": "^2.8.0" } }, "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw=="],
+
+    "@polkadot/types-augment/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/types-known/@polkadot/types": ["@polkadot/types@15.10.2", "", { "dependencies": { "@polkadot/keyring": "^13.4.4", "@polkadot/types-augment": "15.10.2", "@polkadot/types-codec": "15.10.2", "@polkadot/types-create": "15.10.2", "@polkadot/util": "^13.4.4", "@polkadot/util-crypto": "^13.4.4", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw=="],
+
+    "@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@polkadot/x-ws/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/sr25519/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@stricahq/typhonjs/@stricahq/cbors": ["@stricahq/cbors@1.0.2", "", { "dependencies": { "bignumber.js": "^9.0.2", "buffer": "^6.0.3" } }, "sha512-6ePsEiq7EGHA5IiPn9poA7sF5iXPqt30kKw3pjR/BhP7S+XHZNu/OPumESWnVl4AM+IEYC2x9eL+4qRPsTPVww=="],
 
@@ -2161,9 +2333,13 @@
 
     "basic-auth/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
+    "bitcoinjs-lib/bs58check": ["bs58check@3.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^5.0.0" } }, "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ=="],
+
     "bl/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+
+    "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
@@ -2186,6 +2362,8 @@
     "ethers/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
 
     "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "gaxios/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "hardhat/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
@@ -2661,6 +2839,10 @@
 
     "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "wif/bs58check": ["bs58check@2.1.2", "", { "dependencies": { "bs58": "^4.0.0", "create-hash": "^1.1.0", "safe-buffer": "^5.1.2" } }, "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA=="],
+
+    "@cardano-ogmios/client/cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "@effectstream/concise/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
     "@effectstream/concise/viem/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
@@ -2676,6 +2858,8 @@
     "@effectstream/crypto/viem/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
     "@effectstream/crypto/viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "@effectstream/midnight-contracts/@scure/bip39/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@effectstream/runtime/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
@@ -2714,6 +2898,72 @@
     "@libp2p/interface/@multiformats/multiaddr/uint8-varint": ["uint8-varint@3.0.0", "", { "dependencies": { "uint8arraylist": "^3.0.1", "uint8arrays": "^6.1.0" } }, "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q=="],
 
     "@libp2p/interface/@multiformats/multiaddr/uint8arrays": ["uint8arrays@6.1.1", "", { "dependencies": { "multiformats": "^14.0.0" } }, "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA=="],
+
+    "@midnight-ntwrk/wallet-sdk-capabilities/@midnight-ntwrk/wallet-sdk-indexer-client/@midnight-ntwrk/wallet-sdk-utilities": ["@midnight-ntwrk/wallet-sdk-utilities@1.2.0", "", { "dependencies": { "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw=="],
+
+    "@midnight-ntwrk/wallet-sdk-facade/@midnight-ntwrk/wallet-sdk-indexer-client/@midnight-ntwrk/wallet-sdk-utilities": ["@midnight-ntwrk/wallet-sdk-utilities@1.2.0", "", { "dependencies": { "effect": "^3.19.19", "rxjs": "^7.8.2" } }, "sha512-62Q9WeomETvOdyoPcRFX7+OWwOwHuD4/IVQniJwshHdzzLACuy1r/03paXoMH1/+S7CCzFaI1VUEVLcQrtZbaw=="],
+
+    "@midnight-ntwrk/wallet-sdk-hd/@scure/bip32/@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-hd/@scure/bip32/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@midnight-ntwrk/wallet-sdk-hd/@scure/bip39/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/api-augment": ["@polkadot/api-augment@16.5.6", "", { "dependencies": { "@polkadot/api-base": "16.5.6", "@polkadot/rpc-augment": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/types-augment": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/api-base": ["@polkadot/api-base@16.5.6", "", { "dependencies": { "@polkadot/rpc-core": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/util": "^14.0.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/api-derive": ["@polkadot/api-derive@16.5.6", "", { "dependencies": { "@polkadot/api": "16.5.6", "@polkadot/api-augment": "16.5.6", "@polkadot/api-base": "16.5.6", "@polkadot/rpc-core": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "@polkadot/util-crypto": "^14.0.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/keyring": ["@polkadot/keyring@14.0.3", "", { "dependencies": { "@polkadot/util": "14.0.3", "@polkadot/util-crypto": "14.0.3", "tslib": "^2.8.0" } }, "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-augment": ["@polkadot/rpc-augment@16.5.6", "", { "dependencies": { "@polkadot/rpc-core": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-core": ["@polkadot/rpc-core@16.5.6", "", { "dependencies": { "@polkadot/rpc-augment": "16.5.6", "@polkadot/rpc-provider": "16.5.6", "@polkadot/types": "16.5.6", "@polkadot/util": "^14.0.3", "rxjs": "^7.8.1", "tslib": "^2.8.1" } }, "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-provider": ["@polkadot/rpc-provider@16.5.6", "", { "dependencies": { "@polkadot/keyring": "^14.0.3", "@polkadot/types": "16.5.6", "@polkadot/types-support": "16.5.6", "@polkadot/util": "^14.0.3", "@polkadot/util-crypto": "^14.0.3", "@polkadot/x-fetch": "^14.0.3", "@polkadot/x-global": "^14.0.3", "@polkadot/x-ws": "^14.0.3", "eventemitter3": "^5.0.1", "mock-socket": "^9.3.1", "nock": "^13.5.5", "tslib": "^2.8.1" }, "optionalDependencies": { "@substrate/connect": "0.8.11" } }, "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-augment": ["@polkadot/types-augment@16.5.6", "", { "dependencies": { "@polkadot/types": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-codec": ["@polkadot/types-codec@16.5.6", "", { "dependencies": { "@polkadot/util": "^14.0.3", "@polkadot/x-bigint": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-create": ["@polkadot/types-create@16.5.6", "", { "dependencies": { "@polkadot/types-codec": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-known": ["@polkadot/types-known@16.5.6", "", { "dependencies": { "@polkadot/networks": "^14.0.3", "@polkadot/types": "16.5.6", "@polkadot/types-codec": "16.5.6", "@polkadot/types-create": "16.5.6", "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto": ["@polkadot/util-crypto@14.0.3", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "14.0.3", "@polkadot/util": "14.0.3", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "14.0.3", "@polkadot/x-randomvalues": "14.0.3", "@scure/base": "^1.1.7", "@scure/sr25519": "^0.2.0", "tslib": "^2.8.0" } }, "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/util/@polkadot/x-bigint": ["@polkadot/x-bigint@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/util/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/util/@polkadot/x-textdecoder": ["@polkadot/x-textdecoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/util/@polkadot/x-textencoder": ["@polkadot/x-textencoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ=="],
+
+    "@midnight-ntwrk/wallet/@midnight-ntwrk/wallet-sdk-address-format/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/types/@polkadot/types-codec/@polkadot/x-bigint": ["@polkadot/x-bigint@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ=="],
+
+    "@polkadot/types/@polkadot/util/@polkadot/x-bigint": ["@polkadot/x-bigint@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ=="],
+
+    "@polkadot/types/@polkadot/util/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@polkadot/types/@polkadot/util/@polkadot/x-textdecoder": ["@polkadot/x-textdecoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA=="],
+
+    "@polkadot/types/@polkadot/util/@polkadot/x-textencoder": ["@polkadot/x-textencoder@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@14.0.3", "", { "dependencies": { "@polkadot/util": "14.0.3", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "14.0.3", "@polkadot/wasm-util": "*" } }, "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "bitcoinjs-lib/bs58check/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "ethereum-cryptography/@scure/bip32/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 
@@ -2829,6 +3079,8 @@
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
+    "wif/bs58check/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
+
     "@effectstream/concise/viem/ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "@effectstream/config/viem/ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
@@ -2846,6 +3098,32 @@
     "@effectstream/utils/viem/ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "@libp2p/interface/@multiformats/multiaddr/uint8-varint/uint8arraylist": ["uint8arraylist@3.0.2", "", { "dependencies": { "uint8arrays": "^6.0.0" } }, "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-provider/@polkadot/types-support": ["@polkadot/types-support@16.5.6", "", { "dependencies": { "@polkadot/util": "^14.0.3", "tslib": "^2.8.1" } }, "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-provider/@polkadot/x-fetch": ["@polkadot/x-fetch@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "node-fetch": "^3.3.2", "tslib": "^2.8.0" } }, "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-provider/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-provider/@polkadot/x-ws": ["@polkadot/x-ws@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0", "ws": "^8.18.0" } }, "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-codec/@polkadot/x-bigint": ["@polkadot/x-bigint@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-known/@polkadot/networks": ["@polkadot/networks@14.0.3", "", { "dependencies": { "@polkadot/util": "14.0.3", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@14.0.3", "", { "dependencies": { "@polkadot/util": "14.0.3", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" } }, "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@14.0.3", "", { "dependencies": { "@polkadot/x-global": "14.0.3", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "14.0.3", "@polkadot/wasm-util": "*" } }, "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@polkadot/types/@polkadot/types-codec/@polkadot/x-bigint/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@polkadot/x-bigint/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@polkadot/types/@polkadot/util-crypto/@polkadot/x-randomvalues/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
 
     "npm/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -2874,6 +3152,16 @@
     "npm/wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "npm/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "wif/bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/rpc-provider/@polkadot/x-ws/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/types-codec/@polkadot/x-bigint/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto/@polkadot/x-bigint/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
+
+    "@midnight-ntwrk/wallet-sdk-node-client/@polkadot/api/@polkadot/util-crypto/@polkadot/x-randomvalues/@polkadot/x-global": ["@polkadot/x-global@14.0.3", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw=="],
 
     "npm/node-gyp/glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 

--- a/templates/preorder/packages/batcher/batcher.dev.ts
+++ b/templates/preorder/packages/batcher/batcher.dev.ts
@@ -1,0 +1,89 @@
+// Transaction batcher for post-sale NFT minting.
+//
+// The sync node's nft-dispatch worker POSTs one mint job per NFT to this
+// service's /send-input endpoint; the batcher holds its own funds, signs, and
+// submits the actual on-chain mint, then returns the tx hash.
+//
+// EVM mints go through the generic EvmContractAdapter, which calls an arbitrary
+// contract function — here `PreorderItemNft.mint(to)`. Each job is its own batch
+// (size criteria, maxBatchSize 1) because EvmContractAdapter submits one call per
+// batch. The Cardano adapter (Phase B) registers under the `cardanoNft` target.
+
+import { main, suspend } from "effection";
+import {
+  createNewBatcher,
+  FileStorage,
+  EvmContractAdapter,
+  type BatcherConfig,
+} from "@effectstream/batcher-sdk";
+import { hardhat } from "viem/chains";
+import { TrustedAdapter } from "./trusted-adapter.ts";
+import { CardanoMintAdapter } from "./cardano-mint-adapter.ts";
+import fs from "node:fs";
+import path from "node:path";
+
+const port = Number(process.env.BATCHER_PORT ?? "3334");
+const rpcUrl = process.env.EVM_RPC ?? "http://localhost:8545";
+// Hardhat account #9 — dedicated batcher account (funded, separate from the admin
+// account #0 and the buyers, to avoid nonce contention). Override with EVM_PRIVATE_KEY.
+const privateKey = (process.env.EVM_PRIVATE_KEY ??
+  "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6") as `0x${string}`;
+
+const here = import.meta.dirname!;
+const extra = JSON.parse(
+  fs.readFileSync(path.resolve(here, "../contracts-evm/build/extra-addresses.json"), "utf-8"),
+);
+const itemNftArtifact = JSON.parse(
+  fs.readFileSync(
+    path.resolve(
+      here,
+      "../contracts-evm/build/artifacts/hardhat/src/contracts/PreorderItemNft.sol/PreorderItemNft.json",
+    ),
+    "utf-8",
+  ),
+);
+
+// Wrapped so the batcher accepts the node's unsigned, internal mint jobs.
+const evmNft = new TrustedAdapter(
+  new EvmContractAdapter({
+    contractAddress: extra.itemNft as `0x${string}`,
+    privateKey,
+    syncProtocolName: "parallelEvmRpc",
+    artifact: itemNftArtifact,
+    chain: hardhat,
+    rpcUrl,
+    // NOTE: maxBatchSize is a BYTE budget, not a count. The nft-dispatch worker submits
+    // serially (awaits each wait-receipt before the next), so only one input is ever queued
+    // per batch; the default budget comfortably fits a single mint call.
+  }),
+);
+
+// Cardano item-NFT mint (native policy + deliver). Lucid is lazy-initialised on first use.
+const cardanoNft = new CardanoMintAdapter();
+
+const config: BatcherConfig = {
+  pollingIntervalMs: 500,
+  adapters: { evmNft, cardanoNft },
+  defaultTarget: "evmNft",
+  namespace: "",
+  batchingCriteria: {
+    evmNft: { criteriaType: "size", maxBatchSize: 1 },
+    cardanoNft: { criteriaType: "size", maxBatchSize: 1 },
+  },
+  confirmationLevel: "wait-receipt",
+  enableHttpServer: true,
+  port,
+};
+
+const batcher = createNewBatcher(config, new FileStorage("./batcher-data"));
+
+main(function* () {
+  batcher.addStateTransition("startup", ({ publicConfig }) => {
+    console.log(`[batcher] startup — polling every ${publicConfig.pollingIntervalMs} ms`);
+  });
+  batcher.addStateTransition("http:start", ({ port }) => {
+    console.log(`[batcher] HTTP server ready on port ${port}`);
+  });
+  yield* batcher.runBatcher();
+  yield* suspend();
+});

--- a/templates/preorder/packages/batcher/cardano-mint-adapter.ts
+++ b/templates/preorder/packages/batcher/cardano-mint-adapter.ts
@@ -1,0 +1,80 @@
+// Cardano mint adapter for the batcher.
+//
+// There is no built-in Cardano adapter in the batcher SDK, so this implements the minimal
+// BlockchainAdapter surface for minting an item NFT to a buyer: a native-policy mint that
+// delivers to the buyer's address (derived from their payment-key-hash), via the server-side
+// Lucid wallet (funded from the YACI faucet). One input per batch (buildBatchData takes the
+// first), and submitBatch already awaits the tx, so confirmation is immediate.
+
+import type {
+  BlockchainAdapter,
+  BatchBuildingOptions,
+  BatchBuildingResult,
+  BlockchainHash,
+  BlockchainTransactionReceipt,
+  DefaultBatcherInput,
+} from "@effectstream/batcher-sdk";
+import { initLucid, mintItemNftToAddress } from "@preorder/contracts-cardano/helpers";
+
+type CardanoMintData = { to: string; assetName: string } | null;
+
+export class CardanoMintAdapter implements BlockchainAdapter<CardanoMintData> {
+  buildBatchData(
+    inputs: DefaultBatcherInput[],
+    _options?: BatchBuildingOptions,
+  ): BatchBuildingResult<CardanoMintData> | null {
+    if (inputs.length === 0) return null;
+    const input = inputs[0]; // one mint per batch
+    try {
+      const payload = JSON.parse(input.input) as { to: string; assetName: string };
+      return { selectedInputs: [input], data: { to: String(payload.to), assetName: String(payload.assetName) } };
+    } catch {
+      return { selectedInputs: [input], data: null };
+    }
+  }
+
+  async submitBatch(data: CardanoMintData, _fee?: string | bigint): Promise<BlockchainHash> {
+    if (!data) throw new Error("cardano mint: empty/invalid payload");
+    const lucid = await initLucid();
+    const { txHash } = await mintItemNftToAddress(lucid, data.assetName, data.to);
+    return txHash;
+  }
+
+  // submitBatch already awaits the tx (lucid.awaitTx), so the receipt is immediate.
+  async waitForTransactionReceipt(hash: BlockchainHash): Promise<BlockchainTransactionReceipt> {
+    return { hash, blockNumber: 0n, status: 1 };
+  }
+
+  estimateBatchFee(): string | bigint {
+    return 0n;
+  }
+
+  getAccountAddress(): string {
+    return "cardano-batcher";
+  }
+
+  getChainName(): string {
+    return "Cardano (YACI)";
+  }
+
+  isReady(): boolean {
+    return true;
+  }
+
+  async getBlockNumber(): Promise<bigint> {
+    return 0n;
+  }
+
+  getSyncProtocolName(): string {
+    return "parallelUtxoRpc";
+  }
+
+  // Internal node jobs carry no per-user signature (the channel is trusted/local).
+  verifySignature(): boolean {
+    return true;
+  }
+
+  validateInput(): { valid: boolean } {
+    return { valid: true };
+  }
+}

--- a/templates/preorder/packages/batcher/package.json
+++ b/templates/preorder/packages/batcher/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@preorder/batcher",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "batcher:start": "bun run batcher.dev.ts"
+  },
+  "dependencies": {
+    "@effectstream/batcher-sdk": "0.100.14",
+    "@preorder/contracts-cardano": "workspace:*",
+    "effection": "^3.5.0",
+    "viem": "^2.37.0"
+  }
+}

--- a/templates/preorder/packages/batcher/trusted-adapter.ts
+++ b/templates/preorder/packages/batcher/trusted-adapter.ts
@@ -1,0 +1,67 @@
+import type {
+  BlockchainAdapter,
+  BatchBuildingOptions,
+  BatchBuildingResult,
+  DefaultBatcherInput,
+} from "@effectstream/batcher-sdk";
+
+type ValidationResult = { valid: boolean; error?: string };
+
+/**
+ * Wraps an adapter so the batcher accepts node-originated jobs that carry no
+ * per-user signature. The sync node <-> batcher channel is internal (localhost)
+ * and trusted, so `verifySignature()` returns true — without it the batcher core
+ * rejects unsigned inputs ("requires either a signature or a custom
+ * verifySignature implementation"). All other behaviour delegates to the inner
+ * adapter (e.g. EvmContractAdapter performing the actual mint).
+ */
+export class TrustedAdapter<T> implements BlockchainAdapter<T> {
+  constructor(private readonly inner: BlockchainAdapter<T>) {}
+
+  verifySignature(input: DefaultBatcherInput): boolean | Promise<boolean> {
+    return this.inner.verifySignature?.(input) ?? true;
+  }
+
+  validateInput(input: DefaultBatcherInput): ValidationResult | Promise<ValidationResult> {
+    return this.inner.validateInput ? this.inner.validateInput(input) : { valid: true };
+  }
+
+  submitBatch(data: T, fee: string | bigint) {
+    return this.inner.submitBatch(data, fee);
+  }
+
+  estimateBatchFee(data: T) {
+    return this.inner.estimateBatchFee(data);
+  }
+
+  buildBatchData(
+    inputs: DefaultBatcherInput[],
+    options?: BatchBuildingOptions,
+  ): BatchBuildingResult<T> | null {
+    return this.inner.buildBatchData(inputs, options);
+  }
+
+  waitForTransactionReceipt(hash: string, timeout?: number) {
+    return this.inner.waitForTransactionReceipt(hash, timeout);
+  }
+
+  getAccountAddress() {
+    return this.inner.getAccountAddress();
+  }
+
+  getChainName() {
+    return this.inner.getChainName();
+  }
+
+  isReady() {
+    return this.inner.isReady();
+  }
+
+  getBlockNumber() {
+    return this.inner.getBlockNumber();
+  }
+
+  getSyncProtocolName() {
+    return this.inner.getSyncProtocolName?.() ?? this.inner.getChainName();
+  }
+}

--- a/templates/preorder/packages/contracts-cardano/cardano-helpers.ts
+++ b/templates/preorder/packages/contracts-cardano/cardano-helpers.ts
@@ -12,6 +12,8 @@ import {
   PROTOCOL_PARAMETERS_DEFAULT,
   mintingPolicyToId,
   paymentCredentialOf,
+  scriptFromNative,
+  credentialToAddress,
   toUnit,
 } from "@lucid-evolution/utils";
 import fs from "node:fs";
@@ -280,4 +282,52 @@ export async function buyItemsCardano(
   console.log(`[Lucid] Purchase TX submitted: ${txHash} (policy=${policyId}, buyer=${buyerPkh})`);
   await lucid.awaitTx(txHash);
   return { txHash, policyId, buyerPkh };
+}
+
+// ── Post-sale item NFT minting (native policy) ─────────────────────────────
+// Cardano item NFTs are minted by a native "sig" policy keyed to the server wallet and
+// delivered to the buyer. The batcher's Cardano mint adapter uses this for the post-sale
+// distribution (the receipt plutus policy above is a per-purchase proof, a separate concern).
+
+function toHexStr(text: string): string {
+  return Buffer.from(text, "utf-8").toString("hex");
+}
+
+let cachedItemPolicy: { policyId: string; mintingPolicy: ReturnType<typeof scriptFromNative> } | null = null;
+
+// Deliverable address from a recipient: pass a bech32 address through, or derive an enterprise
+// address from a 28-byte payment-key-hash (how #753 records Cardano buyers — metadata `w` = pkh).
+function recipientToAddress(recipient: string): string {
+  if (recipient.startsWith("addr")) return recipient;
+  return credentialToAddress("Custom", { type: "Key", hash: recipient });
+}
+
+export async function mintItemNftToAddress(
+  lucid: LucidEvolution,
+  assetName: string,
+  recipient: string,
+  lovelace: bigint = 2_000_000n,
+): Promise<{ txHash: string; policyId: string; assetNameHex: string; unit: string }> {
+  const ownerAddr = await lucid.wallet().address();
+  if (!cachedItemPolicy) {
+    const cred = paymentCredentialOf(ownerAddr);
+    const nativeScript = scriptFromNative({ type: "sig", keyHash: cred.hash });
+    cachedItemPolicy = { policyId: mintingPolicyToId(nativeScript), mintingPolicy: nativeScript };
+  }
+  const { policyId, mintingPolicy } = cachedItemPolicy;
+  const assetNameHex = toHexStr(assetName);
+  const unit = toUnit(policyId, assetNameHex);
+  const toAddress = recipientToAddress(recipient);
+
+  const tx = lucid
+    .newTx()
+    .mintAssets({ [unit]: 1n })
+    .attach.MintingPolicy(mintingPolicy)
+    .pay.ToAddress(toAddress, { lovelace, [unit]: 1n });
+
+  const signed = await (await tx.complete()).sign.withWallet().complete();
+  const txHash = await signed.submit();
+  console.log(`[Lucid] Item NFT mint+deliver: ${txHash} (asset=${assetName} -> ${toAddress})`);
+  await lucid.awaitTx(txHash);
+  return { txHash, policyId, assetNameHex, unit };
 }

--- a/templates/preorder/packages/contracts-evm/deploy.ts
+++ b/templates/preorder/packages/contracts-evm/deploy.ts
@@ -1,6 +1,6 @@
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 import * as config from "./hardhat.config.ts";
-import { MockERC20Module, LaunchpadFactoryModule, EffectstreamL2Module } from "./ignition/modules/deploy.ts";
+import { MockERC20Module, LaunchpadFactoryModule, EffectstreamL2Module, PreorderItemNftModule } from "./ignition/modules/deploy.ts";
 import type { buildModule } from "@nomicfoundation/ignition-core";
 import { createPublicClient, createWalletClient, http, decodeEventLog } from "viem";
 import { hardhat } from "viem/chains";
@@ -21,6 +21,7 @@ const myDeployments: Deployment[] = [
   { module: MockERC20Module, network: "evmMainHttp" },
   { module: LaunchpadFactoryModule, network: "evmMainHttp" },
   { module: EffectstreamL2Module, network: "evmMainHttp" },
+  { module: PreorderItemNftModule, network: "evmMainHttp" },
 ] as const;
 
 export async function deploy(): Promise<void> {
@@ -40,13 +41,16 @@ export async function deploy(): Promise<void> {
   const factoryResult = results["LaunchpadFactoryModule"];
   const mockErc20Result = results["MockERC20Module"];
   const effectStreamL2Result = results["EffectstreamL2Module"];
+  const itemNftResult = results["PreorderItemNftModule"];
 
   const factoryAddress = factoryResult.factory.address as `0x${string}`;
   const mockErc20Address = mockErc20Result.mockErc20.address as `0x${string}`;
   const effectStreamL2Address = effectStreamL2Result.l2.address as `0x${string}`;
+  const itemNftAddress = itemNftResult.nft.address as `0x${string}`;
   console.log(`Factory: ${factoryAddress}`);
   console.log(`MockERC20: ${mockErc20Address}`);
   console.log(`EffectstreamL2: ${effectStreamL2Address}`);
+  console.log(`PreorderItemNft: ${itemNftAddress}`);
 
   const publicClient = createPublicClient({ chain: hardhat, transport: http("http://localhost:8545") });
   const walletClient = createWalletClient({
@@ -110,6 +114,7 @@ export async function deploy(): Promise<void> {
       factory: factoryAddress,
       mockErc20: mockErc20Address,
       effectStreamL2: effectStreamL2Address,
+      itemNft: itemNftAddress,
       // account #0 — owner of the launchpad + L2 contracts; the STM authorizes admin
       // commands by checking the L2 input signer against this address.
       admin: walletClient.account.address,

--- a/templates/preorder/packages/contracts-evm/ignition/modules/deploy.ts
+++ b/templates/preorder/packages/contracts-evm/ignition/modules/deploy.ts
@@ -24,4 +24,13 @@ export const EffectstreamL2Module = buildModule("EffectstreamL2Module", (m) => {
   return { l2 };
 });
 
+// ERC-721 minted to buyers when the admin finalises a campaign (post-sale distribution).
+export const PreorderItemNftModule = buildModule("PreorderItemNftModule", (m) => {
+  const owner = m.getAccount(0);
+  const name = m.getParameter("name", "Preorder Item");
+  const symbol = m.getParameter("symbol", "PITEM");
+  const nft = m.contract("PreorderItemNft", [name, symbol, owner]);
+  return { nft };
+});
+
 export default LaunchpadFactoryModule;

--- a/templates/preorder/packages/contracts-evm/src/contracts/PreorderItemNft.sol
+++ b/templates/preorder/packages/contracts-evm/src/contracts/PreorderItemNft.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {InverseAppProjectedNft} from "@effectstream/evm-contracts/src/contracts/token/InverseAppProjectedNft.sol";
+
+/// @dev ERC-721 minted to buyers when the admin finalises a preorder campaign.
+/// PRC-3 inverse projection: the canonical item/metadata lives in the Effectstream
+/// app (L2) and is served via `tokenURI` (`baseURI` -> sync node). Minting is
+/// performed post-sale by the batcher's account (the admin-triggered distribution),
+/// not by buyers.
+contract PreorderItemNft is InverseAppProjectedNft {
+    constructor(
+        string memory name,
+        string memory symbol,
+        address owner
+    ) InverseAppProjectedNft(name, symbol, owner) {}
+}

--- a/templates/preorder/packages/database/migration-order.ts
+++ b/templates/preorder/packages/database/migration-order.ts
@@ -3,6 +3,7 @@ import databaseSql from "./migrations/000-init.sql" with { type: "text" };
 import configAndPaymentsSql from "./migrations/001-config-and-payments.sql" with { type: "text" };
 import coinsSql from "./migrations/002-coins.sql" with { type: "text" };
 import referralRewardsSql from "./migrations/003-referral-rewards.sql" with { type: "text" };
+import nftMintsSql from "./migrations/004-nft-mints.sql" with { type: "text" };
 
 export const migrationTable: DBMigrations[] = [
   {
@@ -20,5 +21,9 @@ export const migrationTable: DBMigrations[] = [
   {
     name: "003-referral-rewards.sql",
     sql: referralRewardsSql,
+  },
+  {
+    name: "004-nft-mints.sql",
+    sql: nftMintsSql,
   },
 ];

--- a/templates/preorder/packages/database/migrations/004-nft-mints.sql
+++ b/templates/preorder/packages/database/migrations/004-nft-mints.sql
@@ -1,0 +1,37 @@
+-- Post-sale NFT distribution.
+--
+-- `nft_mints` is the deterministic work-list: the `mint-nfts` admin command (an
+-- on-chain EffectstreamL2 input, applied by the STM) inserts one row per
+-- (campaign, chain, buyer, item) for every item a buyer owns once the campaign
+-- has ended. The off-chain nft-dispatch worker drains pending rows by submitting
+-- each to the batcher, which holds funds and performs the actual mint, then marks
+-- the row and records the minted token in `minted_nfts`.
+
+CREATE TABLE nft_mints (
+  campaign_id TEXT NOT NULL,
+  chain TEXT NOT NULL,            -- 'evm' | 'cardano'
+  wallet TEXT NOT NULL,
+  item_id INTEGER NOT NULL,
+  quantity INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending', -- 'pending' | 'submitted' | 'minted' | 'failed'
+  tx_hash TEXT,
+  error TEXT,
+  created_block INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (campaign_id, chain, wallet, item_id)
+);
+
+CREATE INDEX nft_mints_status_idx ON nft_mints (status);
+
+-- One row per minted NFT (EVM tokenId or Cardano policy+asset).
+CREATE TABLE minted_nfts (
+  campaign_id TEXT NOT NULL,
+  chain TEXT NOT NULL,
+  wallet TEXT NOT NULL,
+  item_id INTEGER NOT NULL,
+  token_id TEXT NOT NULL,         -- EVM tokenId (decimal) or Cardano asset name (hex)
+  policy_id TEXT,                 -- Cardano only
+  tx_hash TEXT NOT NULL,
+  PRIMARY KEY (campaign_id, chain, token_id)
+);
+
+CREATE INDEX minted_nfts_wallet_idx ON minted_nfts (campaign_id, wallet);

--- a/templates/preorder/packages/database/sql/queries.queries.ts
+++ b/templates/preorder/packages/database/sql/queries.queries.ts
@@ -1224,3 +1224,68 @@ const getReferralRewardsByCampaignIR: any = {"usedParamSet":{"campaign_id":true}
 export const getReferralRewardsByCampaign = new PreparedQuery<IGetReferralRewardsByCampaignParams,IGetReferralRewardsByCampaignResult>(getReferralRewardsByCampaignIR);
 
 
+/** 'GetMintableItems' parameters type */
+export interface IGetMintableItemsParams {
+  launchpad: string;
+}
+
+/** 'GetMintableItems' return type */
+export interface IGetMintableItemsResult {
+  chain: string;
+  item_id: number;
+  quantity: number;
+  wallet: string;
+}
+
+/** 'GetMintableItems' query type */
+export interface IGetMintableItemsQuery {
+  params: IGetMintableItemsParams;
+  result: IGetMintableItemsResult;
+}
+
+const getMintableItemsIR: any = {"usedParamSet":{"launchpad":true},"params":[{"name":"launchpad","required":true,"transform":{"type":"scalar"},"locs":[{"a":179,"b":189}]}],"statement":"SELECT ui.wallet, ui.item_id, ui.quantity, u.chain\nFROM launchpad_user_items ui\nJOIN launchpad_users u ON u.launchpad = ui.launchpad AND u.wallet = ui.wallet\nWHERE ui.launchpad = :launchpad!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT ui.wallet, ui.item_id, ui.quantity, u.chain
+ * FROM launchpad_user_items ui
+ * JOIN launchpad_users u ON u.launchpad = ui.launchpad AND u.wallet = ui.wallet
+ * WHERE ui.launchpad = :launchpad!
+ * ```
+ */
+export const getMintableItems = new PreparedQuery<IGetMintableItemsParams,IGetMintableItemsResult>(getMintableItemsIR);
+
+
+/** 'InsertNftMint' parameters type */
+export interface IInsertNftMintParams {
+  campaign_id: string;
+  chain: string;
+  created_block: number;
+  item_id: number;
+  quantity: number;
+  wallet: string;
+}
+
+/** 'InsertNftMint' return type */
+export type IInsertNftMintResult = void;
+
+/** 'InsertNftMint' query type */
+export interface IInsertNftMintQuery {
+  params: IInsertNftMintParams;
+  result: IInsertNftMintResult;
+}
+
+const insertNftMintIR: any = {"usedParamSet":{"campaign_id":true,"chain":true,"wallet":true,"item_id":true,"quantity":true,"created_block":true},"params":[{"name":"campaign_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":101,"b":113}]},{"name":"chain","required":true,"transform":{"type":"scalar"},"locs":[{"a":116,"b":122}]},{"name":"wallet","required":true,"transform":{"type":"scalar"},"locs":[{"a":125,"b":132}]},{"name":"item_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":135,"b":143}]},{"name":"quantity","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":155}]},{"name":"created_block","required":true,"transform":{"type":"scalar"},"locs":[{"a":169,"b":183}]}],"statement":"INSERT INTO nft_mints (campaign_id, chain, wallet, item_id, quantity, status, created_block)\nVALUES (:campaign_id!, :chain!, :wallet!, :item_id!, :quantity!, 'pending', :created_block!)\nON CONFLICT (campaign_id, chain, wallet, item_id) DO NOTHING"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO nft_mints (campaign_id, chain, wallet, item_id, quantity, status, created_block)
+ * VALUES (:campaign_id!, :chain!, :wallet!, :item_id!, :quantity!, 'pending', :created_block!)
+ * ON CONFLICT (campaign_id, chain, wallet, item_id) DO NOTHING
+ * ```
+ */
+export const insertNftMint = new PreparedQuery<IInsertNftMintParams,IInsertNftMintResult>(insertNftMintIR);
+
+

--- a/templates/preorder/packages/database/sql/queries.sql
+++ b/templates/preorder/packages/database/sql/queries.sql
@@ -161,3 +161,14 @@ INSERT INTO referral_rewards (
 
 /* @name getReferralRewardsByCampaign */
 SELECT * FROM referral_rewards WHERE campaign_id = :campaign_id! ORDER BY id DESC;
+
+/* @name getMintableItems */
+SELECT ui.wallet, ui.item_id, ui.quantity, u.chain
+FROM launchpad_user_items ui
+JOIN launchpad_users u ON u.launchpad = ui.launchpad AND u.wallet = ui.wallet
+WHERE ui.launchpad = :launchpad!;
+
+/* @name insertNftMint */
+INSERT INTO nft_mints (campaign_id, chain, wallet, item_id, quantity, status, created_block)
+VALUES (:campaign_id!, :chain!, :wallet!, :item_id!, :quantity!, 'pending', :created_block!)
+ON CONFLICT (campaign_id, chain, wallet, item_id) DO NOTHING;

--- a/templates/preorder/packages/frontend/client/src/components/MyPurchases.tsx
+++ b/templates/preorder/packages/frontend/client/src/components/MyPurchases.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { paymentCredentialOf } from "@lucid-evolution/utils";
 import { useWallet } from "../wallet/WalletContext.tsx";
 import { useLog } from "../logs/LogContext.tsx";
 
@@ -11,6 +12,27 @@ type PurchasedItem = {
   item_id: number;
   quantity: number;
 };
+
+type MintedNft = {
+  chain: string;
+  item_id: number;
+  token_id: string;
+  policy_id: string | null;
+  tx_hash: string;
+};
+
+// minted_nfts.wallet is the EVM address for EVM buyers, but the Cardano payment-key-hash for
+// Cardano buyers (that's what the receipt records). Derive the right lookup key per chain.
+function nftWalletKey(mode: string, address: string): string {
+  if (mode.startsWith("cardano")) {
+    try {
+      return paymentCredentialOf(address).hash;
+    } catch {
+      return address.toLowerCase();
+    }
+  }
+  return address.toLowerCase();
+}
 
 export function MyPurchases({
   slug,
@@ -28,12 +50,14 @@ export function MyPurchases({
   const w = useWallet();
   const { addLog } = useLog();
   const [serverPurchases, setServerPurchases] = useState<PurchasedItem[]>([]);
+  const [mintedNfts, setMintedNfts] = useState<MintedNft[]>([]);
 
   const address = w.mode.startsWith("evm") ? w.evmAddress : w.cardanoAddress;
 
   useEffect(() => {
     if (!address || w.mode === "none") {
       setServerPurchases([]);
+      setMintedNfts([]);
       return;
     }
     addLog("info", "Fetching your purchases...", `GET /api/userData/${slug}?wallet=${address.substring(0, 16)}...`);
@@ -44,6 +68,19 @@ export function MyPurchases({
         setServerPurchases(userItems);
         if (userItems.length > 0) {
           addLog("success", `You own ${userItems.length} item type(s)`);
+        }
+      })
+      .catch(() => {});
+
+    // Minted NFTs (populated after the admin finalises the sale). For Cardano, look up by the
+    // payment-key-hash, since that's how the receipt-based mint records the owner.
+    const nftKey = nftWalletKey(w.mode, address);
+    fetch(`${apiUrl}/api/nfts/${slug}?wallet=${nftKey}`)
+      .then((r) => (r.ok ? r.json() : { nfts: [] }))
+      .then((d: any) => {
+        setMintedNfts(d.nfts || []);
+        if ((d.nfts || []).length > 0) {
+          addLog("success", `You hold ${d.nfts.length} minted NFT(s)`);
         }
       })
       .catch(() => {});
@@ -66,7 +103,7 @@ export function MyPurchases({
     .filter(([, qty]) => qty > 0)
     .map(([id, qty]) => ({ item_id: id, quantity: qty }));
 
-  if (w.mode === "none" || purchased.length === 0) return null;
+  if (w.mode === "none" || (purchased.length === 0 && mintedNfts.length === 0)) return null;
 
   return (
     <div data-testid="my-purchases" style={{ marginTop: 32 }}>
@@ -88,6 +125,32 @@ export function MyPurchases({
           );
         })}
       </div>
+
+      {mintedNfts.length > 0 && (
+        <div data-testid="my-nfts" style={{ marginTop: 24 }}>
+          <h3 style={{ fontSize: 15, marginBottom: 12, color: "#f0c674" }}>
+            Minted NFTs ({mintedNfts.length})
+          </h3>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(170px, 1fr))", gap: 12 }}>
+            {mintedNfts.map((n) => {
+              const info = items.find((i) => i.id === n.item_id);
+              return (
+                <div key={`${n.chain}-${n.token_id}`} style={{
+                  border: "1px solid #5a4708", borderRadius: 8, padding: 12, background: "#0d1117",
+                }}>
+                  <p style={{ fontSize: 13, color: "#e6edf3", fontWeight: 600 }}>{info?.name || `Item #${n.item_id}`}</p>
+                  <div style={{ marginTop: 6, fontSize: 11, color: "#8b949e" }}>
+                    <div>chain: <span style={{ color: "#c9d1d9" }}>{n.chain}</span></div>
+                    <div style={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+                      {n.chain === "evm" ? `#${n.token_id}` : `${n.token_id.substring(0, 16)}…`}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/templates/preorder/packages/frontend/client/src/pages/AdminPanel.tsx
+++ b/templates/preorder/packages/frontend/client/src/pages/AdminPanel.tsx
@@ -167,6 +167,23 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
     }, 1500);
   }, []);
 
+  // Minting (esp. Cardano) is serial + slow, so keep refreshing the status until no jobs remain
+  // pending/submitted (or a generous cap). Without this the table stops polling after ~12s and
+  // looks "stuck" while mints are still completing.
+  const pollMintsUntilSettled = useCallback(() => {
+    let n = 0;
+    const iv = setInterval(async () => {
+      try {
+        const s = await (await fetch(`${apiUrl}/api/admin/status/${CAMPAIGN_ID}`)).json();
+        setStatus(s);
+        const sum = (s.nftMintSummary || {}) as Record<string, number>;
+        const inflight = (sum.pending || 0) + (sum.submitted || 0);
+        if (inflight === 0 && ((sum.minted || 0) + (sum.failed || 0)) > 0) clearInterval(iv);
+      } catch { /* keep polling */ }
+      if (++n >= 150) clearInterval(iv); // ~5 min cap
+    }, 2000);
+  }, [apiUrl]);
+
   // Surface a Sign Transaction modal (admin signs with the local dev key) before submitting.
   const requestConfirm = useCallback((summary: string, run: () => Promise<void>) => {
     getAdminBalance()
@@ -245,7 +262,7 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
     try {
       const { txHash } = await mintNfts(l2, campaignId);
       addLog("success", `mint-nfts submitted: ${campaignId}`, txHash);
-      refreshSoon();
+      pollMintsUntilSettled();
     } catch (e: any) {
       addLog("error", "mint-nfts failed", e.message);
     } finally {

--- a/templates/preorder/packages/frontend/client/src/pages/AdminPanel.tsx
+++ b/templates/preorder/packages/frontend/client/src/pages/AdminPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import type { Address } from "viem";
 import { CurrencyToggle } from "../components/CurrencyToggle.tsx";
-import { adminAddress, createCampaign, setProduct, endCampaign, setCoin, getAdminBalance } from "../wallet/admin-wallet.ts";
+import { adminAddress, createCampaign, setProduct, endCampaign, setCoin, mintNfts, getAdminBalance } from "../wallet/admin-wallet.ts";
 import { WalletConfirmModal } from "../wallet/WalletConfirmModal.tsx";
 import { AddressChip } from "../components/AddressChip.tsx";
 import { useLog } from "../logs/LogContext.tsx";
@@ -84,6 +84,16 @@ type AdminStatus = {
     tx_hash: string;
     block_height: number;
   }[];
+  nftMints?: {
+    chain: string;
+    wallet: string;
+    item_id: number;
+    quantity: number;
+    status: string;
+    tx_hash?: string;
+    error?: string;
+  }[];
+  nftMintSummary?: Record<string, number>;
   summary: { total: number; valid: number; invalid: number };
 };
 
@@ -224,6 +234,20 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
       refreshSoon();
     } catch (e: any) {
       addLog("error", "end-campaign failed", e.message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitMintNfts = async () => {
+    if (!l2) return;
+    setBusy(true);
+    try {
+      const { txHash } = await mintNfts(l2, campaignId);
+      addLog("success", `mint-nfts submitted: ${campaignId}`, txHash);
+      refreshSoon();
+    } catch (e: any) {
+      addLog("error", "mint-nfts failed", e.message);
     } finally {
       setBusy(false);
     }
@@ -567,6 +591,55 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
           </table>
         ) : (
           <p style={{ color: "#8b949e", fontSize: 13 }}>No referral payouts yet.</p>
+        )}
+      </section>
+
+      {/* Post-sale NFT minting */}
+      <section style={cardStyle}>
+        <h2 style={h2Style}>Post-sale NFT minting</h2>
+        <p style={{ color: "#8b949e", fontSize: 12, marginBottom: 12 }}>
+          After the campaign ends, mint an item NFT to every buyer for each item they own. Jobs are
+          submitted to the batcher, which holds funds and performs the actual mint.
+        </p>
+        <button
+          data-testid="admin-mint-nfts"
+          style={{ ...btnStyle, background: "#1f6f5f", border: "1px solid #2ea08c" }}
+          disabled={busy || !l2 || status?.campaign.status !== "ended"}
+          onClick={() => requestConfirm(`mint-nfts · ${campaignId}`, submitMintNfts)}
+        >
+          {busy
+            ? "Submitting…"
+            : status?.campaign.status === "ended"
+              ? "Mint item NFTs"
+              : "End campaign first"}
+        </button>
+        {status?.nftMintSummary && Object.keys(status.nftMintSummary).length > 0 && (
+          <div data-testid="nft-mint-summary" style={{ display: "flex", gap: 16, marginTop: 12, fontSize: 12, fontFamily: "monospace" }}>
+            {Object.entries(status.nftMintSummary).map(([s, n]) => (
+              <span key={s} style={{ color: s === "minted" ? "#3fb950" : s === "failed" ? "#f85149" : "#d29922" }}>
+                {s}: {n}
+              </span>
+            ))}
+          </div>
+        )}
+        {status && status.nftMints && status.nftMints.length > 0 && (
+          <table data-testid="nft-mints-table" style={{ ...tableStyle, marginTop: 12 }}>
+            <thead>
+              <tr>{["chain", "wallet", "item", "qty", "status", "tx"].map((h) => (<th key={h} style={thStyle}>{h}</th>))}</tr>
+            </thead>
+            <tbody>
+              {status.nftMints.slice(0, 20).map((m, i) => (
+                <tr key={`${m.chain}-${m.wallet}-${m.item_id}-${i}`}>
+                  <td style={tdStyle}>{m.chain}</td>
+                  <td style={tdStyle}><AddressChip value={m.wallet} /></td>
+                  <td style={tdStyle}>{m.item_id}</td>
+                  <td style={tdStyle}>{m.quantity}</td>
+                  <td style={{ ...tdStyle, color: m.status === "minted" ? "#3fb950" : m.status === "failed" ? "#f85149" : "#d29922" }}>{m.status}</td>
+                  <td style={tdStyle}>{m.tx_hash ? <AddressChip value={m.tx_hash} /> : "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         )}
       </section>
 

--- a/templates/preorder/packages/frontend/client/src/wallet/admin-wallet.ts
+++ b/templates/preorder/packages/frontend/client/src/wallet/admin-wallet.ts
@@ -66,3 +66,9 @@ export function endCampaign(l2: Address, campaignId: string) {
 export function setCoin(l2: Address, coin: unknown) {
   return submitL2Input(l2, ["set-coin", JSON.stringify(coin)]);
 }
+
+// Post-sale: enqueue NFT mints for every item each buyer owns (campaign must be ended).
+// The sync node's dispatcher then submits each to the batcher, which performs the mint.
+export function mintNfts(l2: Address, campaignId: string) {
+  return submitL2Input(l2, ["mint-nfts", campaignId]);
+}

--- a/templates/preorder/packages/node/addresses.ts
+++ b/templates/preorder/packages/node/addresses.ts
@@ -10,6 +10,7 @@ export interface ExtraAddresses {
   factory: string;
   mockErc20: string;
   effectStreamL2: string;
+  itemNft: string;
   admin: string;
 }
 
@@ -20,6 +21,7 @@ let extra: ExtraAddresses = {
   factory: ZERO,
   mockErc20: ZERO,
   effectStreamL2: ZERO,
+  itemNft: ZERO,
   admin: ZERO,
 };
 
@@ -37,6 +39,7 @@ try {
 export const EXTRA_ADDRESSES = extra;
 export const LAUNCHPAD_ADDRESS = extra.launchpadProxy.toLowerCase();
 export const EFFECTSTREAM_L2_ADDRESS = extra.effectStreamL2;
+export const ITEM_NFT_ADDRESS = extra.itemNft;
 export const MOCK_ERC20_ADDRESS = extra.mockErc20.toLowerCase();
 /** Lower-cased admin address; the STM authorizes admin commands by comparing the L2 input signer to this. */
 export const ADMIN_ADDRESS = extra.admin.toLowerCase();

--- a/templates/preorder/packages/node/api.ts
+++ b/templates/preorder/packages/node/api.ts
@@ -340,11 +340,26 @@ export const apiRouter: StartConfigApiRouter = async function (
         getReferralRewardsByCampaign.run({ campaign_id: campaign.campaign_id }, dbConn),
         "/api/admin/status/referrals",
       );
+      const nftMintsRes = await dbConn.query(
+        `SELECT chain, wallet, item_id, quantity, status, tx_hash, error
+         FROM nft_mints WHERE campaign_id = $1 ORDER BY wallet, item_id`,
+        [campaign.campaign_id],
+      );
+      const nftMints = nftMintsRes.rows;
+      const nftMintSummary = nftMints.reduce(
+        (acc: Record<string, number>, m: { status: string }) => {
+          acc[m.status] = (acc[m.status] ?? 0) + 1;
+          return acc;
+        },
+        {},
+      );
       const valid = payments.filter((p) => p.status === "valid").length;
       const invalid = payments.filter((p) => p.status === "invalid").length;
       reply.send({
         coins,
         referralRewards,
+        nftMints,
+        nftMintSummary,
         campaign: {
           campaignId: campaign.campaign_id,
           slug: campaign.slug,
@@ -363,6 +378,33 @@ export const apiRouter: StartConfigApiRouter = async function (
       });
     },
   );
+
+  // Minted NFTs owned by a wallet (populated after the admin finalises the sale).
+  server.get<{
+    Params: { slug: string };
+    Querystring: { wallet?: string };
+  }>("/api/nfts/:slug", async (request, reply) => {
+    const [campaign] = await runPreparedQuery(
+      getCampaignBySlug.run({ slug: request.params.slug }, dbConn),
+      "/api/nfts/campaign",
+    );
+    if (!campaign) {
+      reply.code(404).send({ error: "Launchpad not found" });
+      return;
+    }
+    const wallet = request.query.wallet?.toLowerCase();
+    if (!wallet) {
+      reply.code(400).send({ error: "wallet query param required" });
+      return;
+    }
+    const result = await dbConn.query(
+      `SELECT chain, item_id, token_id, policy_id, tx_hash
+       FROM minted_nfts WHERE campaign_id = $1 AND wallet = $2
+       ORDER BY item_id, token_id`,
+      [campaign.campaign_id, wallet],
+    );
+    reply.send({ nfts: result.rows });
+  });
 
   // Marketplace integration — item metadata.
   server.get<{ Params: { slug: string } }>(

--- a/templates/preorder/packages/node/grammar.ts
+++ b/templates/preorder/packages/node/grammar.ts
@@ -26,6 +26,10 @@ export const adminGrammar = {
   "set-coin": [
     ["coinJson", Type.String()],
   ],
+  // Post-sale: enqueue NFT mints for every item each buyer owns. Campaign must be ended.
+  "mint-nfts": [
+    ["campaignId", Type.String()],
+  ],
 } as const satisfies GrammarDefinition;
 
 /**

--- a/templates/preorder/packages/node/main.dev.ts
+++ b/templates/preorder/packages/node/main.dev.ts
@@ -1,5 +1,5 @@
 import { init, start } from "@effectstream/runtime";
-import { main, suspend } from "effection";
+import { main, spawn, suspend } from "effection";
 
 import { config } from "./config.dev.ts";
 import {
@@ -11,9 +11,13 @@ import { gameStateTransitions } from "./state-machine.ts";
 import { apiRouter } from "./api.ts";
 import { grammar } from "./grammar.ts";
 import { BuyItemsPrimitive, ReferrerRewardPrimitive } from "./primitives.ts";
+import { startNftDispatch } from "./nft-dispatch.ts";
 main(function* () {
   yield* init();
   console.log("Starting Preorder Sync Node (Local)");
+
+  // Drain nft_mints -> batcher. Spawn before start() (which never returns control).
+  yield* spawn(startNftDispatch);
 
   yield* withEffectstreamStaticConfig(config, function* () {
     yield* start({

--- a/templates/preorder/packages/node/nft-dispatch.ts
+++ b/templates/preorder/packages/node/nft-dispatch.ts
@@ -1,0 +1,202 @@
+// Off-chain NFT mint dispatcher.
+//
+// Drains `nft_mints` (enqueued by the `mint-nfts` admin command) by submitting one
+// job per NFT to the batcher's /send-input endpoint. The batcher holds funds, signs,
+// and submits the actual mint, returning a tx hash; we record the minted token in
+// `minted_nfts` and mark the job. The dispatcher itself holds NO keys.
+//
+// Runs as an effection task spawned from main.dev.ts BEFORE start() (start() enters an
+// infinite block loop and never returns). DB access is wrapped in the runtime's global
+// mutex (PGLite-safe; no-op on real Postgres) and never held across the network call.
+
+import { sleep, call, type Operation } from "effection";
+import { createPublicClient, http, decodeEventLog, type Hex } from "viem";
+import { hardhat } from "viem/chains";
+import { getConnection, acquireDBMutex, releaseDBMutex } from "@effectstream/db";
+import type { Pool } from "pg";
+
+const BATCHER_URL = process.env.BATCHER_URL ?? "http://localhost:3334";
+const EVM_RPC = process.env.EVM_RPC ?? "http://localhost:8545";
+const POLL_MS = 3000;
+const MUTEX = "nft-dispatch";
+
+const mintedEventAbi = [
+  {
+    type: "event",
+    name: "Minted",
+    inputs: [
+      { name: "tokenId", type: "uint256", indexed: true },
+      { name: "minter", type: "address", indexed: true },
+      { name: "userTokenId", type: "uint256", indexed: true },
+    ],
+  },
+] as const;
+
+let pub: ReturnType<typeof createPublicClient> | null = null;
+function getPub() {
+  if (!pub) pub = createPublicClient({ chain: hardhat, transport: http(EVM_RPC) });
+  return pub;
+}
+
+type NftMint = {
+  campaign_id: string;
+  chain: string;
+  wallet: string;
+  item_id: number;
+  quantity: number;
+};
+
+function* dbOp<T>(fn: () => Promise<T>): Operation<T> {
+  yield* acquireDBMutex(MUTEX);
+  try {
+    return yield* call(fn);
+  } finally {
+    releaseDBMutex(MUTEX);
+  }
+}
+
+// Submit one job to the batcher and block until it returns the tx hash.
+async function submitJob(
+  target: string,
+  address: string,
+  input: unknown,
+  timeoutMs: number,
+): Promise<string> {
+  const body = {
+    data: {
+      address,
+      addressType: 1, // informational; the adapters here don't verify per-user signatures
+      input: JSON.stringify(input),
+      timestamp: String(Date.now()),
+      target,
+    },
+    confirmationLevel: "wait-receipt",
+    timeoutMs,
+  };
+  const res = await fetch(`${BATCHER_URL}/send-input`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`batcher ${res.status}: ${await res.text()}`);
+  const j = (await res.json()) as { transactionHash?: string };
+  if (!j.transactionHash) throw new Error(`batcher returned no tx hash: ${JSON.stringify(j)}`);
+  return j.transactionHash;
+}
+
+async function tokenIdFromReceipt(txHash: string): Promise<string> {
+  const receipt = await getPub().getTransactionReceipt({ hash: txHash as Hex });
+  for (const lg of receipt.logs) {
+    try {
+      const d = decodeEventLog({ abi: mintedEventAbi, data: lg.data, topics: lg.topics });
+      if (d.eventName === "Minted") return String((d.args as { tokenId: bigint }).tokenId);
+    } catch { /* not the Minted event */ }
+  }
+  return "";
+}
+
+function* setStatus(
+  pool: Pool,
+  job: NftMint,
+  status: string,
+  txHash: string | null,
+  error: string | null,
+): Operation<void> {
+  yield* dbOp(() =>
+    pool.query(
+      `UPDATE nft_mints SET status = $5, tx_hash = $6, error = $7
+       WHERE campaign_id = $1 AND chain = $2 AND wallet = $3 AND item_id = $4`,
+      [job.campaign_id, job.chain, job.wallet, job.item_id, status, txHash, error],
+    ),
+  );
+}
+
+function* processEvmJob(pool: Pool, job: NftMint): Operation<void> {
+  // Claim the row so a slow mint isn't re-picked next tick.
+  yield* setStatus(pool, job, "submitted", null, null);
+
+  let lastTx = "";
+  for (let i = 0; i < job.quantity; i++) {
+    const txHash = yield* call(() => submitJob("evmNft", job.wallet, { method: "mint", args: [job.wallet] }, 60_000));
+    lastTx = txHash;
+    const tokenId = (yield* call(() => tokenIdFromReceipt(txHash))) || `${txHash}-${i}`;
+    yield* dbOp(() =>
+      pool.query(
+        `INSERT INTO minted_nfts (campaign_id, chain, wallet, item_id, token_id, policy_id, tx_hash)
+         VALUES ($1, 'evm', $2, $3, $4, NULL, $5)
+         ON CONFLICT (campaign_id, chain, token_id) DO NOTHING`,
+        [job.campaign_id, job.wallet, job.item_id, tokenId, txHash],
+      ),
+    );
+    console.log(`[nft-dispatch] EVM minted token=${tokenId} item=${job.item_id} -> ${job.wallet}`);
+  }
+  yield* setStatus(pool, job, "minted", lastTx, null);
+}
+
+function* processCardanoJob(pool: Pool, job: NftMint): Operation<void> {
+  yield* setStatus(pool, job, "submitted", null, null);
+
+  let lastTx = "";
+  for (let i = 0; i < job.quantity; i++) {
+    // Asset name must be <= 32 bytes + unique per (item, unit, buyer). token_id = its hex.
+    const assetName = `IT${job.item_id}N${i}-${job.wallet.slice(-16)}`;
+    const tokenId = Buffer.from(assetName, "utf-8").toString("hex");
+    // First Cardano mint funds a fresh server wallet via the faucet — allow extra time.
+    const txHash = yield* call(() => submitJob("cardanoNft", job.wallet, { to: job.wallet, assetName }, 120_000));
+    lastTx = txHash;
+    yield* dbOp(() =>
+      pool.query(
+        `INSERT INTO minted_nfts (campaign_id, chain, wallet, item_id, token_id, policy_id, tx_hash)
+         VALUES ($1, 'cardano', $2, $3, $4, NULL, $5)
+         ON CONFLICT (campaign_id, chain, token_id) DO NOTHING`,
+        [job.campaign_id, job.wallet, job.item_id, tokenId, txHash],
+      ),
+    );
+    console.log(`[nft-dispatch] Cardano minted ${assetName} item=${job.item_id} -> ${job.wallet}`);
+  }
+  yield* setStatus(pool, job, "minted", lastTx, null);
+}
+
+function* tick(pool: Pool): Operation<void> {
+  let rows: NftMint[];
+  try {
+    const r = yield* dbOp(() =>
+      pool.query<NftMint>(
+        // EVM first ('evm' > 'cardano' under DESC): EVM mints are fast, whereas the first
+        // Cardano mint blocks on a faucet top-up — don't let it stall the EVM jobs.
+        `SELECT campaign_id, chain, wallet, item_id, quantity FROM nft_mints WHERE status = 'pending' ORDER BY chain DESC, item_id`,
+      ),
+    );
+    rows = r.rows;
+  } catch (err) {
+    // nft_mints doesn't exist until migrations apply — stay quiet about that.
+    const m = err instanceof Error ? err.message : String(err);
+    if (!m.includes("does not exist")) console.error("[nft-dispatch] poll error:", m);
+    return;
+  }
+  for (const job of rows) {
+    try {
+      if (job.chain === "cardano") {
+        yield* processCardanoJob(pool, job);
+      } else {
+        yield* processEvmJob(pool, job);
+      }
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err);
+      console.error(`[nft-dispatch] job failed (${job.wallet} item ${job.item_id}):`, m);
+      try {
+        yield* setStatus(pool, job, "failed", null, m.slice(0, 500));
+      } catch { /* best effort */ }
+    }
+  }
+}
+
+/// Effection task: poll loop. Spawn from main.dev.ts (before `start()`).
+export function* startNftDispatch(): Operation<void> {
+  const pool = getConnection();
+  console.log("[nft-dispatch] started (polling nft_mints)");
+  while (true) {
+    yield* sleep(POLL_MS);
+    yield* tick(pool);
+  }
+}

--- a/templates/preorder/packages/node/state-machine.ts
+++ b/templates/preorder/packages/node/state-machine.ts
@@ -15,7 +15,10 @@ import {
   upsertCampaign,
   endCampaign,
   getCampaignByReceiver,
+  getCampaignById,
   getActiveCampaign,
+  getMintableItems,
+  insertNftMint,
   upsertProduct,
   getProductsByCampaign,
   upsertCoin,
@@ -220,6 +223,44 @@ stm.addStateTransition("set-coin", function* (data) {
     decimals: Number(c.decimals ?? 18),
   });
   console.log(`[STM:set-coin] ${c.token} x=${c.x} n=${c.n}`);
+});
+
+// Post-sale NFT distribution. Once a campaign is ended, enqueue one mint job per
+// (chain, buyer, item) for every item a buyer owns. The off-chain nft-dispatch
+// worker drains these and submits them to the batcher. Deterministic + idempotent
+// (re-running adds nothing new thanks to the nft_mints primary key).
+stm.addStateTransition("mint-nfts", function* (data) {
+  if (!isAdmin(data)) return;
+  const { campaignId } = data.parsedInput;
+  const id = String(campaignId);
+
+  const [campaign] = yield* World.resolve(getCampaignById, { campaign_id: id });
+  if (!campaign) {
+    console.log(`[STM:mint-nfts] unknown campaign ${id}`);
+    return;
+  }
+  if (campaign.status !== "ended") {
+    console.log(`[STM:mint-nfts] campaign ${id} not ended (status=${campaign.status})`);
+    return;
+  }
+
+  // launchpad_user_items is keyed by the campaign's launchpad address (see buy-items).
+  const launchpad = String(campaign.launchpad_address);
+  const rows = yield* World.resolve(getMintableItems, { launchpad });
+
+  let count = 0;
+  for (const r of rows) {
+    yield* World.resolve(insertNftMint, {
+      campaign_id: id,
+      chain: r.chain,
+      wallet: r.wallet,
+      item_id: r.item_id,
+      quantity: r.quantity,
+      created_block: data.blockHeight,
+    });
+    count++;
+  }
+  console.log(`[STM:mint-nfts] campaign=${id} enqueued ${count} mint job(s)`);
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/templates/preorder/packages/tests/helpers.ts
+++ b/templates/preorder/packages/tests/helpers.ts
@@ -7,6 +7,7 @@ export type DeployedAddresses = {
   factory: `0x${string}`;
   mockErc20: `0x${string}`;
   effectStreamL2: `0x${string}`;
+  itemNft: `0x${string}`;
   admin: `0x${string}`;
 };
 

--- a/templates/preorder/packages/tests/run-tests.ts
+++ b/templates/preorder/packages/tests/run-tests.ts
@@ -250,6 +250,14 @@ async function test() {
     const { frontendE2eTest } = await import("./frontend/e2e.test.ts");
     await frontendE2eTest();
 
+    // ── Phase F: Admin post-sale NFT minting ────────────────────────────
+    // Runs last: it ends the campaign + mints via the batcher, which would
+    // otherwise break the purchase-dependent phases above.
+    console.log("\n--- Phase F: Admin NFT Minting ---\n");
+
+    const { adminMintTest } = await import("./stm/admin-mint.test.ts");
+    await adminMintTest(db);
+
     printSummary();
   } catch (e) {
     printSummary();

--- a/templates/preorder/packages/tests/start.test.ts
+++ b/templates/preorder/packages/tests/start.test.ts
@@ -54,6 +54,17 @@ export default {
     },
 
     {
+      name: "batcher",
+      description: "NFT mint batcher",
+      args: ["run", "packages/batcher/batcher.dev.ts"],
+      cwd: root,
+      waitToExit: false,
+      type: "system-dependency",
+      stopProcessAtPort: [3334],
+      dependsOn: [EvmNames.GENERATE_MOD],
+    },
+
+    {
       name: "frontend-dev",
       description: "Vite dev server for E2E tests",
       args: ["x", "vite", "--port", "10598", "--mode", "dev"],

--- a/templates/preorder/packages/tests/stm/admin-mint.test.ts
+++ b/templates/preorder/packages/tests/stm/admin-mint.test.ts
@@ -1,0 +1,142 @@
+// Post-sale NFT minting: end-campaign -> mint-nfts (admin, on-chain via EffectstreamL2)
+// -> STM enqueues nft_mints -> nft-dispatch worker submits to the batcher -> batcher mints
+// PreorderItemNft to each buyer. Verifies the gate (non-admin / not-ended rejected), the
+// enqueue, the on-chain mint, and the API. Runs LAST in Phase B (it ends the campaign).
+import { assert, assertSQL, getDeployedAddresses, mineBlock } from "../helpers.ts";
+import type { Client } from "pg";
+import { createPublicClient, createWalletClient, http, parseAbi, toHex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { foundry } from "viem/chains";
+
+const L2_ABI = parseAbi(["function effectstreamSubmitGameInput(bytes data) payable"]);
+const NFT_ABI = parseAbi(["function ownerOf(uint256 tokenId) view returns (address)"]);
+
+// Account #0 is the configured admin (deployer) in PR #753.
+const ADMIN_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+// Account #2 — a non-admin.
+const NON_ADMIN_KEY = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
+
+const SLUG = "test-launchpad-1";
+const RPC = "http://localhost:8545";
+const API = `http://localhost:${process.env["EFFECTSTREAM_API_PORT"] || "9999"}`;
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function adminMintTest(db: Client) {
+  const addresses = getDeployedAddresses();
+  if (!addresses?.effectStreamL2 || !addresses?.itemNft) {
+    console.log("Warning: missing effectStreamL2/itemNft addresses, skipping admin-mint test");
+    return;
+  }
+  const pub = createPublicClient({ chain: foundry, transport: http(RPC) });
+  const adminW = createWalletClient({ account: privateKeyToAccount(ADMIN_KEY), chain: foundry, transport: http(RPC) });
+  const nonAdminW = createWalletClient({ account: privateKeyToAccount(NON_ADMIN_KEY), chain: foundry, transport: http(RPC) });
+
+  const submit = async (wallet: typeof adminW, concise: unknown[]) => {
+    const hash = await wallet.writeContract({
+      address: addresses.effectStreamL2!,
+      abi: L2_ABI,
+      functionName: "effectstreamSubmitGameInput",
+      args: [toHex(JSON.stringify(concise))],
+    });
+    await pub.waitForTransactionReceipt({ hash });
+    await mineBlock();
+  };
+
+  // ── Negative: non-admin cannot enqueue mints ──────────────────────────
+  await submit(nonAdminW, ["mint-nfts", SLUG]);
+  await delay(6000);
+  await assert("admin-mint: non-admin enqueues nothing", async () => {
+    const r = await db.query("SELECT COUNT(*)::int AS c FROM nft_mints");
+    return Number(r.rows[0].c) === 0;
+  });
+
+  // ── Negative: admin cannot mint while the campaign is still active ─────
+  await submit(adminW, ["mint-nfts", SLUG]);
+  await delay(6000);
+  await assert("admin-mint: rejected while campaign active", async () => {
+    const r = await db.query("SELECT COUNT(*)::int AS c FROM nft_mints");
+    return Number(r.rows[0].c) === 0;
+  });
+
+  // ── End the campaign ──────────────────────────────────────────────────
+  await submit(adminW, ["end-campaign", SLUG]);
+  await assertSQL(
+    "admin-mint: campaign ended",
+    db,
+    `SELECT status FROM offchain_campaigns WHERE slug = '${SLUG}'`,
+    (rows) => rows.length > 0 && (rows[0] as any).status === "ended",
+    (rows) => (rows[0] as any).status === "ended",
+  );
+
+  // ── Positive: admin enqueues mints ────────────────────────────────────
+  await submit(adminW, ["mint-nfts", SLUG]);
+  await assertSQL(
+    "admin-mint: EVM mint jobs enqueued",
+    db,
+    `SELECT * FROM nft_mints WHERE chain = 'evm'`,
+    (rows) => rows.length > 0,
+    (rows) => rows.length > 0,
+  );
+
+  // ── Worker -> batcher mints the NFTs ──────────────────────────────────
+  const minted = await assertSQL(
+    "admin-mint: NFTs minted via batcher",
+    db,
+    `SELECT * FROM minted_nfts WHERE chain = 'evm' ORDER BY token_id`,
+    (rows) => rows.length > 0,
+    (rows) => (rows as any[]).every((r) => r.tx_hash && r.token_id),
+  );
+
+  await assertSQL(
+    "admin-mint: EVM jobs resolve (minted, none failed)",
+    db,
+    `SELECT status, COUNT(*)::int AS c FROM nft_mints WHERE chain = 'evm' GROUP BY status`,
+    (rows) => (rows as any[]).some((r) => r.status === "minted"),
+    (rows) => !(rows as any[]).some((r) => r.status === "failed"),
+  );
+
+  // ── On-chain ownership reflects the mint ──────────────────────────────
+  await assert("admin-mint: buyer owns minted NFT on-chain", async () => {
+    const row = minted[0] as any;
+    const owner = (await pub.readContract({
+      address: addresses.itemNft!,
+      abi: NFT_ABI,
+      functionName: "ownerOf",
+      args: [BigInt(row.token_id)],
+    })) as string;
+    return owner.toLowerCase() === String(row.wallet).toLowerCase();
+  });
+
+  // ── API ───────────────────────────────────────────────────────────────
+  await assert("admin-mint: /api/nfts returns buyer NFTs", async () => {
+    const row = minted[0] as any;
+    const res = await fetch(`${API}/api/nfts/${SLUG}?wallet=${row.wallet}`);
+    const body = await res.json();
+    return res.ok && Array.isArray(body.nfts) && body.nfts.length > 0;
+  });
+
+  await assert("admin-mint: /api/admin/status reports nft mints", async () => {
+    const res = await fetch(`${API}/api/admin/status/${SLUG}`);
+    const body = await res.json();
+    return res.ok && (body.nftMintSummary?.minted ?? 0) > 0;
+  });
+
+  // ── Cardano (Phase B): the worker routes cardano jobs to the batcher's Cardano adapter,
+  //    which mints a native-policy NFT and delivers it to the buyer. Slower than EVM (the
+  //    first mint funds a fresh server wallet via the faucet), so poll with a long deadline.
+  await assert("admin-mint: Cardano NFTs minted via batcher", async () => {
+    const start = Date.now();
+    while (Date.now() - start < 240_000) {
+      const r = await db.query("SELECT COUNT(*)::int AS c FROM minted_nfts WHERE chain = 'cardano'");
+      if (Number(r.rows[0].c) > 0) return true;
+      const f = await db.query("SELECT COUNT(*)::int AS c FROM nft_mints WHERE chain = 'cardano' AND status = 'failed'");
+      if (Number(f.rows[0].c) > 0) {
+        const e = await db.query("SELECT error FROM nft_mints WHERE chain = 'cardano' AND status = 'failed' LIMIT 1");
+        console.error("[admin-mint] cardano mint failed:", e.rows[0]?.error);
+        return false;
+      }
+      await delay(3000);
+    }
+    return false;
+  });
+}

--- a/templates/preorder/packages/tests/stm/admin-mint.test.ts
+++ b/templates/preorder/packages/tests/stm/admin-mint.test.ts
@@ -7,6 +7,7 @@ import type { Client } from "pg";
 import { createPublicClient, createWalletClient, http, parseAbi, toHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { foundry } from "viem/chains";
+import { createFreshLucid, buyItemsCardano } from "@preorder/contracts-cardano/helpers";
 
 const L2_ABI = parseAbi(["function effectstreamSubmitGameInput(bytes data) payable"]);
 const NFT_ABI = parseAbi(["function ownerOf(uint256 tokenId) view returns (address)"]);
@@ -41,6 +42,32 @@ export async function adminMintTest(db: Client) {
     await pub.waitForTransactionReceipt({ hash });
     await mineBlock();
   };
+
+  // Multi-item Cardano buyer to exercise the SERIAL multi-mint path (the case that looked
+  // stuck in manual testing): buy 3 items so admin-mint enqueues 3 Cardano jobs for one buyer.
+  let cardanoBuyerPkh = "";
+  try {
+    const { lucid } = await createFreshLucid();
+    const lp = await (await fetch(`${API}/api/launchpad/${SLUG}`)).json();
+    const ids = [1, 2, 3];
+    const cost = ids.reduce(
+      (s: bigint, id: number) => s + BigInt(lp.items.find((i: any) => i.id === id).amounts.ada),
+      0n,
+    );
+    const { buyerPkh } = await buyItemsCardano(lucid, ids.map((id) => [id, 1] as [number, number]), cost);
+    cardanoBuyerPkh = buyerPkh.toLowerCase();
+  } catch (e) {
+    console.log("[admin-mint] multi-item cardano purchase setup failed:", e);
+  }
+  if (cardanoBuyerPkh) {
+    await assertSQL(
+      "admin-mint: multi-item Cardano purchase ingested",
+      db,
+      `SELECT item_id FROM launchpad_user_items WHERE wallet = '${cardanoBuyerPkh}'`,
+      (rows) => rows.length >= 3,
+      (rows) => rows.length >= 3,
+    );
+  }
 
   // ── Negative: non-admin cannot enqueue mints ──────────────────────────
   await submit(nonAdminW, ["mint-nfts", SLUG]);
@@ -121,22 +148,27 @@ export async function adminMintTest(db: Client) {
     return res.ok && (body.nftMintSummary?.minted ?? 0) > 0;
   });
 
-  // ── Cardano (Phase B): the worker routes cardano jobs to the batcher's Cardano adapter,
-  //    which mints a native-policy NFT and delivers it to the buyer. Slower than EVM (the
-  //    first mint funds a fresh server wallet via the faucet), so poll with a long deadline.
-  await assert("admin-mint: Cardano NFTs minted via batcher", async () => {
+  // ── Cardano: the worker routes cardano jobs to the batcher's Cardano adapter, which mints a
+  //    native-policy NFT and delivers it to the buyer. Mints are SERIAL and the first funds a
+  //    fresh server wallet via the faucet, so allow a long deadline. Assert ALL cardano jobs
+  //    settle to 'minted' (catches a partial stall — a job stuck pending/submitted, or failed).
+  await assert("admin-mint: all Cardano NFTs minted via batcher", async () => {
     const start = Date.now();
-    while (Date.now() - start < 240_000) {
-      const r = await db.query("SELECT COUNT(*)::int AS c FROM minted_nfts WHERE chain = 'cardano'");
-      if (Number(r.rows[0].c) > 0) return true;
-      const f = await db.query("SELECT COUNT(*)::int AS c FROM nft_mints WHERE chain = 'cardano' AND status = 'failed'");
-      if (Number(f.rows[0].c) > 0) {
-        const e = await db.query("SELECT error FROM nft_mints WHERE chain = 'cardano' AND status = 'failed' LIMIT 1");
-        console.error("[admin-mint] cardano mint failed:", e.rows[0]?.error);
+    while (Date.now() - start < 300_000) {
+      const r = await db.query("SELECT status, COUNT(*)::int AS c FROM nft_mints WHERE chain = 'cardano' GROUP BY status");
+      const by: Record<string, number> = {};
+      for (const row of r.rows) by[row.status] = Number(row.c);
+      if ((by.failed ?? 0) > 0) {
+        const e = await db.query("SELECT wallet, item_id, error FROM nft_mints WHERE chain = 'cardano' AND status = 'failed' LIMIT 1");
+        console.error("[admin-mint] cardano mint failed:", JSON.stringify(e.rows[0]));
         return false;
       }
+      const total = Object.values(by).reduce((a, b) => a + b, 0);
+      if (total > 0 && (by.minted ?? 0) === total) return true; // every cardano job settled to minted
       await delay(3000);
     }
+    const pend = await db.query("SELECT status, COUNT(*)::int AS c FROM nft_mints WHERE chain = 'cardano' GROUP BY status");
+    console.error("[admin-mint] cardano jobs did not all settle:", JSON.stringify(pend.rows));
     return false;
   });
 

--- a/templates/preorder/packages/tests/stm/admin-mint.test.ts
+++ b/templates/preorder/packages/tests/stm/admin-mint.test.ts
@@ -139,4 +139,15 @@ export async function adminMintTest(db: Client) {
     }
     return false;
   });
+
+  // The Cardano buyer is recorded by payment-key-hash; confirm /api/nfts returns their NFTs by
+  // that pkh (the lookup the buyer "My Purchases" view uses for Cardano).
+  await assert("admin-mint: /api/nfts returns Cardano buyer NFTs (by pkh)", async () => {
+    const r = await db.query("SELECT wallet FROM minted_nfts WHERE chain = 'cardano' LIMIT 1");
+    const pkh = r.rows[0]?.wallet;
+    if (!pkh) return false;
+    const res = await fetch(`${API}/api/nfts/${SLUG}?wallet=${pkh}`);
+    const body = await res.json();
+    return res.ok && Array.isArray(body.nfts) && body.nfts.some((n: any) => n.chain === "cardano");
+  });
 }

--- a/templates/preorder/start.dev.ts
+++ b/templates/preorder/start.dev.ts
@@ -56,6 +56,19 @@ export default {
     },
 
     {
+      // Holds funds + signs the post-sale NFT mints. The sync node's nft-dispatch
+      // worker POSTs mint jobs to it; it calls PreorderItemNft.mint(buyer) on-chain.
+      name: "batcher",
+      description: "NFT mint batcher",
+      args: ["run", "packages/batcher/batcher.dev.ts"],
+      waitToExit: false,
+      type: "system-dependency",
+      link: "http://localhost:3334",
+      stopProcessAtPort: [3334],
+      dependsOn: [EvmNames.GENERATE_MOD],
+    },
+
+    {
       name: "frontend-build",
       description: "Build frontend",
       cwd: path.join(root, "packages/frontend"),


### PR DESCRIPTION
## Summary

Adds an admin **post-sale NFT minting** flow to the `preorder` template: after a campaign ends, the admin mints an item NFT to every buyer for each item they own — on **both EVM and Cardano** — executed by the **batcher** (which holds funds, queues, signs, and submits).

> **Stacked on #753.** This PR targets `feat/preorder-admin-cardano-validator-referrals` so the diff is only the NFT-minting delta. It builds on #753's deterministic admin/config (`EffectstreamL2` + `isAdmin` STM gating), unified `payments`, and `/admin` page. Rebase onto `v-next` once #753 merges.

## How it works

```
/admin "Mint item NFTs" → effectstreamSubmitGameInput(["mint-nfts", slug])
  → EVM:EffectstreamL2 primitive → STM `mint-nfts` (isAdmin + campaign ended)
      → enqueues nft_mints from valid payments / launchpad_user_items
  → nft-dispatch worker (effection task, holds NO keys) POSTs each job to the batcher
      → EvmContractAdapter   → PreorderItemNft.mint(buyer)      (EVM)
      → CardanoMintAdapter    → native-policy mint + deliver      (Cardano)
  → records minted_nfts → /admin status table + /api/nfts
```

The node never holds mint keys; the batcher account does the on-chain work.

## What's included

- **Contract**: `PreorderItemNft.sol` (PRC-3 `InverseAppProjectedNft`) + Ignition module + `deploy.ts`/`addresses.ts` wiring (`itemNft`).
- **DB**: migration `004-nft-mints.sql` (`nft_mints`, `minted_nfts`) + queries (`getMintableItems`, `insertNftMint`).
- **STM**: `mint-nfts` admin command — `isAdmin`-gated, requires campaign `ended`, idempotent enqueue per `(chain, buyer, item)`.
- **Batcher** (`packages/batcher`): `batcher.dev.ts` + `EvmContractAdapter`, a new **`CardanoMintAdapter`** (no Cardano adapter ships in the SDK), and a `TrustedAdapter` wrapper so the batcher accepts internal unsigned node jobs. Wired as a process into `start.dev.ts` / `start.test.ts` (port 3334).
- **Worker**: `nft-dispatch.ts` — drains `nft_mints`, submits to the batcher (`wait-receipt`), records results. EVM-first ordering so the slow first Cardano faucet top-up doesn't stall EVM mints.
- **UI/API**: "Post-sale NFT minting" section in `/admin` (`Mint item NFTs`, status table), `mintNfts()` in `admin-wallet`, `nftMints` in `/api/admin/status`, new `/api/nfts`.
- **Tests** (`stm/admin-mint.test.ts`, Phase F): rejects non-admin / not-ended; enqueues; EVM mint via batcher + on-chain `ownerOf`; API; Cardano delivery.

## Notes / implementation details

- `EvmContractAdapter` `maxBatchSize` is a **byte** budget (not a count) — left at default; one-input-per-batch is guaranteed by the worker submitting serially.
- Cardano buyers are recorded by payment-key-hash; the adapter derives a deliverable enterprise address via `credentialToAddress`.

## Tests

**Full e2e: 56 passed / 0 failed** — `cd templates/preorder && bun run test` (the #753 suite + 10 new admin-mint assertions, EVM + Cardano mints confirmed on-chain).