### PR TITLE
fix(wallets-ui): make `bun run build` work on a fresh checkout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4108,6 +4108,8 @@
 
     "@e2e/engine/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
 
+    "@e2e/evm-contracts/@effectstream/evm-contracts": ["@effectstream/evm-contracts@file:packages/chains/evm-contracts", { "dependencies": { "@nomicfoundation/hardhat-ignition": "3.0.2", "@nomicfoundation/hardhat-ignition-viem": "3.0.2", "@nomicfoundation/hardhat-viem": "3.0.0", "@opentelemetry/sdk-node": "0.56.0", "@openzeppelin/contracts": "5.1.0", "@openzeppelin/contracts-upgradeable": "^5.1.0", "@wagmi/cli": "2.3.1", "hardhat": "3.0.4", "jsonc-parser": "^3.3.1" } }],
+
     "@e2e/wallets-ui/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@effectstream/batcher-sdk/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],

--- a/e2e/wallets-ui/README.md
+++ b/e2e/wallets-ui/README.md
@@ -15,6 +15,22 @@ a runtime `ReferenceError` / `null is not an object` during module load.
 That's the entire value proposition. No wallet flow is automated — see
 the manual matrix below.
 
+## Prerequisite: compile the Midnight contracts
+
+The client statically imports the generated (`gitignore`d) `src/managed/`
+output of the two Midnight contracts, so on a fresh checkout compile them
+once before building (requires the `compact` CLI):
+
+```bash
+cd e2e/shared/contracts/midnight/contract-counter && bun run compact
+cd ../contract-eip-20 && bun run compact
+```
+
+The deployed-contract address file (`contract-counter.undeployed.json`,
+written by `midnight-contract:deploy` against a live local node) is
+optional: without it the build still succeeds and only the Midnight
+counter flow fails at runtime when fetching the address.
+
 ## Automated: build + start smoke
 
 `run-tests.ts` is wired into the `wallets` suite in `e2e/runner.ts`.

--- a/e2e/wallets-ui/package.json
+++ b/e2e/wallets-ui/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "server:start": "bun --watch ./server/main.ts",
     "serve": "bun run build && bun run server:start"
   },

--- a/e2e/wallets-ui/vite.config.ts
+++ b/e2e/wallets-ui/vite.config.ts
@@ -22,6 +22,22 @@ const utilsPath = join(projectRoot, "../../packages/effectstream-sdk/utils/");
 const midnightContractEip20Path = join(projectRoot, "../shared/contracts/midnight/contract-eip-20/src/managed/contract/");
 const midnightContractCounterBasicPath = join(projectRoot, "../shared/contracts/midnight/contract-counter/src/managed/contract/");
 
+// The client statically imports the gitignored `src/managed/` output of the
+// Midnight contracts. Fail fast with instructions instead of letting rollup
+// die later with a cryptic "Could not resolve ./managed/contract/index.js".
+for (const [name, managedPath] of [
+  ["contract-counter", midnightContractCounterBasicPath],
+  ["contract-eip-20", midnightContractEip20Path],
+] as const) {
+  if (!existsSync(managedPath)) {
+    throw new Error(
+      `Missing generated Midnight contract artifacts for ${name}.\n` +
+        `Compile them first (requires the \`compact\` CLI):\n\n` +
+        `  cd e2e/shared/contracts/midnight/${name} && bun run compact\n`,
+    );
+  }
+}
+
 // Browser-safe config — the real @e2e/data-types/config-localhost reads
 // the filesystem at module load which crashes in the browser.
 const browserConfigPath = join(projectRoot, "config-browser.ts");

--- a/e2e/wallets-ui/vite.config.ts
+++ b/e2e/wallets-ui/vite.config.ts
@@ -5,6 +5,7 @@ import "react";
 import "react-dom";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { existsSync } from "node:fs";
 import wasm from "vite-plugin-wasm";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
@@ -71,11 +72,19 @@ export default defineConfig({
     nodePolyfills(),
     viteStaticCopy({
       targets: [
-        {
-          src: join(projectRoot, "../shared/contracts/midnight/contract-counter.undeployed.json"),
-          dest: "contract_address",
-          rename: "counter.undeployed.json",
-        },
+        // The deployed-contract address only exists after
+        // `midnight-contract:deploy` against a live local node; the build
+        // smoke must work without it (the Midnight counter flow fails its
+        // runtime fetch with a clear error instead).
+        ...(existsSync(join(projectRoot, "../shared/contracts/midnight/contract-counter.undeployed.json"))
+          ? [
+              {
+                src: join(projectRoot, "../shared/contracts/midnight/contract-counter.undeployed.json"),
+                dest: "contract_address",
+                rename: "counter.undeployed.json",
+              },
+            ]
+          : []),
         {
           src: join(projectRoot, "../shared/contracts/midnight/contract-counter/src/managed/keys/*"),
           dest: "keys",


### PR DESCRIPTION
## Problem

`cd e2e/wallets-ui && bun i && bun run build` fails on a fresh checkout for three stacked reasons:

1. **Missing generated contract code** — the client statically imports the gitignored `src/managed/` output of the two Midnight contracts, and rollup dies with a cryptic `Could not resolve "./managed/contract/index.js"`. Compiling them is a real prerequisite (`bun run compact` needs the `compact` CLI and a live toolchain), so the build now **fails fast with instructions** instead of bundling it in.
2. **Node heap OOM** — once the contracts compile, `vite build` dies with SIGABRT (V8 out of memory). `run-tests.ts` already bumps `NODE_OPTIONS` for exactly this reason, but the package's own `build` script didn't, so manual builds crashed.
3. **Hard failure on a deploy-time artifact** — `vite-plugin-static-copy` aborts the build because `contract-counter.undeployed.json` is missing. That file is only written by `midnight-contract:deploy` against a live local Midnight node, yet the README states the build smoke needs no live chain, and the app already handles its absence at runtime with a clear fetch error.

## Changes

- `vite.config.ts`: preflight check — if either contract's `src/managed/` is missing, the build exits immediately with:

  ```
  Error: Missing generated Midnight contract artifacts for contract-counter.
  Compile them first (requires the `compact` CLI):

    cd e2e/shared/contracts/midnight/contract-counter && bun run compact
  ```
- `vite.config.ts`: the `contract-counter.undeployed.json` copy target is skipped when the file doesn't exist, so only the Midnight counter flow degrades at runtime instead of the whole build failing.
- `package.json`: `build` now runs `NODE_OPTIONS=--max-old-space-size=8192 vite build`, matching `run-tests.ts`.
- `README.md`: documents the compact-compile prerequisite and the optional deploy artifact.
- `bun.lock`: lockfile sync from `bun i`.

## Verification

- With `src/managed/` absent: build exits immediately with the instruction message above (verified by temporarily moving the directory away).
- With artifacts present and no `undeployed.json`: `bun run build` completes in ~20s (`✓ built in 20.16s`). Pre-existing build warnings (eval in polyfills, mixed static/dynamic Midnight WASM imports) are unchanged.