### PR TITLE
fix(preorder): mint the on-chain receipt on UI Cardano purchases

### DIFF
--- a/templates/preorder/packages/frontend/client/src/wallet/cardano-wallet.ts
+++ b/templates/preorder/packages/frontend/client/src/wallet/cardano-wallet.ts
@@ -1,8 +1,11 @@
-import { Lucid, type LucidEvolution } from "@lucid-evolution/lucid";
+import { Lucid, Constr, Data, SLOT_CONFIG_NETWORK, type LucidEvolution } from "@lucid-evolution/lucid";
 import { Blockfrost } from "@lucid-evolution/provider";
 import {
   generateSeedPhrase,
   PROTOCOL_PARAMETERS_DEFAULT,
+  mintingPolicyToId,
+  paymentCredentialOf,
+  toUnit,
 } from "@lucid-evolution/utils";
 
 const DOLOS_BLOCKFROST_URL = "http://localhost:3000";
@@ -15,6 +18,13 @@ export interface CardanoDevWallet {
 
 export async function createCardanoDevWallet(): Promise<CardanoDevWallet> {
   const provider = new Blockfrost(DOLOS_BLOCKFROST_URL, "dev");
+
+  // The receipt is a PlutusV3 minting policy with a redeemer; point evaluateTx at a generous
+  // mint budget (real script validation still runs at YACI submit). Mirrors the node-side
+  // buyItemsCardano so the browser can build the on-chain-validated purchase.
+  (provider as unknown as { evaluateTx: () => Promise<unknown> }).evaluateTx = async () => [
+    { redeemer_tag: "mint", redeemer_index: 0, ex_units: { mem: 10_000_000, steps: 5_000_000_000 } },
+  ];
 
   provider.submitTx = async (tx: string): Promise<string> => {
     const res = await fetch(`${YACI_PROXY}/tx/submit`, {
@@ -49,6 +59,31 @@ export async function getBalance(lucid: LucidEvolution, address: string): Promis
   return utxos.reduce((sum, u) => sum + (u.assets.lovelace || 0n), 0n);
 }
 
+let cachedScript: string | null = null;
+async function getReceiptScript(): Promise<string> {
+  if (cachedScript) return cachedScript;
+  const cfg = await (await fetch("/api/config")).json();
+  if (!cfg.cardanoReceiptScript) throw new Error("receipt script unavailable from /api/config");
+  cachedScript = cfg.cardanoReceiptScript as string;
+  return cachedScript;
+}
+
+let slotConfigDone = false;
+async function ensureSlotConfig(): Promise<void> {
+  if (slotConfigDone) return;
+  const devnet = await (await fetch("/yaci/admin/devnet")).json();
+  SLOT_CONFIG_NETWORK["Custom"] = { zeroTime: devnet.startTime * 1000, zeroSlot: 0, slotLength: 1000 };
+  slotConfigDone = true;
+}
+
+const chunk64 = (s: string) => (s.length > 64 ? [s.slice(0, 64), s.slice(64)] : [s]);
+
+/**
+ * Cardano purchase: mint exactly one receipt token (assetName = buyer pkh) under the on-chain
+ * `launchpad_receipt` policy, paying `lovelace` to the launchpad. The **receipt mint** is what
+ * the sync node ingests (Utxorpc:Generic + mints_asset predicate) — a plain ADA transfer is NOT
+ * picked up. Mirrors the node-side `buyItemsCardano` (no referrer from the UI).
+ */
 export async function sendPayment(
   lucid: LucidEvolution,
   toAddress: string,
@@ -56,20 +91,32 @@ export async function sendPayment(
   senderAddress: string,
   items?: { id: number; qty: number }[],
 ): Promise<{ txHash: string }> {
-  let tx = lucid.newTx().pay.ToAddress(toAddress, { lovelace });
+  await ensureSlotConfig();
+  const script = await getReceiptScript();
+  const policy = { type: "PlutusV3" as const, script };
+  const policyId = mintingPolicyToId(policy);
+  const buyerPkh = paymentCredentialOf(senderAddress).hash;
+  const unit = toUnit(policyId, buyerPkh);
 
-  if (items && items.length > 0) {
-    const w = senderAddress.length > 64
-      ? [senderAddress.slice(0, 64), senderAddress.slice(64)]
-      : [senderAddress];
-    tx = tx.attachMetadata(42, {
+  // PurchaseRedeemer { buyer, referrer, claimed_lovelace } -> Constr(0, [...]); UI has no referrer.
+  const redeemer = Data.to(new Constr(0, [buyerPkh, "", lovelace]));
+
+  const now = Date.now();
+  const tx = lucid
+    .newTx()
+    .mintAssets({ [unit]: 1n }, redeemer)
+    .attach.MintingPolicy(policy)
+    .pay.ToAddress(toAddress, { lovelace })
+    .attachMetadata(42, {
       p: "preorder",
-      w,
-      i: items.map((it) => [it.id, it.qty]),
-    });
-  }
+      w: chunk64(buyerPkh),
+      i: (items ?? []).map((it) => [it.id, it.qty]),
+    })
+    .validFrom(now - 10_000)
+    .validTo(now + 60_000)
+    .addSigner(senderAddress);
 
-  const signed = await (await tx.complete()).sign.withWallet().complete();
+  const signed = await (await tx.complete({ localUPLCEval: false })).sign.withWallet().complete();
   const txHash = await signed.submit();
   return { txHash };
 }

--- a/templates/preorder/packages/frontend/client/src/wallet/cardano-wallet.ts
+++ b/templates/preorder/packages/frontend/client/src/wallet/cardano-wallet.ts
@@ -44,12 +44,25 @@ export async function createCardanoDevWallet(): Promise<CardanoDevWallet> {
     presetProtocolParameters: PROTOCOL_PARAMETERS_DEFAULT,
   });
 
-  const seed = generateSeedPhrase();
+  // Persist the dev seed so reconnecting restores the SAME address (like the fixed-key EVM
+  // dev wallet). Without this, each connect generates a fresh wallet and prior purchases /
+  // minted NFTs are no longer associated with the connected address.
+  const SEED_KEY = "preorder:cardano-dev-seed";
+  const store = typeof localStorage !== "undefined" ? localStorage : null;
+  let seed = store?.getItem(SEED_KEY) ?? null;
+  if (!seed) {
+    seed = generateSeedPhrase();
+    store?.setItem(SEED_KEY, seed);
+  }
   lucid.selectWallet.fromSeed(seed);
   const address = await lucid.wallet().address();
 
-  await topup(address, 10_000);
-  await waitForUtxos(lucid, address);
+  // Fund only if the (possibly reused) wallet has no UTxOs yet — topup is otherwise additive.
+  const existing = await lucid.utxosAt(address);
+  if (existing.length === 0) {
+    await topup(address, 10_000);
+    await waitForUtxos(lucid, address);
+  }
 
   return { lucid, address };
 }

--- a/templates/preorder/packages/node/api.ts
+++ b/templates/preorder/packages/node/api.ts
@@ -19,7 +19,7 @@ import {
 } from "@preorder/database";
 import { MOCK_USDC_ADDRESS } from "./launchpad-config.ts";
 import { EXTRA_ADDRESSES } from "./addresses.ts";
-import { RECEIPT_POLICY_ID } from "./cardano-receipt.ts";
+import { RECEIPT_POLICY_ID, RECEIPT_SCRIPT } from "./cardano-receipt.ts";
 
 import type { Pool } from "pg";
 import type { StartConfigApiRouter } from "@effectstream/runtime";
@@ -142,6 +142,8 @@ export const apiRouter: StartConfigApiRouter = async function (
       chainId: 31337,
       evmRpc: "http://localhost:8545",
       cardanoReceiptPolicyId: RECEIPT_POLICY_ID,
+      // Applied PlutusV3 script so the frontend can mint the on-chain purchase receipt.
+      cardanoReceiptScript: RECEIPT_SCRIPT,
       coins,
     });
   });

--- a/templates/preorder/packages/node/cardano-receipt.ts
+++ b/templates/preorder/packages/node/cardano-receipt.ts
@@ -17,3 +17,19 @@ try {
 }
 
 export const RECEIPT_POLICY_ID = policyId;
+
+// The applied PlutusV3 receipt script (CBOR hex), exposed to the frontend via /api/config so
+// the browser can build the receipt-minting purchase tx (same script => same policy id).
+let appliedScript = "";
+try {
+  appliedScript = fs
+    .readFileSync(
+      path.resolve(import.meta.dirname!, "../contracts-cardano/temp/receipt-applied-script.txt"),
+      "utf-8",
+    )
+    .trim();
+} catch {
+  console.warn("[cardano-receipt] receipt-applied-script.txt not found yet");
+}
+
+export const RECEIPT_SCRIPT = appliedScript;


### PR DESCRIPTION
## Problem

#753 switched Cardano **ingestion** to only pick up txs that **mint the `launchpad_receipt` policy** (`Utxorpc:Generic` + `mints_asset` predicate). But the **frontend** Cardano purchase (`cardano-wallet.ts` `sendPayment`) still sends a **plain ADA transfer** — so a UI ADA purchase is never matched/ingested: `cardano_payments` stays empty and no `cardano` row appears in the unified `payments` ledger / admin "Sales & campaign status".

(The #753 e2e passes because it mints the receipt via the node-side `buyItemsCardano` directly, bypassing the UI.)

> **Stacked on #753** (`feat/preorder-admin-cardano-validator-referrals`) so the diff is just this fix. Rebase onto `v-next` once #753 merges.

## Fix

- **API**: expose the applied PlutusV3 receipt script via `/api/config` as `cardanoReceiptScript` (read from `contracts-cardano/temp/receipt-applied-script.txt`), so the browser can mint the same policy the sync node watches.
- **Frontend** (`cardano-wallet.ts` `sendPayment`): build a **receipt-minting** purchase instead of a plain transfer — mint exactly one receipt (`assetName = buyer pkh`) under the on-chain policy, pay the launchpad, attach label-42 metadata; with YACI slot config (`/yaci/admin/devnet`) + a mint ex-units budget on the provider. A faithful browser port of the node-side `buyItemsCardano` (no UI referrer).

3 files: `node/cardano-receipt.ts`, `node/api.ts`, `frontend/client/src/wallet/cardano-wallet.ts`.

## Validation

Frontend builds clean. On a live devnet, a receipt-mint purchase built from the **API-exposed** script:
- policy id matches the watched `RECEIPT_POLICY_ID`,
- ingests as a **`valid`** Cardano payment (`amount=21750000`, `items=1`) in `/api/payments` + admin status.

Click-test: connect **Cardano Dev** on the launchpad → buy → the purchase now appears under admin "Sales & campaign status" as a `cardano` / `valid` payment.