### PR TITLE
feat(zswap-da): offer validation — ingestion + pre-fee gates with spent-set liveness

### DIFF
--- a/templates/zswap-da/README.md
+++ b/templates/zswap-da/README.md
@@ -68,6 +68,7 @@ zswap-da/
 ├── packages/
 │   ├── node/                                 # @zswap-da/node
 │   ├── database/                             # @zswap-da/database
+│   ├── validator/                            # @zswap-da/validator (shared offer validation)
 │   ├── batcher/                              # @zswap-da/batcher
 │   ├── contracts-midnight/                   # @zswap-da/contracts-midnight (+ contract-offer-files subworkspace)
 │   ├── contracts-celestia/                   # @zswap-da/contracts-celestia (bridge + fund scripts)
@@ -80,8 +81,9 @@ zswap-da/
 | Package | Files |
 |---------|-------|
 | `node/` | `main.{dev,mainnet}.ts`, `config.{dev,mainnet}.ts`, `env.ts` (env-derived constants), `grammar.ts`, `state-machine.ts`, `api.ts`, `zswap-logic.ts`, `batcher-client.ts`, `event-bus.ts` |
-| `database/` | `mod.ts` (re-exports), `migration-order.ts`, `migrations/000-init.sql`, `sql/queries.sql` (+ generated `queries.queries.ts`) |
-| `batcher/` | `batcher.{dev,mainnet}.ts`, `config.ts`, `midnight-balancing.ts`, `celestia.ts` (adapter factories) |
+| `database/` | `mod.ts` (re-exports), `migration-order.ts`, `migrations/000-init.sql`, `migrations/001-spent-sets.sql` (permanent `spent_nullifiers` / `spent_unshielded` liveness sets), `sql/queries.sql` (+ generated `queries.queries.ts`) |
+| `validator/` | `validate.ts` (pipeline), `derive.ts`, `refstate.ts`, `types.ts`, `README.md`, `scripts/check-preview-indexer.ts` |
+| `batcher/` | `batcher.{dev,mainnet}.ts`, `config.ts`, `midnight-balancing.ts`, `celestia.ts` (`ZswapCelestiaAdapter.validateInput` — pre-fee offer gate) |
 | `contracts-midnight/` | `package.json` (scripts for `launchMidnight`), `deploy.ts`, `contract-offer-files/` (Compact source + compiled output) |
 | `contracts-celestia/` | `package.json` (`celestia-{node,bridge,fund}:*` scripts), `fund-bridge.ts` |
 | `tests/` | `run-tests.ts`, `start.test.ts` (test orchestrator), `helpers.ts`, `infra/{celestia,midnight}-ready.test.ts`, `stm/{zswap-flow,api}.test.ts` |
@@ -105,10 +107,10 @@ zswap-da/
 
 | Key | Source | Purpose |
 |-----|--------|---------|
-| `celestia-zswap` | Celestia DA primitive | Index a published swap-offer blob (extract gives/wants, nullifiers, unshielded spends; schedule TTL cleanup). |
+| `celestia-zswap` | Celestia DA primitive | Validate a published offer blob (structure + ZK proofs + spent-set liveness), then index it (gives/wants, nullifiers, unshielded spends; schedule TTL cleanup) or drop + emit `offer_rejected`. |
 | `midnight-zswap` | Midnight ledger primitive | Snapshot contract state. |
-| `midnight-nullifier` | Midnight nullifier primitive | Archive an offer when its shielded nullifier is consumed on chain. |
-| `midnight-unshielded-spend` | Midnight unshielded-spend primitive | Archive an offer when an unshielded UTXO it referenced is spent. |
+| `midnight-nullifier` | Midnight nullifier primitive | Record the nullifier in `spent_nullifiers` (liveness) and archive any offer whose shielded nullifier is consumed on chain. |
+| `midnight-unshielded-spend` | Midnight unshielded-spend primitive | Record the UTXO in `spent_unshielded` (liveness) and archive any offer whose unshielded UTXO is spent. |
 | `zswap-ttl-cleanup` | Scheduled timestamp data | Archive offers whose TTL elapsed without on-chain consumption. |
 
 ## API
@@ -119,8 +121,36 @@ zswap-da/
 | `GET` | `/api/known-tokens` | Token color → name registry. |
 | `POST` | `/api/known-tokens` | Register a token name/color/kind. |
 | `GET` | `/api/midnight/config` | Public Midnight config the browser contract client needs. |
-| `POST` | `/api/zswap/submit` | Validate a bech32m `zswapoffer1…` blob and forward it to the batcher → Celestia. |
+| `POST` | `/api/zswap/submit` | Fully validate an offer (structure + ZK proofs + liveness); `400 {error, reason}` on failure, else forward to the batcher → Celestia. |
 | `GET` | `/api/events` | Server-Sent Events stream for offer lifecycle (indexed / consumed / expired). |
+
+## Celestia data retention (read before relying on history)
+
+Celestia prunes blob data after **~7 days** (CIP-36 sampling window; pruning
+default-on since celestia-node v0.25.3; storage window = 7d + 1h). Celestia's
+official position: *"rollups and applications are responsible for storing their
+historical data"* — there is no native archival product (namespace pinning is a
+long-open feature request).
+
+What this means here:
+
+- **Our Postgres already archives every valid offer permanently**
+  (`offer_file.transaction_hex`, including `offer_file_history`) — historical
+  analysis of offers is served by our own DB, not by Celestia.
+- **A fresh node cannot sync the namespace from genesis once blobs are >7d
+  old** via ordinary Celestia nodes. Bootstrap options: an archival endpoint
+  (run `celestia ... --archival`, or providers — QuickNode; community archival
+  RPCs), the free Arweave-backed **KYVE Trustless API** (`blob.Get`-compatible),
+  **Celenium** API, or a DB snapshot / blob mirror we publish.
+- **Mirroring recipe** (e.g. S3/R2 public good, requester-pays for readers):
+  at ingestion (we see every namespace blob, including third-party posts) store
+  `{height, namespace, commitment, blob, pfb_txhash, inclusion_proof}`. The
+  share commitment is recomputable from the bytes (self-verifying integrity);
+  the inclusion proof must be captured **within the 7-day window**
+  (`blob.GetProof`) for provable on-chain history after pruning.
+- Note the window asymmetry: with Midnight's next-release root window (~14d),
+  an offer can still be **fillable after its Celestia blob is pruned** — takers
+  depend on our API/mirror for the blob, not on Celestia.
 
 ## Stopping
 

--- a/templates/zswap-da/bun.lock
+++ b/templates/zswap-da/bun.lock
@@ -23,6 +23,7 @@
         "@effectstream/batcher-sdk": "0.100.17",
         "@effectstream/midnight-contracts": "0.100.17",
         "@effectstream/utils": "0.100.17",
+        "@zswap-da/validator": "workspace:*",
         "effection": "^3.5.0",
       },
     },
@@ -141,6 +142,7 @@
         "@sinclair/typebox": "^0.34.30",
         "@zswap-da/contract-offer-files": "workspace:*",
         "@zswap-da/database": "workspace:*",
+        "@zswap-da/validator": "workspace:*",
         "effection": "^3.5.0",
         "mip-zswap-offer": "github:effectstream/mip-zswap-offer#main",
         "rxjs": "^7.8.2",
@@ -163,6 +165,17 @@
       },
       "devDependencies": {
         "@types/pg": "^8.11.10",
+      },
+    },
+    "packages/validator": {
+      "name": "@zswap-da/validator",
+      "version": "0.1.0",
+      "dependencies": {
+        "@midnight-ntwrk/ledger-v8": "8.0.3",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^2.0.0",
+        "mip-zswap-offer": "github:effectstream/mip-zswap-offer#main",
       },
     },
   },
@@ -1026,6 +1039,8 @@
     "@zswap-da/node": ["@zswap-da/node@workspace:packages/node"],
 
     "@zswap-da/tests": ["@zswap-da/tests@workspace:packages/tests"],
+
+    "@zswap-da/validator": ["@zswap-da/validator@workspace:packages/validator"],
 
     "@zxing/text-encoding": ["@zxing/text-encoding@0.9.0", "", {}, "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="],
 
@@ -2330,6 +2345,8 @@
     "@zswap-da/tests/@midnight-ntwrk/midnight-js-contracts": ["@midnight-ntwrk/midnight-js-contracts@4.0.4", "", { "dependencies": { "@midnight-ntwrk/compact-js": "2.5.0", "@midnight-ntwrk/midnight-js-network-id": "4.0.4", "@midnight-ntwrk/midnight-js-types": "4.0.4", "@midnight-ntwrk/midnight-js-utils": "4.0.4" } }, "sha512-lu9A45upwvPSy/YohU0TMvaeL2ru1zJt6axbuGwGup2L16p+fN8ojjHji6YGEC6XkgyISH3L0GfsgxsQKmt56g=="],
 
     "@zswap-da/tests/@midnight-ntwrk/midnight-js-network-id": ["@midnight-ntwrk/midnight-js-network-id@4.0.4", "", {}, "sha512-bieKcN9ybIf+HoaHPjCJGxmYrcmUrdEOErxkxhiqgos2k7DKM9mZO7AgzN0WnBbPHYdT4z0c740QAcG95BaV8g=="],
+
+    "@zswap-da/validator/mip-zswap-offer": ["mip-zswap-offer@github:effectstream/mip-zswap-offer#32377f4", { "peerDependencies": { "@midnight-ntwrk/ledger-v8": "*", "@noble/curves": "^1.0.0 || ^2.0.0", "@noble/hashes": "^1.0.0 || ^2.0.0", "@scure/base": "^1.1.0 || ^2.0.0" }, "optionalPeers": ["@midnight-ntwrk/ledger-v8"] }, "effectstream-mip-zswap-offer-32377f4", "sha512-pmokkKfv9IMm/Gp4NeBvoq3FleFt60NOgfk54zvSNJi76BgRUIUqfsulypICPGDpt0hVT04hruU+85jQR1ZOkw=="],
 
     "algosdk/js-sha3": ["js-sha3@0.8.0", "", {}, "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="],
 

--- a/templates/zswap-da/packages/batcher/celestia.ts
+++ b/templates/zswap-da/packages/batcher/celestia.ts
@@ -1,20 +1,80 @@
-import { CelestiaAdapter } from "@effectstream/batcher-sdk";
+import {
+  CelestiaAdapter,
+  type CelestiaAdapterConfig,
+  type DefaultBatcherInput,
+} from "@effectstream/batcher-sdk";
+import { getBlankRefState, validateZswapOffer } from "@zswap-da/validator";
 import type { BatcherConfig } from "./config.ts";
+
+// DoS guard on the decoded offer size; mirrors the node's OFFER_MAX_BYTES. The
+// base adapter separately caps the on-wire blob at 1.5 MB.
+const OFFER_MAX_BYTES = parseInt(
+  process.env["OFFER_MAX_BYTES"] ?? String(1024 * 1024),
+  10,
+);
+
+type ValidationResult = { valid: boolean; error?: string };
+
+// CelestiaAdapter that validates a ZSwap offer before the batcher posts it (and
+// pays a TIA fee). The batcher invokes `validateInput` in `batchInput()` BEFORE
+// the blob is queued or submitted, so a rejected offer never costs a fee. This
+// is the authoritative pre-fee gate — it also covers producers that hit the
+// batcher's `/send-input` directly, bypassing `/api/zswap/submit`.
+class ZswapCelestiaAdapter extends CelestiaAdapter {
+  private readonly networkId: string;
+
+  constructor(config: CelestiaAdapterConfig, networkId: string) {
+    super(config);
+    this.networkId = networkId;
+  }
+
+  override validateInput(input: DefaultBatcherInput): ValidationResult {
+    // Base adapter checks: non-empty string input + max blob size.
+    const base = super.validateInput(input);
+    if (!base.valid) return base;
+
+    // Structure + cryptographic proofs (steps 1–5): rejects malformed, forged,
+    // and non-swap offers — the bulk of fee-wasting "bad" blobs. This is
+    // self-contained (blank reference state + bundled verifier keys; no network
+    // call), so the fee gate has no live dependency.
+    //
+    // Liveness (already-spent coins) is NOT repeated here: the batcher has no DB
+    // access and the indexer has no point-lookup ("is X spent?") query — only
+    // filtered subscriptions (unshieldedTransactions(address),
+    // shieldedNullifierTransactions(nullifierPrefixes)). Liveness is enforced
+    // deterministically at STM ingestion and at /api/zswap/submit (both consult
+    // the node's permanent spent_* sets). Adding subscription-based best-effort
+    // liveness here (indexer unshieldedTransactions / nullifier search) is a
+    // clean follow-up.
+    const result = validateZswapOffer(input.input, {
+      refState: getBlankRefState(this.networkId),
+      tblock: new Date(),
+      maxBytes: OFFER_MAX_BYTES,
+    });
+    if (!result.ok) {
+      return { valid: false, error: `${result.code}: ${result.reason ?? ""}` };
+    }
+    return { valid: true };
+  }
+}
 
 export function createCelestiaAdapter(
   batcherConfig: BatcherConfig,
 ): CelestiaAdapter {
-  return new CelestiaAdapter({
-    rpcUrl: batcherConfig.celestia.rpcUrl,
-    namespace: batcherConfig.celestia.namespace,
-    authToken: batcherConfig.celestia.authToken,
-    network: batcherConfig.celestia.network,
-    fee: batcherConfig.celestia.fee,
-    gasLimit: batcherConfig.celestia.gasLimit,
-    gasPrice: batcherConfig.celestia.gasPrice,
-    gas: batcherConfig.celestia.gas,
-    maxGasPrice: batcherConfig.celestia.maxGasPrice,
-    txPriority: batcherConfig.celestia.txPriority,
-    syncProtocolName: "parallelCelestia",
-  });
+  return new ZswapCelestiaAdapter(
+    {
+      rpcUrl: batcherConfig.celestia.rpcUrl,
+      namespace: batcherConfig.celestia.namespace,
+      authToken: batcherConfig.celestia.authToken,
+      network: batcherConfig.celestia.network,
+      fee: batcherConfig.celestia.fee,
+      gasLimit: batcherConfig.celestia.gasLimit,
+      gasPrice: batcherConfig.celestia.gasPrice,
+      gas: batcherConfig.celestia.gas,
+      maxGasPrice: batcherConfig.celestia.maxGasPrice,
+      txPriority: batcherConfig.celestia.txPriority,
+      syncProtocolName: "parallelCelestia",
+    },
+    batcherConfig.midnight.id,
+  );
 }

--- a/templates/zswap-da/packages/batcher/package.json
+++ b/templates/zswap-da/packages/batcher/package.json
@@ -14,6 +14,7 @@
     "@effectstream/batcher-sdk": "0.100.17",
     "@effectstream/midnight-contracts": "0.100.17",
     "@effectstream/utils": "0.100.17",
+    "@zswap-da/validator": "workspace:*",
     "effection": "^3.5.0"
   }
 }

--- a/templates/zswap-da/packages/database/migration-order.ts
+++ b/templates/zswap-da/packages/database/migration-order.ts
@@ -1,9 +1,14 @@
 import type { DBMigrations } from "@effectstream/runtime";
 import databaseSql from "./migrations/000-init.sql" with { type: "text" };
+import spentSetsSql from "./migrations/001-spent-sets.sql" with { type: "text" };
 
 export const migrationTable: DBMigrations[] = [
   {
     name: "000-init.sql",
     sql: databaseSql,
+  },
+  {
+    name: "001-spent-sets.sql",
+    sql: spentSetsSql,
   },
 ];

--- a/templates/zswap-da/packages/database/migrations/001-spent-sets.sql
+++ b/templates/zswap-da/packages/database/migrations/001-spent-sets.sql
@@ -1,0 +1,24 @@
+-- Permanent record of every on-chain coin spend the node has observed. The
+-- offer validator's liveness check reads these to reject an offer whose inputs
+-- are already consumed — so we neither index such an offer (it can never
+-- settle) nor pay Celestia fees to publish it.
+--
+-- Distinct from seen_nullifiers / seen_unshielded_spends: those are a TRANSIENT
+-- early-arrival reconciliation buffer (rows are DELETEd once matched to an
+-- indexed offer). The spent_* tables below are append-only and never pruned,
+-- so a lookup is a definitive "has this coin ever been spent?".
+
+CREATE TABLE spent_nullifiers (
+    nullifier TEXT PRIMARY KEY,
+    height BIGINT NOT NULL,
+    recorded_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE spent_unshielded (
+    owner TEXT NOT NULL,
+    intent_hash TEXT NOT NULL,
+    output_no INTEGER NOT NULL,
+    height BIGINT NOT NULL,
+    recorded_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (owner, intent_hash, output_no)
+);

--- a/templates/zswap-da/packages/database/spent-sets.test.ts
+++ b/templates/zswap-da/packages/database/spent-sets.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+
+// Verifies the 001-spent-sets migration + the spent_* queries end-to-end
+// against an in-memory PGlite served over the pg wire protocol — no Docker /
+// external Postgres needed. This is the regression guard for the hand-written
+// pgtyped IR (param offsets) and the migration SQL.
+process.env["DB_USER"] ??= "postgres";
+process.env["DB_NAME"] ??= "postgres";
+process.env["PGLITE_DATA_DIR"] ??= "memory://";
+
+const { startPglite } = await import("@effectstream/db/start-pglite");
+const pg = (await import("pg")).default;
+const {
+  migrationTable,
+  insertSpentNullifier,
+  isNullifierSpent,
+  insertSpentUnshielded,
+  isUnshieldedSpent,
+} = await import("@zswap-da/database");
+
+const PORT = 54329;
+let handle: { close: () => Promise<void> };
+let client: InstanceType<typeof pg.Client>;
+
+beforeAll(async () => {
+  handle = await startPglite(PORT);
+  client = new pg.Client({
+    host: "127.0.0.1",
+    port: PORT,
+    user: "postgres",
+    database: "postgres",
+  });
+  await client.connect();
+  for (const migration of migrationTable) {
+    await client.query(migration.sql);
+  }
+});
+
+afterAll(async () => {
+  // Close the server/DB without sending a client Terminate: PGlite's WASM
+  // throws when it processes the Terminate on socket teardown (a PGlite +
+  // pg-gateway + Bun quirk, unrelated to the assertions, which have run).
+  try {
+    await handle?.close();
+  } catch { /* noop */ }
+});
+
+test("spent_nullifiers: insert then lookup, and absent lookup", async () => {
+  await insertSpentNullifier.run({ nullifier: "deadbeef", height: 7 }, client);
+  expect((await isNullifierSpent.run({ nullifier: "deadbeef" }, client)).length).toBe(1);
+  expect((await isNullifierSpent.run({ nullifier: "cafe" }, client)).length).toBe(0);
+});
+
+test("insertSpentNullifier is idempotent (ON CONFLICT DO NOTHING)", async () => {
+  await insertSpentNullifier.run({ nullifier: "dup", height: 1 }, client);
+  await insertSpentNullifier.run({ nullifier: "dup", height: 2 }, client);
+  expect((await isNullifierSpent.run({ nullifier: "dup" }, client)).length).toBe(1);
+});
+
+test("spent_unshielded: triple insert then lookup, and partial-mismatch absent", async () => {
+  const ref = { owner: "owner1", intent_hash: "ih1", output_no: 3 };
+  await insertSpentUnshielded.run({ ...ref, height: 9 }, client);
+  expect((await isUnshieldedSpent.run(ref, client)).length).toBe(1);
+  // Same owner/intent but different output index must NOT match.
+  expect(
+    (await isUnshieldedSpent.run({ ...ref, output_no: 4 }, client)).length,
+  ).toBe(0);
+});

--- a/templates/zswap-da/packages/database/sql/queries.queries.ts
+++ b/templates/zswap-da/packages/database/sql/queries.queries.ts
@@ -876,3 +876,129 @@ const deleteSeenUnshieldedSpendIR: any = {"usedParamSet":{"owner":true,"intent_h
 export const deleteSeenUnshieldedSpend = new PreparedQuery<IDeleteSeenUnshieldedSpendParams,IDeleteSeenUnshieldedSpendResult>(deleteSeenUnshieldedSpendIR);
 
 
+
+
+/** 'InsertSpentNullifier' parameters type */
+export interface IInsertSpentNullifierParams {
+  height: NumberOrString;
+  nullifier: string;
+}
+
+/** 'InsertSpentNullifier' return type */
+export type IInsertSpentNullifierResult = void;
+
+/** 'InsertSpentNullifier' query type */
+export interface IInsertSpentNullifierQuery {
+  params: IInsertSpentNullifierParams;
+  result: IInsertSpentNullifierResult;
+}
+
+const insertSpentNullifierIR: any = {"usedParamSet":{"nullifier":true,"height":true},"params":[{"name":"nullifier","required":true,"transform":{"type":"scalar"},"locs":[{"a":208,"b":218}]},{"name":"height","required":true,"transform":{"type":"scalar"},"locs":[{"a":221,"b":228}]}],"statement":"-- Append-only record of an observed shielded nullifier spend. The offer\n-- validator reads spent_nullifiers to reject offers referencing spent coins.\nINSERT INTO spent_nullifiers (nullifier, height)\nVALUES (:nullifier!, :height!)\nON CONFLICT (nullifier) DO NOTHING"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * -- Append-only record of an observed shielded nullifier spend. The offer
+ * -- validator reads spent_nullifiers to reject offers referencing spent coins.
+ * INSERT INTO spent_nullifiers (nullifier, height)
+ * VALUES (:nullifier!, :height!)
+ * ON CONFLICT (nullifier) DO NOTHING
+ * ```
+ */
+export const insertSpentNullifier = new PreparedQuery<IInsertSpentNullifierParams,IInsertSpentNullifierResult>(insertSpentNullifierIR);
+
+
+
+/** 'IsNullifierSpent' parameters type */
+export interface IIsNullifierSpentParams {
+  nullifier: string;
+}
+
+/** 'IsNullifierSpent' return type */
+export interface IIsNullifierSpentResult {
+  spent: number | null;
+}
+
+/** 'IsNullifierSpent' query type */
+export interface IIsNullifierSpentQuery {
+  params: IIsNullifierSpentParams;
+  result: IIsNullifierSpentResult;
+}
+
+const isNullifierSpentIR: any = {"usedParamSet":{"nullifier":true},"params":[{"name":"nullifier","required":true,"transform":{"type":"scalar"},"locs":[{"a":58,"b":68}]}],"statement":"SELECT 1 AS spent\nFROM spent_nullifiers\nWHERE nullifier = :nullifier!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT 1 AS spent
+ * FROM spent_nullifiers
+ * WHERE nullifier = :nullifier!
+ * ```
+ */
+export const isNullifierSpent = new PreparedQuery<IIsNullifierSpentParams,IIsNullifierSpentResult>(isNullifierSpentIR);
+
+
+
+/** 'InsertSpentUnshielded' parameters type */
+export interface IInsertSpentUnshieldedParams {
+  height: NumberOrString;
+  intent_hash: string;
+  output_no: number;
+  owner: string;
+}
+
+/** 'InsertSpentUnshielded' return type */
+export type IInsertSpentUnshieldedResult = void;
+
+/** 'InsertSpentUnshielded' query type */
+export interface IInsertSpentUnshieldedQuery {
+  params: IInsertSpentUnshieldedParams;
+  result: IInsertSpentUnshieldedResult;
+}
+
+const insertSpentUnshieldedIR: any = {"usedParamSet":{"owner":true,"intent_hash":true,"output_no":true,"height":true},"params":[{"name":"owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":137,"b":143}]},{"name":"intent_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":146,"b":158}]},{"name":"output_no","required":true,"transform":{"type":"scalar"},"locs":[{"a":161,"b":171}]},{"name":"height","required":true,"transform":{"type":"scalar"},"locs":[{"a":174,"b":181}]}],"statement":"-- Append-only record of an observed unshielded UTXO spend.\nINSERT INTO spent_unshielded (owner, intent_hash, output_no, height)\nVALUES (:owner!, :intent_hash!, :output_no!, :height!)\nON CONFLICT (owner, intent_hash, output_no) DO NOTHING"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * -- Append-only record of an observed unshielded UTXO spend.
+ * INSERT INTO spent_unshielded (owner, intent_hash, output_no, height)
+ * VALUES (:owner!, :intent_hash!, :output_no!, :height!)
+ * ON CONFLICT (owner, intent_hash, output_no) DO NOTHING
+ * ```
+ */
+export const insertSpentUnshielded = new PreparedQuery<IInsertSpentUnshieldedParams,IInsertSpentUnshieldedResult>(insertSpentUnshieldedIR);
+
+
+
+/** 'IsUnshieldedSpent' parameters type */
+export interface IIsUnshieldedSpentParams {
+  intent_hash: string;
+  output_no: number;
+  owner: string;
+}
+
+/** 'IsUnshieldedSpent' return type */
+export interface IIsUnshieldedSpentResult {
+  spent: number | null;
+}
+
+/** 'IsUnshieldedSpent' query type */
+export interface IIsUnshieldedSpentQuery {
+  params: IIsUnshieldedSpentParams;
+  result: IIsUnshieldedSpentResult;
+}
+
+const isUnshieldedSpentIR: any = {"usedParamSet":{"owner":true,"intent_hash":true,"output_no":true},"params":[{"name":"owner","required":true,"transform":{"type":"scalar"},"locs":[{"a":54,"b":60}]},{"name":"intent_hash","required":true,"transform":{"type":"scalar"},"locs":[{"a":82,"b":94}]},{"name":"output_no","required":true,"transform":{"type":"scalar"},"locs":[{"a":114,"b":124}]}],"statement":"SELECT 1 AS spent\nFROM spent_unshielded\nWHERE owner = :owner!\n  AND intent_hash = :intent_hash!\n  AND output_no = :output_no!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT 1 AS spent
+ * FROM spent_unshielded
+ * WHERE owner = :owner!
+ *   AND intent_hash = :intent_hash!
+ *   AND output_no = :output_no!
+ * ```
+ */
+export const isUnshieldedSpent = new PreparedQuery<IIsUnshieldedSpentParams,IIsUnshieldedSpentResult>(isUnshieldedSpentIR);

--- a/templates/zswap-da/packages/database/sql/queries.sql
+++ b/templates/zswap-da/packages/database/sql/queries.sql
@@ -373,3 +373,28 @@ DELETE FROM seen_unshielded_spends
 WHERE owner = :owner!
   AND intent_hash = :intent_hash!
   AND output_no = :output_no!;
+
+/* @name InsertSpentNullifier */
+-- Append-only record of an observed shielded nullifier spend. The offer
+-- validator reads spent_nullifiers to reject offers referencing spent coins.
+INSERT INTO spent_nullifiers (nullifier, height)
+VALUES (:nullifier!, :height!)
+ON CONFLICT (nullifier) DO NOTHING;
+
+/* @name IsNullifierSpent */
+SELECT 1 AS spent
+FROM spent_nullifiers
+WHERE nullifier = :nullifier!;
+
+/* @name InsertSpentUnshielded */
+-- Append-only record of an observed unshielded UTXO spend.
+INSERT INTO spent_unshielded (owner, intent_hash, output_no, height)
+VALUES (:owner!, :intent_hash!, :output_no!, :height!)
+ON CONFLICT (owner, intent_hash, output_no) DO NOTHING;
+
+/* @name IsUnshieldedSpent */
+SELECT 1 AS spent
+FROM spent_unshielded
+WHERE owner = :owner!
+  AND intent_hash = :intent_hash!
+  AND output_no = :output_no!;

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -5,12 +5,14 @@ import {
   getOfferFiles,
   getOfferFileTokens,
   insertKnownToken,
+  isNullifierSpent,
+  isUnshieldedSpent,
 } from "@zswap-da/database";
 
-import { midnightContract } from "./env.ts";
+import { MIDNIGHT_NETWORK_ID, OFFER_MAX_BYTES, midnightContract } from "./env.ts";
 import { midnightNetworkConfig } from "@effectstream/midnight-contracts/midnight-env";
 import { submitBlobViaBatcher } from "./batcher-client.ts";
-import { decodeOffer, OFFER_HRP } from "mip-zswap-offer";
+import { getBlankRefState, validateZswapOffer } from "@zswap-da/validator";
 import { eventBus, emitAppEvent } from "./event-bus.ts";
 
 // ─── API Router ───────────────────────────────────────────────────────────────
@@ -158,8 +160,11 @@ export const apiRouter: StartConfigApiRouter = async function (
     };
   });
 
-  // POST /api/zswap/submit — validate a bech32m `zswapoffer1…` blob and forward
-  // it to Celestia DA. The frontend produces the blob via encodeOffer().
+  // POST /api/zswap/submit — fully validate a `zswapoffer1…` blob, then forward
+  // it to Celestia DA via the batcher. We validate here so the frontend gets
+  // fast, specific feedback; the batcher's validateInput hook re-validates as
+  // the authoritative pre-fee gate. The frontend produces the blob via
+  // encodeOffer().
   server.post(
     "/api/zswap/submit",
     {
@@ -173,18 +178,45 @@ export const apiRouter: StartConfigApiRouter = async function (
         },
       },
     },
-    async (request: any) => {
+    async (request: any, reply: any) => {
       const { blob } = request.body;
 
-      if (typeof blob !== "string" || !blob.startsWith(`${OFFER_HRP}1`)) {
-        throw new Error("Invalid blob: not a zswapoffer bech32m string");
+      // Structure + cryptographic proofs (steps 1–5).
+      const validation = validateZswapOffer(blob, {
+        refState: getBlankRefState(MIDNIGHT_NETWORK_ID),
+        tblock: new Date(),
+        maxBytes: OFFER_MAX_BYTES,
+      });
+      if (!validation.ok) {
+        return reply
+          .code(400)
+          .send({ error: validation.code, reason: validation.reason });
       }
 
-      // Verify it decodes without error (checksum + HRP check).
-      try {
-        decodeOffer(blob);
-      } catch (e: any) {
-        throw new Error(`Invalid bech32m: ${e.message ?? String(e)}`);
+      // Liveness: never pay a Celestia fee for an offer whose coins are already
+      // spent on chain (it can never settle). The spent_* sets are populated by
+      // the node's midnight-* sync handlers.
+      for (const nullifier of validation.nullifiers ?? []) {
+        const spent = await isNullifierSpent.run({ nullifier }, dbConn);
+        if (spent.length > 0) {
+          return reply.code(400).send({
+            error: "NULLIFIER_SPENT",
+            reason: `nullifier already spent: ${nullifier}`,
+          });
+        }
+      }
+      for (const s of validation.unshieldedSpends ?? []) {
+        const spent = await isUnshieldedSpent.run(
+          { owner: s.owner, intent_hash: s.intentHash, output_no: s.outputNo },
+          dbConn,
+        );
+        if (spent.length > 0) {
+          return reply.code(400).send({
+            error: "UTXO_SPENT",
+            reason:
+              `unshielded UTXO already spent: ${s.owner}/${s.intentHash}/${s.outputNo}`,
+          });
+        }
       }
 
       const result = await submitBlobViaBatcher(blob);

--- a/templates/zswap-da/packages/node/env.ts
+++ b/templates/zswap-da/packages/node/env.ts
@@ -34,23 +34,43 @@ export const CELESTIA_TX_PRIORITY = _txPriority ? parseInt(_txPriority) : undefi
 
 // Offer lifetime before the TTL-cleanup scheduled input archives it.
 //
-// Shielded offers carry a Merkle-tree root in each `Input`/`Transient` and
-// the Midnight node only retains recent roots (reference implementation:
-// 1 hour). Once the referenced root ages out, the input fails with
-// `UnknownMerkleRoot` at apply time — silently, with no event the indexer
-// can observe. So we cap the default TTL to 1 hour to keep the active set
-// in line with on-chain fillability.
+// A shielded offer is fillable only while the Merkle root its `Input`/`Transient`
+// proves against is still in the node's retained root history; once that root
+// ages out the input fails with `UnknownMerkleRoot` at apply time — silently,
+// with no event the indexer can observe. So the TTL should track that
+// root-history window to keep the active set in line with on-chain fillability.
+//
+// That window is **version-dependent**:
+//   - current ledger release: ~1 hour (`Duration::from_secs(3600)`,
+//     `zswap/src/ledger.rs:235-247`)
+//   - next release: ~14 days (per Midnight release notes; not yet visible in
+//     the reference checkout — re-verify when it lands)
+// We default to **30 days** for headroom across releases (a too-short TTL
+// archives still-fillable offers). Tune `OFFER_TTL_SECONDS` to your network:
+// e.g. set ~3600 on a current 1h-window network so the indexer doesn't keep
+// serving offers that can no longer settle.
 //
 // Caveats:
-//   - The exact root-history window depends on the deployed ledger; tune
-//     this for your network if the node configures something other than
-//     the reference 3600s.
-//   - Unshielded-only offers don't have this constraint and could live
-//     longer; if you need that, split the TTL by offer kind.
-//   - Makers should publish offers immediately after proving — the fill
-//     window starts at the referenced root, not at publication.
+//   - The window bounds *proof freshness*, not coin age: a maker proves an
+//     old coin against a recent root, so old coins are unaffected.
+//   - Unshielded-only offers have no root window (a UTXO is valid until spent);
+//     if you need them to live longer, split the TTL by offer kind.
+//   - Makers should publish promptly after proving — the fill window starts at
+//     the referenced root, not at publication.
 export const OFFER_TTL_SECONDS = parseInt(
-  getEnv("OFFER_TTL_SECONDS") ?? String(60 * 60),
+  getEnv("OFFER_TTL_SECONDS") ?? String(60 * 60 * 24 * 30),
+);
+
+// Midnight network id the offers are created against. Used as the `wellFormed`
+// reference-state network (offer validation) — must match the network whose
+// proofs the offers carry.
+export const MIDNIGHT_NETWORK_ID = midnightNetworkConfig.id;
+
+// Upper bound on a decoded offer transaction, in bytes. A DoS guard for the
+// validator (the Celestia adapter separately caps the on-wire blob at 1.5 MB);
+// set generously so legitimate proof-bearing offers are never rejected.
+export const OFFER_MAX_BYTES = parseInt(
+  getEnv("OFFER_MAX_BYTES") ?? String(1024 * 1024),
 );
 
 export const midnightContract = (() => {

--- a/templates/zswap-da/packages/node/event-bus.ts
+++ b/templates/zswap-da/packages/node/event-bus.ts
@@ -9,7 +9,13 @@ export type AppEvent =
       unshieldedSpend?: { owner: string; intentHash: string; outputNo: number };
     }
   | { type: "offer_expired"; offerId: number }
-  | { type: "token_minted"; name: string; color: string };
+  | { type: "token_minted"; name: string; color: string }
+  | {
+      type: "offer_rejected";
+      code?: string;
+      reason?: string;
+      celestiaHeight: number | string;
+    };
 
 export const eventBus = new EventEmitter();
 eventBus.setMaxListeners(50);

--- a/templates/zswap-da/packages/node/package.json
+++ b/templates/zswap-da/packages/node/package.json
@@ -21,6 +21,7 @@
     "@effectstream/sm": "0.100.17",
     "@effectstream/utils": "0.100.17",
     "@zswap-da/database": "workspace:*",
+    "@zswap-da/validator": "workspace:*",
     "@zswap-da/contract-offer-files": "workspace:*",
     "@midnight-ntwrk/compact-js": "2.5.0",
     "@midnight-ntwrk/ledger-v8": "8.0.3",

--- a/templates/zswap-da/packages/node/state-machine.ts
+++ b/templates/zswap-da/packages/node/state-machine.ts
@@ -3,17 +3,11 @@ import { World } from "@effectstream/coroutine";
 import { Stm } from "@effectstream/sm";
 import type { BaseStfInput } from "@effectstream/sm";
 import type { StartConfigGameStateTransitions } from "@effectstream/runtime";
-import {
-  addressFromKey,
-  Transaction,
-  type UnprovenTransaction,
-  type TokenType,
-} from "@midnight-ntwrk/ledger-v8";
 import { MidnightBech32m } from "@midnight-ntwrk/wallet-sdk-address-format";
 import { Buffer } from "node:buffer";
 import { newScheduledTimestampData } from "@effectstream/db";
 import { AddressType } from "@effectstream/utils";
-import { decodeOffer, OFFER_HRP } from "mip-zswap-offer";
+import { getBlankRefState, validateZswapOffer } from "@zswap-da/validator";
 
 import {
   insertOfferFile,
@@ -29,6 +23,10 @@ import {
   upsertSeenUnshieldedSpend,
   findSeenUnshieldedSpend,
   deleteSeenUnshieldedSpend,
+  insertSpentNullifier,
+  isNullifierSpent,
+  insertSpentUnshielded,
+  isUnshieldedSpent,
 } from "@zswap-da/database";
 
 // ─── Indexer scope and known limitations ─────────────────────────────────────
@@ -54,7 +52,7 @@ import {
 import { grammar } from "./grammar.ts";
 import { extractMidnightLedgerSnapshot } from "./zswap-logic.ts";
 import { emitAppEvent } from "./event-bus.ts";
-import { OFFER_TTL_SECONDS } from "./env.ts";
+import { MIDNIGHT_NETWORK_ID, OFFER_MAX_BYTES, OFFER_TTL_SECONDS } from "./env.ts";
 
 // Normalize a value that may be a Uint8Array or a hex string into lowercase
 // hex (no `0x` prefix). Used at offer-indexing for nullifiers, owner keys,
@@ -102,6 +100,14 @@ stm.addStateTransition("midnight-nullifier", function* (data) {
   const { nullifier } = payload;
 
   try {
+    // Record the spend permanently (append-only) so the offer validator can
+    // reject offers that reference this now-consumed coin. Done on every event,
+    // matched or not, so spent_nullifiers is a superset of seen_nullifiers.
+    yield* World.resolve(insertSpentNullifier, {
+      nullifier,
+      height: data.blockHeight,
+    });
+
     const archived = yield* World.resolve(archiveOfferByNullifier, {
       nullifier,
     });
@@ -155,6 +161,15 @@ stm.addStateTransition("midnight-unshielded-spend", function* (data) {
   }
 
   try {
+    // Record the spend permanently for the offer validator's liveness check
+    // (see midnight-nullifier handler). Superset of seen_unshielded_spends.
+    yield* World.resolve(insertSpentUnshielded, {
+      owner,
+      intent_hash: intentHash,
+      output_no: outputNo,
+      height: data.blockHeight,
+    });
+
     const archived = yield* World.resolve(archiveOfferByUnshieldedSpend, {
       owner,
       intent_hash: intentHash,
@@ -202,87 +217,79 @@ stm.addStateTransition("celestia-zswap", function* (data) {
   const { payload } = data.parsedInput;
   const raw = payload.suppliedValue;
 
-  // Blob must be a bech32m `zswapoffer1…` string — no JSON envelope.
-  if (typeof raw !== "string" || !raw.startsWith(`${OFFER_HRP}1`)) {
-    console.error("[ZSWAP] Invalid blob: not a zswapoffer bech32m string, skipping");
+  // ── Validate the offer (structure + cryptographic proofs) ──
+  // Deterministic: the verdict is a pure function of (raw, refState, tblock).
+  // `tblock` is the Celestia block time and `refState` is a blank ledger state
+  // for the configured network, so it replays identically. Anyone can post a
+  // blob directly to the public Celestia namespace, so we must validate
+  // defensively even though /api/zswap/submit and the batcher also gate.
+  const result = validateZswapOffer(raw, {
+    refState: getBlankRefState(MIDNIGHT_NETWORK_ID),
+    tblock: new Date(data.blockTimestamp),
+    maxBytes: OFFER_MAX_BYTES,
+  });
+  if (!result.ok) {
+    console.warn("[ZSWAP] Rejected offer", {
+      code: result.code,
+      reason: result.reason,
+      celestiaHeight: data.blockHeight,
+    });
+    emitAppEvent({
+      type: "offer_rejected",
+      code: result.code,
+      reason: result.reason,
+      celestiaHeight: data.blockHeight,
+    });
     return;
   }
 
-  // Decode bech32m → raw bytes → deserialized transaction.
-  let rawTx: Uint8Array;
-  try {
-    rawTx = decodeOffer(raw);
-  } catch (e) {
-    console.error("[ZSWAP] Invalid bech32m blob, skipping", e);
-    return;
-  }
+  const nullifierStrs = result.nullifiers ?? [];
+  const unshieldedSpends = (result.unshieldedSpends ?? []).map((s) => ({
+    owner: s.owner,
+    intent_hash: s.intentHash,
+    output_no: s.outputNo,
+  }));
+  const gives = result.gives ?? [];
+  const wants = result.wants ?? [];
 
-  // Lace-made offers (`makeIntent`) arrive as <Sig, Proof, Binding> — the wallet
-  // proves+binds inside its secure context.
-  let offerTx: UnprovenTransaction;
-  try {
-    offerTx = Transaction.deserialize(
-      "signature" as const,
-      "proof" as const,
-      "binding" as const,
-      rawTx,
-    ) as UnprovenTransaction;
-    console.log(`[ZSWAP] Deserialized offer at height ${data.blockHeight}`);
-  } catch (e) {
-    console.error("[ZSWAP] Failed to deserialize transaction as <signature, proof, binding>", e);
-    return;
-  }
-
-  try {
-    // ── Derive gives/wants from imbalances ──
-    // 0 = guaranteed segment. Lace's makeIntent populates `intents` and may also
-    // touch `fallibleOffer` depending on the kinds (shielded/unshielded) involved.
-    // Union both so we capture every segment with imbalances.
-    const intentKeys = (offerTx as any).intents
-      ? Array.from((offerTx as any).intents.keys() as Iterable<number>)
-      : [];
-    const fallibleKeys = offerTx.fallibleOffer
-      ? Array.from(offerTx.fallibleOffer.keys() as Iterable<number>)
-      : [];
-    const segmentIds: number[] = Array.from(
-      new Set<number>([0, ...intentKeys, ...fallibleKeys]),
-    );
-
-    const mergedImbalances = new Map<string, bigint>();
-    for (const segId of segmentIds) {
-      let entries: Iterable<[TokenType, bigint]>;
-      try {
-        entries = offerTx.imbalances(segId);
-      } catch (e) {
-        // Segment IDs came from the tx itself — this shouldn't happen.
-        // Partial imbalance data would produce a wrong offer, so drop it entirely.
-        console.error(`[ZSWAP] imbalances(${segId}) threw at height ${data.blockHeight}`, e);
-        return;
-      }
-
-      for (const [tokenType, delta] of entries) {
-        const tt = tokenType as TokenType;
-        if (tt.tag === 'dust') continue;
-        if (tt.tag !== 'shielded' && tt.tag !== 'unshielded') {
-          console.warn(`[ZSWAP] Unknown token tag "${tt.tag}" in segment ${segId}, skipping`);
-          continue;
-        }
-        const token = tt.raw.toLowerCase();
-        mergedImbalances.set(token, (mergedImbalances.get(token) ?? 0n) + delta);
-      }
+  // ── Liveness: drop offers whose coins are already spent on chain ──
+  // The midnight-* handlers ingest every consumed nullifier / unshielded UTXO
+  // into the permanent spent_* sets, so these are a plain existence check. We
+  // do NOT compare heights across chains (Midnight height ≠ Celestia height);
+  // determinism comes from the rollup's fixed input ordering. An already-spent
+  // coin means the offer can never settle, so it must not be indexed.
+  for (const nullifier of nullifierStrs) {
+    const spent = yield* World.resolve(isNullifierSpent, { nullifier });
+    if (spent.length > 0) {
+      console.warn("[ZSWAP] Rejected offer: nullifier already spent", {
+        nullifier,
+        celestiaHeight: data.blockHeight,
+      });
+      emitAppEvent({
+        type: "offer_rejected",
+        code: "NULLIFIER_SPENT",
+        celestiaHeight: data.blockHeight,
+      });
+      return;
     }
-
-    const gives: { token: string; amount: string }[] = [];
-    const wants: { token: string; amount: string }[] = [];
-
-    for (const [token, delta] of mergedImbalances) {
-      if (delta > 0n) {
-        gives.push({ token, amount: delta.toString() });
-      } else if (delta < 0n) {
-        wants.push({ token, amount: (-delta).toString() });
-      }
+  }
+  for (const s of unshieldedSpends) {
+    const spent = yield* World.resolve(isUnshieldedSpent, s);
+    if (spent.length > 0) {
+      console.warn("[ZSWAP] Rejected offer: unshielded UTXO already spent", {
+        ...s,
+        celestiaHeight: data.blockHeight,
+      });
+      emitAppEvent({
+        type: "offer_rejected",
+        code: "UTXO_SPENT",
+        celestiaHeight: data.blockHeight,
+      });
+      return;
     }
+  }
 
+  try {
     // ── Insert offer ──
     const offerFileRes = yield* World.resolve(insertOfferFile, {
       celestia_height: data.blockHeight,
@@ -298,64 +305,17 @@ stm.addStateTransition("celestia-zswap", function* (data) {
 
     const offerFileId = offerFileRes[0].id;
 
-    // ── Extract nullifiers (shielded path) ──
-    // Shielded spends carry a cryptographic nullifier; the chain emits a
-    // `midnight-nullifier` STM event whenever one is consumed. Cover all
-    // input sources the ledger applies:
-    //   - guaranteedOffer.inputs    (segment 0 spent inputs)
-    //   - guaranteedOffer.transients (segment 0 input+output in same tx)
-    //   - fallibleOffer[seg].inputs / .transients (each non-guaranteed segment)
-    // Detection (Midnight fetcher) is segment-agnostic, so indexing must
-    // match — otherwise consumed offers go un-archived until TTL.
-    const shieldedOffers: any[] = [];
-    if (offerTx.guaranteedOffer) shieldedOffers.push(offerTx.guaranteedOffer);
-    if (offerTx.fallibleOffer && typeof (offerTx.fallibleOffer as any).values === "function") {
-      for (const segOffer of (offerTx.fallibleOffer as any).values() as Iterable<any>) {
-        if (segOffer) shieldedOffers.push(segOffer);
-      }
-    }
-    const nullifierStrs: string[] = [];
-    for (const o of shieldedOffers) {
-      for (const input of o.inputs ?? []) nullifierStrs.push(bytesOrStringToHex(input.nullifier));
-      for (const t of o.transients ?? []) nullifierStrs.push(bytesOrStringToHex(t.nullifier));
-    }
-    for (const nullifierStr of nullifierStrs) {
+    // ── Persist spend refs (derived + validated above) ──
+    // nullifierStrs covers guaranteed + fallible segments, inputs + transients;
+    // unshieldedSpends carries the (owner, intentHash, outputNo) triples with
+    // owner already normalized via addressFromKey so the midnight-* consumption
+    // events match. Both must be inserted before the early-arrival
+    // reconciliation, which copies them into the history tables in one shot.
+    for (const nullifier of nullifierStrs) {
       yield* World.resolve(insertOfferFileNullifier, {
         offer_file_id: offerFileId,
-        nullifier: nullifierStr,
+        nullifier,
       });
-    }
-
-    // ── Extract unshielded UTXO refs (unshielded path) ──
-    // Unshielded inputs have no nullifier; they're identified by the
-    // (owner, intentHash, outputNo) triple of `UtxoSpend` records on each
-    // Intent's guaranteed/fallible UnshieldedOffer. Capture them so the
-    // `midnight-unshielded-spend` STM event can match-and-archive when the
-    // chain consumes one of these UTXOs.
-    //
-    // `UtxoSpend.owner` is a raw SignatureVerifyingKey — distinct from the
-    // 32-byte address that the indexer reports on consumption. Apply
-    // `addressFromKey` so both sides of the lookup store the same address.
-    const unshieldedSpends: Array<{ owner: string; intent_hash: string; output_no: number }> = [];
-    const intents = (offerTx as any).intents;
-    if (intents && typeof intents.values === "function") {
-      for (const intent of intents.values() as Iterable<any>) {
-        const unshieldedOffers = [
-          intent.guaranteedUnshieldedOffer,
-          intent.fallibleUnshieldedOffer,
-        ].filter(Boolean);
-        for (const offer of unshieldedOffers) {
-          for (const spend of offer.inputs ?? []) {
-            const ownerSvk = bytesOrStringToHex(spend.owner);
-            const ownerAddr = addressFromKey(ownerSvk).toLowerCase();
-            unshieldedSpends.push({
-              owner: ownerAddr,
-              intent_hash: bytesOrStringToHex(spend.intentHash).toLowerCase(),
-              output_no: Number(spend.outputNo),
-            });
-          }
-        }
-      }
     }
     for (const s of unshieldedSpends) {
       yield* World.resolve(insertOfferFileUnshieldedSpend, {

--- a/templates/zswap-da/packages/validator/README.md
+++ b/templates/zswap-da/packages/validator/README.md
@@ -1,0 +1,51 @@
+# @zswap-da/validator
+
+Shared, pure ZSwap offer validation. One deterministic routine,
+`validateZswapOffer`, used by both trust points:
+
+- **Ingestion** — the `celestia-zswap` state-machine handler, so the indexer
+  never serves an invalid offer.
+- **Pre-submission** — `/api/zswap/submit` and the batcher's Celestia adapter
+  `validateInput` hook, so we never pay a Celestia fee for an offer that can't
+  settle.
+
+The module has no I/O of its own: callers supply the reference state, block
+timestamp, and (optionally) liveness checks.
+
+## Pipeline (`validate.ts`)
+
+1. `BAD_ENCODING` — bech32m `zswapoffer1…` + `decodeOffer`
+2. `TOO_LARGE` — decoded size ≤ `maxBytes`
+3. `BAD_DESERIALIZE` — `Transaction.deserialize("signature","proof","binding")`
+4. structural — `NO_SPENDABLE_INPUT` / `NOT_A_SWAP` / `UNKNOWN_TOKEN`
+5. **crypto** — `Transaction.wellFormed` (`enforceBalancing=false`; verifies the
+   ZK proofs + signatures). Rejects forged/made-up coins. State-independent, so
+   a blank `LedgerState` suffices (see `refstate.ts`).
+6. liveness (optional) — `NULLIFIER_SPENT` / `UTXO_SPENT`
+7. dedup (optional) — `DUPLICATE`
+
+On success it returns the derived `nullifiers / unshieldedSpends / gives /
+wants / identifiers` so callers don't re-parse.
+
+## Liveness
+
+Implemented: cryptographic validation (`wellFormed`) plus nullifier- and
+unshielded-spent checks against the node's permanent spent-sets, so an offer
+spending an already-consumed coin is rejected. Not yet implemented: **root-known**
+(rejecting offers proven against a fabricated or aged-out Merkle root) — until
+then it is bounded by `OFFER_TTL_SECONDS` (set to track the on-chain root
+window) plus the fact that such an offer can never settle.
+
+`scripts/check-preview-indexer.ts` confirms (against the public preview indexer)
+that the on-chain fields these checks rely on exist and are populated:
+
+```bash
+bun packages/validator/scripts/check-preview-indexer.ts        # preview
+```
+
+## Tests
+
+`bun test packages/validator`. Encoding/size/structural + config + derive logic
+run with synthetic data. The cryptographic tests need a **real proven offer** —
+drop one into `fixtures/valid-offer.bech32` to activate them (see
+[fixtures/README.md](./fixtures/README.md)).

--- a/templates/zswap-da/packages/validator/derive.test.ts
+++ b/templates/zswap-da/packages/validator/derive.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  bytesOrStringToHex,
+  collectNullifiers,
+  collectUnshieldedSpends,
+  deriveLegs,
+  UnknownTokenTagError,
+} from "./derive.ts";
+
+// A valid 32-byte Schnorr verifying key (addressFromKey rejects malformed keys).
+const VALID_SVK = "aa".repeat(32);
+
+const shielded = (raw: string) => ({ tag: "shielded" as const, raw });
+const unshielded = (raw: string) => ({ tag: "unshielded" as const, raw });
+const dust = () => ({ tag: "dust" as const });
+
+// Minimal duck-typed Transaction the derive helpers read.
+function mockTx(opts: {
+  guaranteed?: any;
+  fallible?: Map<number, any>;
+  intents?: Map<number, any>;
+  imbalances?: Map<number, Map<any, bigint>>;
+}) {
+  return {
+    guaranteedOffer: opts.guaranteed,
+    fallibleOffer: opts.fallible,
+    intents: opts.intents,
+    imbalances(seg: number) {
+      return opts.imbalances?.get(seg) ?? new Map();
+    },
+  } as any;
+}
+
+describe("bytesOrStringToHex", () => {
+  test("Uint8Array → lowercase hex", () => {
+    expect(bytesOrStringToHex(new Uint8Array([0xab, 0x0f]))).toBe("ab0f");
+  });
+  test("strips 0x and lowercases", () => {
+    expect(bytesOrStringToHex("0xABcd")).toBe("abcd");
+    expect(bytesOrStringToHex("EE")).toBe("ee");
+  });
+});
+
+describe("collectNullifiers", () => {
+  test("gathers inputs + transients across guaranteed + fallible segments", () => {
+    const tx = mockTx({
+      guaranteed: {
+        inputs: [{ nullifier: new Uint8Array([0x01]) }],
+        transients: [{ nullifier: "0x02" }],
+      },
+      fallible: new Map([
+        [1, { inputs: [{ nullifier: "AA" }], transients: [{ nullifier: "bb" }] }],
+      ]),
+    });
+    expect(collectNullifiers(tx).sort()).toEqual(["01", "02", "aa", "bb"]);
+  });
+
+  test("empty when no shielded offers", () => {
+    expect(collectNullifiers(mockTx({}))).toEqual([]);
+  });
+});
+
+describe("collectUnshieldedSpends", () => {
+  test("derives owner address from the input SVK + intentHash + outputNo", () => {
+    const tx = mockTx({
+      intents: new Map([
+        [
+          0,
+          {
+            guaranteedUnshieldedOffer: {
+              inputs: [
+                { owner: VALID_SVK, intentHash: "0xDEAD", outputNo: 3 },
+              ],
+            },
+            fallibleUnshieldedOffer: undefined,
+          },
+        ],
+      ]),
+    });
+    const spends = collectUnshieldedSpends(tx);
+    expect(spends).toHaveLength(1);
+    expect(spends[0]!.intentHash).toBe("dead");
+    expect(spends[0]!.outputNo).toBe(3);
+    expect(spends[0]!.owner).toBe(spends[0]!.owner.toLowerCase());
+    expect(spends[0]!.owner.length).toBeGreaterThan(0);
+  });
+
+  test("empty when no intents", () => {
+    expect(collectUnshieldedSpends(mockTx({}))).toEqual([]);
+  });
+});
+
+describe("deriveLegs", () => {
+  test("positive imbalance is a give, negative is a want; dust ignored", () => {
+    const tx = mockTx({
+      imbalances: new Map([
+        [
+          0,
+          new Map<any, bigint>([
+            [unshielded("aabb"), 100n],
+            [shielded("ccdd"), -50n],
+            [dust(), 999n],
+          ]),
+        ],
+      ]),
+    });
+    const { gives, wants } = deriveLegs(tx);
+    expect(gives).toEqual([{ token: "aabb", amount: "100" }]);
+    expect(wants).toEqual([{ token: "ccdd", amount: "50" }]);
+  });
+
+  test("merges the same token across segments", () => {
+    const tx = mockTx({
+      intents: new Map([[1, {}]]),
+      imbalances: new Map([
+        [0, new Map<any, bigint>([[unshielded("aa"), 30n]])],
+        [1, new Map<any, bigint>([[unshielded("aa"), 70n], [shielded("bb"), -10n]])],
+      ]),
+    });
+    const { gives, wants } = deriveLegs(tx);
+    expect(gives).toEqual([{ token: "aa", amount: "100" }]);
+    expect(wants).toEqual([{ token: "bb", amount: "10" }]);
+  });
+
+  test("throws UnknownTokenTagError on an unexpected tag", () => {
+    const tx = mockTx({
+      imbalances: new Map([
+        [0, new Map<any, bigint>([[{ tag: "weird", raw: "00" }, 1n]])],
+      ]),
+    });
+    expect(() => deriveLegs(tx)).toThrow(UnknownTokenTagError);
+  });
+
+  test("lowercases token color", () => {
+    const tx = mockTx({
+      imbalances: new Map([
+        [0, new Map<any, bigint>([[unshielded("AABB"), 5n], [shielded("CCDD"), -5n]])],
+      ]),
+    });
+    const { gives, wants } = deriveLegs(tx);
+    expect(gives[0]!.token).toBe("aabb");
+    expect(wants[0]!.token).toBe("ccdd");
+  });
+});

--- a/templates/zswap-da/packages/validator/derive.ts
+++ b/templates/zswap-da/packages/validator/derive.ts
@@ -1,0 +1,129 @@
+import { addressFromKey } from "@midnight-ntwrk/ledger-v8";
+import type { TokenType, UnprovenTransaction } from "@midnight-ntwrk/ledger-v8";
+import { Buffer } from "node:buffer";
+
+import type { OfferLeg, UnshieldedSpendRef } from "./types.ts";
+
+// Normalize a value that may be a Uint8Array or a hex string into lowercase
+// hex (no `0x` prefix). ledger-v8 returns nullifiers / owner keys / intent
+// hashes as either form depending on the field. Mirrors the helper in the
+// node's state-machine so indexing and validation agree byte-for-byte.
+export function bytesOrStringToHex(value: unknown): string {
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("hex").toLowerCase();
+  }
+  if (typeof value === "string") {
+    const clean = value.startsWith("0x") || value.startsWith("0X")
+      ? value.slice(2)
+      : value;
+    return clean.toLowerCase();
+  }
+  return String(value).toLowerCase();
+}
+
+// The set of shielded offers carried by a transaction: the guaranteed segment
+// plus every non-guaranteed (fallible) segment.
+function shieldedOffersOf(tx: UnprovenTransaction): any[] {
+  const offers: any[] = [];
+  if (tx.guaranteedOffer) offers.push(tx.guaranteedOffer);
+  const fallible = tx.fallibleOffer as any;
+  if (fallible && typeof fallible.values === "function") {
+    for (const segOffer of fallible.values() as Iterable<any>) {
+      if (segOffer) offers.push(segOffer);
+    }
+  }
+  return offers;
+}
+
+// Collect every shielded nullifier the offer consumes, across guaranteed +
+// fallible segments and both `inputs` and `transients`. The Midnight fetcher
+// detects consumption segment-agnostically, so indexing must match.
+export function collectNullifiers(tx: UnprovenTransaction): string[] {
+  const nullifiers: string[] = [];
+  for (const o of shieldedOffersOf(tx)) {
+    for (const input of o.inputs ?? []) {
+      nullifiers.push(bytesOrStringToHex(input.nullifier));
+    }
+    for (const t of o.transients ?? []) {
+      nullifiers.push(bytesOrStringToHex(t.nullifier));
+    }
+  }
+  return nullifiers;
+}
+
+// Collect the (owner, intentHash, outputNo) triples for every unshielded UTXO
+// the offer spends. `UtxoSpend.owner` is a raw SignatureVerifyingKey; apply
+// `addressFromKey` so it matches the 32-byte address the indexer reports on
+// consumption (the `midnight-unshielded-spend` path).
+export function collectUnshieldedSpends(
+  tx: UnprovenTransaction,
+): UnshieldedSpendRef[] {
+  const spends: UnshieldedSpendRef[] = [];
+  const intents = (tx as any).intents;
+  if (intents && typeof intents.values === "function") {
+    for (const intent of intents.values() as Iterable<any>) {
+      const unshieldedOffers = [
+        intent.guaranteedUnshieldedOffer,
+        intent.fallibleUnshieldedOffer,
+      ].filter(Boolean);
+      for (const offer of unshieldedOffers) {
+        for (const spend of offer.inputs ?? []) {
+          const ownerSvk = bytesOrStringToHex(spend.owner);
+          spends.push({
+            owner: addressFromKey(ownerSvk).toLowerCase(),
+            intentHash: bytesOrStringToHex(spend.intentHash).toLowerCase(),
+            outputNo: Number(spend.outputNo),
+          });
+        }
+      }
+    }
+  }
+  return spends;
+}
+
+// Thrown when a token carries a tag other than shielded/unshielded/dust.
+export class UnknownTokenTagError extends Error {
+  constructor(public readonly tag: string) {
+    super(`Unknown token tag "${tag}"`);
+    this.name = "UnknownTokenTagError";
+  }
+}
+
+// Derive give/want legs from the transaction's per-segment imbalances, merged
+// across the guaranteed segment + every intent/fallible segment. A positive
+// merged delta is a give (surplus the maker provides); negative is a want.
+// `dust` is ignored; any other unexpected tag throws UnknownTokenTagError.
+export function deriveLegs(
+  tx: UnprovenTransaction,
+): { gives: OfferLeg[]; wants: OfferLeg[] } {
+  const intentKeys = (tx as any).intents
+    ? Array.from((tx as any).intents.keys() as Iterable<number>)
+    : [];
+  const fallibleKeys = tx.fallibleOffer
+    ? Array.from(tx.fallibleOffer.keys() as Iterable<number>)
+    : [];
+  const segmentIds = Array.from(
+    new Set<number>([0, ...intentKeys, ...fallibleKeys]),
+  );
+
+  const merged = new Map<string, bigint>();
+  for (const segId of segmentIds) {
+    for (const [tokenType, delta] of tx.imbalances(segId)) {
+      const tt = tokenType as TokenType;
+      if (tt.tag === "dust") continue;
+      if (tt.tag !== "shielded" && tt.tag !== "unshielded") {
+        throw new UnknownTokenTagError(String((tt as any).tag));
+      }
+      const token = tt.raw.toLowerCase();
+      merged.set(token, (merged.get(token) ?? 0n) + delta);
+    }
+  }
+
+  const gives: OfferLeg[] = [];
+  const wants: OfferLeg[] = [];
+  for (const [token, delta] of merged) {
+    if (delta > 0n) gives.push({ token, amount: delta.toString() });
+    else if (delta < 0n) wants.push({ token, amount: (-delta).toString() });
+  }
+  return { gives, wants };
+}

--- a/templates/zswap-da/packages/validator/fixtures/README.md
+++ b/templates/zswap-da/packages/validator/fixtures/README.md
@@ -1,0 +1,33 @@
+# Validator test fixtures
+
+The structural + encoding tests run with synthetic data. The **cryptographic**
+tests (`wellFormed` proof verification, the blank-refState risk, tampered-proof,
+liveness) need a **real proven offer** — ZK proofs cannot be synthesized — so
+they are `skip`ped until a fixture exists here.
+
+## To activate the crypto tests
+
+1. Make a real offer with Lace via the frontend (the normal flow:
+   `SwapInterface` → `makeIntent` produces a `<signature, proof, binding>`
+   transaction, encoded as a `zswapoffer1…` bech32m string).
+2. Save that string (no trailing newline matters; it's trimmed) to:
+
+   ```
+   packages/validator/fixtures/valid-offer.bech32
+   ```
+
+3. If the offer's Midnight network is not `undeployed`, set the env var when
+   running tests so the reference state matches:
+
+   ```
+   ZSWAP_TEST_NETWORK_ID=testnet bun test packages/validator
+   ```
+
+`valid-offer.bech32` should be committed once captured — it is a public,
+intentionally-unbalanced open offer and contains no secrets.
+
+## Capturing during e2e
+
+The orchestrator e2e brings up the Midnight proof server + node + indexer. A
+real offer produced during that run can be copied here to lock in a regression
+fixture for the crypto path.

--- a/templates/zswap-da/packages/validator/mod.ts
+++ b/templates/zswap-da/packages/validator/mod.ts
@@ -1,0 +1,21 @@
+// @zswap-da/validator — shared, pure ZSwap offer validation.
+//
+// One deterministic routine used by the state-machine ingestion path and the
+// batcher / submit fee-gate. No I/O of its own: callers supply `refState`,
+// `tblock`, and (optionally) liveness checks. See validate.ts for the pipeline.
+export { validateZswapOffer } from "./validate.ts";
+export { getBlankRefState, buildStrictness } from "./refstate.ts";
+export {
+  bytesOrStringToHex,
+  collectNullifiers,
+  collectUnshieldedSpends,
+  deriveLegs,
+  UnknownTokenTagError,
+} from "./derive.ts";
+export type {
+  OfferRejectCode,
+  OfferValidation,
+  OfferLeg,
+  UnshieldedSpendRef,
+  ValidateOpts,
+} from "./types.ts";

--- a/templates/zswap-da/packages/validator/package.json
+++ b/templates/zswap-da/packages/validator/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zswap-da/validator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": "./mod.ts",
+  "scripts": {
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@midnight-ntwrk/ledger-v8": "8.0.3",
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
+    "@scure/base": "^2.0.0",
+    "mip-zswap-offer": "github:effectstream/mip-zswap-offer#main"
+  }
+}

--- a/templates/zswap-da/packages/validator/refstate.ts
+++ b/templates/zswap-da/packages/validator/refstate.ts
@@ -1,0 +1,48 @@
+import { LedgerState, WellFormedStrictness } from "@midnight-ntwrk/ledger-v8";
+
+// Reference state for `Transaction.wellFormed`. The security-critical
+// `stateless_check` (ZK proof + signature verification) is STATE-INDEPENDENT —
+// it uses bundled verifier keys and never reads state content — so a blank
+// state verifies proofs exactly like a real one. With `enforceBalancing=false`
+// and `enforceLimits=false` (below), the only parts of `ref_state` consulted
+// are the network id (we pass the matching one) and a couple of network
+// parameters (the weak TTL check's `global_ttl`, and a tolerated fee
+// computation), all of which a blank state carries at the network defaults.
+//
+// RISK / fallback: if a real offer is rejected by `wellFormed` against a blank
+// state (e.g. its TTL/params disagree with the blank defaults), construct a
+// state from real `LedgerParameters` instead — the indexer exposes
+// `block.ledgerParameters`. Verify empirically with a real proven-offer
+// fixture (see packages/validator/fixtures/README.md) before relying on this.
+const blankCache = new Map<string, LedgerState>();
+
+export function getBlankRefState(networkId: string): LedgerState {
+  let state = blankCache.get(networkId);
+  if (!state) {
+    state = LedgerState.blank(networkId);
+    blankCache.set(networkId, state);
+  }
+  return state;
+}
+
+// Strictness for an OPEN (intentionally unbalanced) ZSwap offer. Every flag is
+// set explicitly — do NOT rely on constructor defaults.
+//
+//   enforceBalancing = false  ← CRITICAL: open offers are unbalanced by design;
+//                               true rejects every legitimate offer.
+//   verifyNativeProofs = true ← verify the zswap input/output/transient ZK
+//                               proofs (this is what rejects forged coins).
+//   verifyContractProofs = true
+//   verifySignatures = true
+//   enforceLimits = false     ← the ledger byte-limit check reads a blank-state
+//                               parameter; we cap size ourselves via maxBytes,
+//                               so leave it off to avoid that dependency.
+export function buildStrictness(): WellFormedStrictness {
+  const s = new WellFormedStrictness();
+  s.enforceBalancing = false;
+  s.verifyNativeProofs = true;
+  s.verifyContractProofs = true;
+  s.verifySignatures = true;
+  s.enforceLimits = false;
+  return s;
+}

--- a/templates/zswap-da/packages/validator/scripts/check-preview-indexer.ts
+++ b/templates/zswap-da/packages/validator/scripts/check-preview-indexer.ts
@@ -1,0 +1,102 @@
+// Simple, dependency-free confirmation of the on-chain data the liveness checks
+// rely on, run against a public Midnight indexer. No wallet/secrets needed — it
+// only reads public block data + schema introspection.
+//
+//   bun packages/validator/scripts/check-preview-indexer.ts            # preview
+//   bun packages/validator/scripts/check-preview-indexer.ts testnet    # other net
+//
+// It confirms: RegularTransaction.raw (full tx) and zswapMerkleTreeRoot exist
+// and are populated; Block.timestamp exists; the spent-set sources
+// (unshieldedSpentOutputs, zswapLedgerEvents) exist; and there is NO global
+// serialized ledger/zswap *state* type (only per-contract state + a wallet-sync
+// MerkleTreeCollapsedUpdate) — i.e. a validation-capable global ZswapChainState
+// would have to be reconstructed.
+
+const net = process.argv[2] ?? "preview";
+const URL = `https://indexer.${net}.midnight.network/api/v3/graphql`;
+
+async function gql(query: string, variables?: unknown) {
+  const res = await fetch(URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  return (await res.json()) as any;
+}
+const ok = (b: boolean) => (b ? "✅" : "❌");
+
+console.log(`Indexer: ${URL}\n`);
+
+// 1) RegularTransaction schema — the fields we read.
+const rt = await gql(`{ __type(name:"RegularTransaction"){ fields(includeDeprecated:true){ name isDeprecated deprecationReason } } }`);
+const fields: any[] = rt?.data?.__type?.fields ?? [];
+const has = (n: string) => fields.some((f) => f.name === n);
+console.log(`${ok(has("raw"))} RegularTransaction.raw (full serialized tx → reconstruct/deserialize)`);
+console.log(`${ok(has("zswapMerkleTreeRoot"))} RegularTransaction.zswapMerkleTreeRoot (post-tx coin-tree root == past_roots entry)`);
+const dep = fields.find((f) => f.name === "merkleTreeRoot");
+if (dep?.isDeprecated) console.log(`   ↳ legacy alias 'merkleTreeRoot' is deprecated: "${dep.deprecationReason}"`);
+console.log(`${ok(has("zswapLedgerEvents"))} RegularTransaction.zswapLedgerEvents (nullifier spends → spent_nullifiers)`);
+console.log(`${ok(has("unshieldedSpentOutputs"))} RegularTransaction.unshieldedSpentOutputs (→ spent_unshielded)`);
+
+// 2) Block.timestamp — needed for postBlockUpdate's root window.
+const blk = await gql(`{ __type(name:"Block"){ fields { name } } }`);
+const blkHas = (n: string) => (blk?.data?.__type?.fields ?? []).some((f: any) => f.name === n);
+console.log(`${ok(blkHas("timestamp"))} Block.timestamp (postBlockUpdate window)`);
+
+// 3) No global serialized ledger/zswap *state* type.
+const all = await gql(`{ __schema { types { name kind } } }`);
+const stateTypes = (all?.data?.__schema?.types ?? [])
+  .filter((t: any) => /chainstate|ledgerstate|zswapstate/i.test(t.name) && !t.name.startsWith("__"))
+  .map((t: any) => t.name);
+console.log(`${ok(stateTypes.length === 0)} no global ZswapChainState/LedgerState type exposed${stateTypes.length ? " (found: " + stateTypes.join(",") + ")" : ""}`);
+const qfields = (await gql(`{ __schema { queryType { fields { name } } } }`))?.data?.__schema?.queryType?.fields?.map((f: any) => f.name) ?? [];
+const zswapQ = qfields.filter((n: string) => /zswap/i.test(n));
+console.log(`   ↳ root zswap queries: ${zswapQ.join(", ") || "none"} (collapsed-tree update → wallet ZswapLocalState, not a tryApply-capable state)`);
+
+// 4) Reconstruction correctness inputs: per-segment success + unshielded
+//    existence sources.
+console.log(`${ok(has("transactionResult"))} RegularTransaction.transactionResult (segments[].success — a state rebuild must skip failed segments)`);
+console.log(`${ok(has("unshieldedCreatedOutputs"))} RegularTransaction.unshieldedCreatedOutputs (unshielded-existence source)`);
+const utxo = await gql(`{ __type(name:"UnshieldedUtxo"){ fields { name } } }`);
+const utxoFields = (utxo?.data?.__type?.fields ?? []).map((f: any) => f.name);
+console.log(`${ok(utxoFields.includes("createdAtTransaction") && utxoFields.includes("spentAtTransaction"))} UnshieldedUtxo.createdAtTransaction + spentAtTransaction (existence + spent queryable)`);
+
+// 5) Node RPC: only root digests, no full-state method.
+try {
+  const rpcUrl = `https://rpc.${net}.midnight.network`;
+  const rpc = async (method: string) =>
+    (await (await fetch(rpcUrl, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [] }) })).json()) as any;
+  const midnightMethods: string[] = ((await rpc("rpc_methods"))?.result?.methods ?? []).filter((m: string) => /midnight/i.test(m));
+  console.log(`\nRPC ${rpcUrl}`);
+  console.log(`   midnight_* methods: ${midnightMethods.join(", ") || "(none listed)"}`);
+  const fullState = midnightMethods.filter((m) => /state/i.test(m) && !/root/i.test(m) && !/contract/i.test(m));
+  console.log(`${ok(fullState.length === 0)} no full-state RPC (only root digests + per-contract state)`);
+  const root = await rpc("midnight_zswapStateRoot");
+  console.log(`${ok(Array.isArray(root?.result))} midnight_zswapStateRoot returns a bare digest (${Array.isArray(root?.result) ? root.result.length + " bytes" : JSON.stringify(root?.error ?? root).slice(0, 60)})`);
+} catch (e) {
+  console.log(`RPC check skipped (${String(e).slice(0, 80)})`);
+}
+
+// 6) Root-check blocker, demonstrated at runtime: the installed ledger-v8
+//    binding exposes ZswapInput.nullifier but NOT the input's merkleTreeRoot,
+//    so a roots-set membership check has nothing to compare against.
+const { ZswapInput } = await import("@midnight-ntwrk/ledger-v8");
+const desc = (p: string) => !!Object.getOwnPropertyDescriptor((ZswapInput as any).prototype, p);
+console.log(`\n${ok(desc("nullifier"))} ZswapInput.nullifier getter exists (binding pattern works)`);
+console.log(`${ok(!desc("merkleTreeRoot"))} ZswapInput.merkleTreeRoot getter ABSENT — root-check blocker confirmed at runtime`);
+console.log(`   ZswapInput.prototype: ${Object.getOwnPropertyNames((ZswapInput as any).prototype).join(", ")}`);
+
+// 7) Show populated values from a recent block that has transactions.
+const latest = (await gql(`{ block { height } }`))?.data?.block?.height;
+const heights = Array.from({ length: 24 }, (_, i) => latest - i * 137);
+const blocks = await Promise.all(
+  heights.map((h) => gql(`query($h:Int!){ block(offset:{height:$h}){ height transactions { __typename ... on RegularTransaction { zswapMerkleTreeRoot raw transactionResult { status } } } } }`, { h })),
+);
+const hit = blocks.map((b) => b?.data?.block).find((b: any) => (b?.transactions?.length ?? 0) > 0);
+console.log(`\nLatest height ${latest}.`);
+if (hit) {
+  const t = hit.transactions.find((x: any) => x.__typename === "RegularTransaction") ?? hit.transactions[0];
+  console.log(`Populated block ${hit.height}: zswapMerkleTreeRoot=${t.zswapMerkleTreeRoot?.slice(0, 24)}… (len ${t.zswapMerkleTreeRoot?.length}), raw len ${t.raw?.length}, result=${t.transactionResult?.status}`);
+} else {
+  console.log("No transactions in the sampled blocks (this network is low-traffic) — fields confirmed via schema above.");
+}

--- a/templates/zswap-da/packages/validator/types.ts
+++ b/templates/zswap-da/packages/validator/types.ts
@@ -1,0 +1,81 @@
+import type { LedgerState, UnprovenTransaction } from "@midnight-ntwrk/ledger-v8";
+
+// Why an offer is rejected. Ordered roughly cheap → expensive in the pipeline.
+//
+// Liveness note: ROOT_UNKNOWN is intentionally absent. The apply-time
+// root-known check needs the global ZswapChainState, which is not fetchable
+// from the node RPC or indexer, and `ZswapInput` does not expose the input's
+// merkle root — so it cannot be checked here. Root staleness is instead
+// bounded by the offer TTL (set to track the on-chain root window — ~1h in the
+// current ledger release, ~14 days next; default 30 days, configurable), and a
+// fake/stale-root offer can never settle. A future Midnight sync primitive that
+// ingests the recent-roots set can make this check explicit.
+export type OfferRejectCode =
+  | "BAD_ENCODING"
+  | "TOO_LARGE"
+  | "BAD_DESERIALIZE"
+  | "WRONG_TX_VARIANT"
+  | "NO_SPENDABLE_INPUT"
+  | "NOT_A_SWAP"
+  | "UNKNOWN_TOKEN"
+  | "PROOF_INVALID"
+  | "SIGNATURE_INVALID"
+  | "NULLIFIER_SPENT"
+  | "UTXO_SPENT"
+  | "DUPLICATE";
+
+// An unshielded UTXO an offer spends, identified the same way the
+// `midnight-unshielded-spend` consumption event identifies it: the maker's
+// address (derived from the input's SignatureVerifyingKey), the intent hash,
+// and the output index. All hex fields are lowercase, no `0x` prefix.
+export interface UnshieldedSpendRef {
+  owner: string;
+  intentHash: string;
+  outputNo: number;
+}
+
+// A give/want leg derived from the transaction's per-segment imbalances.
+// `token` is the lowercase token color (RawTokenType hex); `amount` is a
+// non-negative decimal string (the absolute imbalance for that direction).
+export interface OfferLeg {
+  token: string;
+  amount: string;
+}
+
+export interface OfferValidation {
+  ok: boolean;
+  code?: OfferRejectCode;
+  reason?: string;
+
+  // Populated whenever deserialization (step 3) succeeds, so a caller can
+  // perform its own async liveness using the derived nullifiers/triples even
+  // when the verdict is ok.
+  tx?: UnprovenTransaction;
+  nullifiers?: string[];
+  unshieldedSpends?: UnshieldedSpendRef[];
+  gives?: OfferLeg[];
+  wants?: OfferLeg[];
+  identifiers?: string[];
+}
+
+export interface ValidateOpts {
+  // Reference ledger state for `Transaction.wellFormed`. Use
+  // `getBlankRefState(networkId)` unless you have a real state to pass.
+  refState: LedgerState;
+  // Deterministic block timestamp for `wellFormed` time checks. In the STM use
+  // `new Date(data.blockTimestamp)`; in request/response paths `new Date()`.
+  tblock: Date;
+  // Max decoded transaction size in bytes.
+  maxBytes: number;
+
+  // Optional SYNCHRONOUS liveness checks. Provide these only when a sync check
+  // is available (unit tests with in-memory sets; callers that pre-fetched).
+  // Async callers (the STM via World.resolve, submit via pg, the batcher via
+  // the indexer) should instead leave these unset and run liveness themselves
+  // on the returned `nullifiers` / `unshieldedSpends`, reusing the
+  // NULLIFIER_SPENT / UTXO_SPENT codes.
+  isNullifierSpent?: (nullifierHex: string) => boolean;
+  isUnshieldedSpent?: (ref: UnshieldedSpendRef) => boolean;
+  // Optional dedup hook (e.g. already-indexed nullifiers/identifiers).
+  seen?: (nullifiers: string[], identifiers: string[]) => boolean;
+}

--- a/templates/zswap-da/packages/validator/validate.test.ts
+++ b/templates/zswap-da/packages/validator/validate.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { bech32m } from "@scure/base";
+import {
+  LedgerState,
+  Transaction,
+  WellFormedStrictness,
+} from "@midnight-ntwrk/ledger-v8";
+import { decodeOffer, OFFER_HRP } from "mip-zswap-offer";
+
+import {
+  buildStrictness,
+  getBlankRefState,
+  validateZswapOffer,
+} from "./mod.ts";
+
+// A reference state is only consulted in step 5 (wellFormed); steps 1–4 never
+// touch it, so the cheap-path tests pass a dummy.
+const NO_REF = undefined as unknown as LedgerState;
+const TBLOCK = new Date(0);
+
+// Build a syntactically valid bech32m `zswapoffer1…` blob wrapping arbitrary
+// bytes (decodeOffer does pure bech32m, so this passes encoding but not
+// deserialization).
+function craftBlob(byteLen: number): string {
+  return bech32m.encode(OFFER_HRP, bech32m.toWords(new Uint8Array(byteLen).fill(7)), false);
+}
+
+describe("validateZswapOffer — encoding (step 1)", () => {
+  test("non-bech32m string → BAD_ENCODING", () => {
+    const r = validateZswapOffer("definitely-not-an-offer", {
+      refState: NO_REF,
+      tblock: TBLOCK,
+      maxBytes: 10_000,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("BAD_ENCODING");
+  });
+
+  test("right HRP but bad checksum → BAD_ENCODING", () => {
+    const r = validateZswapOffer(`${OFFER_HRP}1qqqqqzzzz`, {
+      refState: NO_REF,
+      tblock: TBLOCK,
+      maxBytes: 10_000,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("BAD_ENCODING");
+  });
+});
+
+describe("validateZswapOffer — size (step 2)", () => {
+  test("decoded bytes over maxBytes → TOO_LARGE", () => {
+    const r = validateZswapOffer(craftBlob(40), {
+      refState: NO_REF,
+      tblock: TBLOCK,
+      maxBytes: 8,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("TOO_LARGE");
+  });
+});
+
+describe("validateZswapOffer — deserialize (step 3)", () => {
+  test("valid bech32m of junk bytes → BAD_DESERIALIZE", () => {
+    const r = validateZswapOffer(craftBlob(40), {
+      refState: NO_REF,
+      tblock: TBLOCK,
+      maxBytes: 10_000,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("BAD_DESERIALIZE");
+  });
+});
+
+describe("config helpers", () => {
+  test("buildStrictness sets every flag explicitly (balancing OFF)", () => {
+    const s = buildStrictness();
+    expect(s.enforceBalancing).toBe(false);
+    expect(s.verifyNativeProofs).toBe(true);
+    expect(s.verifyContractProofs).toBe(true);
+    expect(s.verifySignatures).toBe(true);
+    expect((s as unknown as { enforceLimits: boolean }).enforceLimits).toBe(false);
+  });
+
+  test("getBlankRefState returns a LedgerState and caches per network id", () => {
+    const a = getBlankRefState("undeployed");
+    const b = getBlankRefState("undeployed");
+    expect(a).toBeInstanceOf(LedgerState);
+    expect(a).toBe(b); // cached
+  });
+});
+
+// ── Cryptographic + liveness path (step 5–6) ──────────────────────────────
+//
+// These require a REAL proven offer; ZK proofs cannot be synthesized. Drop a
+// Lace-made `zswapoffer1…` string into packages/validator/fixtures/valid-offer.bech32
+// (and set ZSWAP_TEST_NETWORK_ID if the offer's network is not "undeployed"),
+// then these activate automatically. See fixtures/README.md.
+const FIXTURE = join(import.meta.dir, "fixtures", "valid-offer.bech32");
+const NETWORK_ID = process.env["ZSWAP_TEST_NETWORK_ID"] ?? "undeployed";
+const hasFixture = existsSync(FIXTURE);
+
+describe.skipIf(!hasFixture)("validateZswapOffer — crypto + liveness (real fixture)", () => {
+  const blob = hasFixture ? readFileSync(FIXTURE, "utf8").trim() : "";
+  const opts = () => ({
+    refState: getBlankRefState(NETWORK_ID),
+    tblock: TBLOCK,
+    maxBytes: 1_000_000,
+  });
+
+  test("a valid open offer passes with a BLANK refState (the #1 risk)", () => {
+    const r = validateZswapOffer(blob, opts());
+    expect(r.ok).toBe(true);
+    expect(r.gives!.length).toBeGreaterThan(0);
+    expect(r.wants!.length).toBeGreaterThan(0);
+    // open offer must have at least one spendable input
+    expect((r.nullifiers!.length + r.unshieldedSpends!.length)).toBeGreaterThan(0);
+  });
+
+  test("enforceBalancing=true rejects the same open offer (proves false is required)", () => {
+    const raw = decodeOffer(blob);
+    const tx = Transaction.deserialize("signature", "proof", "binding", raw);
+    const strict = new WellFormedStrictness();
+    strict.enforceBalancing = true;
+    strict.verifyNativeProofs = true;
+    strict.verifyContractProofs = true;
+    strict.verifySignatures = true;
+    (strict as unknown as { enforceLimits: boolean }).enforceLimits = true;
+    expect(() => tx.wellFormed(getBlankRefState(NETWORK_ID), strict, TBLOCK)).toThrow();
+  });
+
+  test("tampered proof bytes are rejected (PROOF_INVALID or BAD_DESERIALIZE)", () => {
+    const raw = decodeOffer(blob);
+    const tampered = Uint8Array.from(raw);
+    // Flip bytes deep in the blob (proof region) to corrupt the ZK proof.
+    const at = Math.floor(tampered.length * 0.8);
+    tampered[at] = tampered[at]! ^ 0xff;
+    const blob2 = bech32m.encode(OFFER_HRP, bech32m.toWords(tampered), false);
+    const r = validateZswapOffer(blob2, opts());
+    expect(r.ok).toBe(false);
+  });
+
+  test("liveness: a spent nullifier → NULLIFIER_SPENT", () => {
+    const probe = validateZswapOffer(blob, opts());
+    if (!probe.ok || probe.nullifiers!.length === 0) return; // unshielded-only fixture
+    const spent = new Set(probe.nullifiers);
+    const r = validateZswapOffer(blob, {
+      ...opts(),
+      isNullifierSpent: (n) => spent.has(n),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("NULLIFIER_SPENT");
+  });
+
+  test("determinism: identical verdict on repeat", () => {
+    const a = validateZswapOffer(blob, opts());
+    const b = validateZswapOffer(blob, opts());
+    expect(a.ok).toBe(b.ok);
+    expect(a.nullifiers).toEqual(b.nullifiers);
+    expect(a.gives).toEqual(b.gives);
+    expect(a.wants).toEqual(b.wants);
+  });
+});

--- a/templates/zswap-da/packages/validator/validate.ts
+++ b/templates/zswap-da/packages/validator/validate.ts
@@ -1,0 +1,189 @@
+import { Transaction } from "@midnight-ntwrk/ledger-v8";
+import type { UnprovenTransaction } from "@midnight-ntwrk/ledger-v8";
+import { decodeOffer, OFFER_HRP } from "mip-zswap-offer";
+
+import {
+  collectNullifiers,
+  collectUnshieldedSpends,
+  deriveLegs,
+  UnknownTokenTagError,
+} from "./derive.ts";
+import { buildStrictness } from "./refstate.ts";
+import type {
+  OfferRejectCode,
+  OfferValidation,
+  ValidateOpts,
+} from "./types.ts";
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// `identifiers()` is only needed for dedup; never let it sink a validation.
+function safeIdentifiers(tx: UnprovenTransaction): string[] {
+  try {
+    return tx.identifiers();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Validate a ZSwap offer blob. Deterministic given (blob, refState, tblock) —
+ * safe to call inside the state machine. Steps run cheap → expensive and stop
+ * at the first failure:
+ *
+ *   1 encoding · 2 size · 3 deserialize · 4 structural/semantic · 5 crypto
+ *   (wellFormed) · 6 liveness (optional sync) · 7 dedup (optional)
+ *
+ * On success — and whenever deserialization succeeds — the derived
+ * `tx/nullifiers/unshieldedSpends/gives/wants/identifiers` are returned so a
+ * caller can run its own async liveness without reparsing.
+ */
+export function validateZswapOffer(
+  blob: string,
+  opts: ValidateOpts,
+): OfferValidation {
+  // ── 1. Encoding ──
+  if (typeof blob !== "string" || !blob.startsWith(`${OFFER_HRP}1`)) {
+    return {
+      ok: false,
+      code: "BAD_ENCODING",
+      reason: "not a zswapoffer bech32m string",
+    };
+  }
+  let rawTx: Uint8Array;
+  try {
+    rawTx = decodeOffer(blob);
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_ENCODING",
+      reason: `bech32m decode failed: ${errMsg(e)}`,
+    };
+  }
+
+  // ── 2. Size ──
+  if (rawTx.length > opts.maxBytes) {
+    return {
+      ok: false,
+      code: "TOO_LARGE",
+      reason: `offer is ${rawTx.length} bytes > max ${opts.maxBytes}`,
+    };
+  }
+
+  // ── 3. Deserialize (Lace-shaped <signature, proof, binding>) ──
+  let tx: UnprovenTransaction;
+  try {
+    tx = Transaction.deserialize(
+      "signature" as const,
+      "proof" as const,
+      "binding" as const,
+      rawTx,
+    ) as UnprovenTransaction;
+  } catch (e) {
+    return {
+      ok: false,
+      code: "BAD_DESERIALIZE",
+      reason: `deserialize failed: ${errMsg(e)}`,
+    };
+  }
+
+  // ── 4. Structural / semantic ──
+  const nullifiers = collectNullifiers(tx);
+  const unshieldedSpends = collectUnshieldedSpends(tx);
+  if (nullifiers.length === 0 && unshieldedSpends.length === 0) {
+    return {
+      ok: false,
+      code: "NO_SPENDABLE_INPUT",
+      reason: "no shielded input/transient or unshielded spend",
+      tx,
+    };
+  }
+
+  let gives, wants;
+  try {
+    ({ gives, wants } = deriveLegs(tx));
+  } catch (e) {
+    if (e instanceof UnknownTokenTagError) {
+      return {
+        ok: false,
+        code: "UNKNOWN_TOKEN",
+        reason: e.message,
+        tx,
+        nullifiers,
+        unshieldedSpends,
+      };
+    }
+    // Segment ids came from the tx itself; a throw here means a malformed tx.
+    return {
+      ok: false,
+      code: "BAD_DESERIALIZE",
+      reason: `imbalance derivation failed: ${errMsg(e)}`,
+      tx,
+      nullifiers,
+      unshieldedSpends,
+    };
+  }
+  if (gives.length === 0 || wants.length === 0) {
+    return {
+      ok: false,
+      code: "NOT_A_SWAP",
+      reason:
+        `expected ≥1 give and ≥1 want; got ${gives.length} give(s), ${wants.length} want(s)`,
+      tx,
+      nullifiers,
+      unshieldedSpends,
+      gives,
+      wants,
+    };
+  }
+
+  const identifiers = safeIdentifiers(tx);
+  const derived = { tx, nullifiers, unshieldedSpends, gives, wants, identifiers };
+
+  // ── 5. Cryptographic (rejects forged proofs / made-up coins) ──
+  try {
+    tx.wellFormed(opts.refState, buildStrictness(), opts.tblock);
+  } catch (e) {
+    const m = errMsg(e);
+    const code: OfferRejectCode = /signature/i.test(m)
+      ? "SIGNATURE_INVALID"
+      : "PROOF_INVALID";
+    return { ok: false, code, reason: `wellFormed failed: ${m}`, ...derived };
+  }
+
+  // ── 6. Liveness (optional synchronous checks) ──
+  if (opts.isNullifierSpent) {
+    for (const n of nullifiers) {
+      if (opts.isNullifierSpent(n)) {
+        return {
+          ok: false,
+          code: "NULLIFIER_SPENT",
+          reason: `nullifier already spent: ${n}`,
+          ...derived,
+        };
+      }
+    }
+  }
+  if (opts.isUnshieldedSpent) {
+    for (const ref of unshieldedSpends) {
+      if (opts.isUnshieldedSpent(ref)) {
+        return {
+          ok: false,
+          code: "UTXO_SPENT",
+          reason:
+            `unshielded UTXO already spent: ${ref.owner}/${ref.intentHash}/${ref.outputNo}`,
+          ...derived,
+        };
+      }
+    }
+  }
+
+  // ── 7. Dedup (optional) ──
+  if (opts.seen && opts.seen(nullifiers, identifiers)) {
+    return { ok: false, code: "DUPLICATE", reason: "offer already seen", ...derived };
+  }
+
+  return { ok: true, ...derived };
+}


### PR DESCRIPTION
## What

One shared, pure validation routine (`@zswap-da/validator`) wired into all three trust points of the zswap-da template, so malformed / cryptographically-forged / non-swap / **already-spent** offers are neither indexed nor paid for:

| Gate | Behavior on bad offer |
|---|---|
| `celestia-zswap` STM handler (defensive — anyone can post to the public namespace) | drop + `offer_rejected` event, never indexed |
| `POST /api/zswap/submit` | `400 {error, reason}` before any batcher forward |
| Batcher `ZswapCelestiaAdapter.validateInput` | rejected in `batchInput()` **before any Celestia post → no fee spent** |

Pipeline: bech32m → size cap → deserialize → structural derive (nullifiers, unshielded-spend triples, gives/wants from the ledger's own `imbalances()`) → **`Transaction.wellFormed`** (ZK proof + signature verification; `enforceBalancing=false` since open offers are unbalanced by design) → spent-set liveness → dedup hooks.

## Liveness

New permanent `spent_nullifiers` / `spent_unshielded` tables (`001-spent-sets.sql`), populated by the existing `midnight-nullifier` / `midnight-unshielded-spend` handlers on every event (the transient `seen_*` buffers are unchanged). These answer "has this coin **ever** been spent" — required because old coins can be re-proven against fresh roots, so spent-history must be eternal.

`bun packages/validator/scripts/check-preview-indexer.ts` reproduces the on-chain data assumptions against the public preview indexer + RPC (read-only, no secrets).

## Config

- `OFFER_TTL_SECONDS` default 1h → **30 days** (tracks the on-chain root-retention window: ~1h current ledger release, ~14d next per release notes; operators tune to their network).
- `OFFER_MAX_BYTES` (1 MiB default) decode-size guard.

## Tests

- `bun test packages/validator packages/database` → **19 pass / 5 skip / 0 fail**.
- The 5 skipped are the crypto-path tests requiring a **real proven offer fixture** (`packages/validator/fixtures/valid-offer.bech32`, see fixtures/README.md) — capturing one during the next e2e run activates them and closes the one unverified assumption (blank-`LedgerState` acceptance by `wellFormed`; fallback documented in `refstate.ts`).
- DB migration + hand-generated pgtyped IRs verified end-to-end against in-memory PGlite over the pg wire protocol (`spent-sets.test.ts`) — `build:pgtypes` against a live Postgres will reproduce them.

## Follow-ups (next PR, planned)

`created_unshielded` + `known_roots` liveness primitives (touches `node-sdk/sync` + `node-sdk/sm`); and the submit-side anti-fee-griefing policy gate (rate limits + auth + min give-value).