### PR TITLE
fix(frontend): externalize optional/peer deps from browser bundle (fixes release publish)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,11 +73,41 @@ jobs:
           docker run --rm --name templates_${{ github.run_number }} testing_image:${{ github.sha }} \
             bash -c "bun run templates/run-template-tests.ts ${{ needs.changes.outputs.templates }} --skip-disabled"
 
+  # Browser build (+ tests) of @effectstream/frontend-sdk. This is the ONLY
+  # package that needs a build before publish, and that build (`bun run build`,
+  # target: "browser") is otherwise never exercised until release-publish time.
+  # A node-only module leaking into the browser bundle therefore passes every
+  # push/PR check and only blows up the release — which is exactly what happened
+  # for v0.100.19–v0.100.22 (@effectstream/midnight-contracts, an optional peer
+  # dep of @effectstream/wallets reached via dynamic import, pulled `node:util`
+  # parseArgs into the bundle). Run the build + its regression test here, gated on
+  # core changes, so the failure surfaces in PRs instead of at release.
+  frontend-build:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' && (github.event_name == 'push' || !github.event.pull_request.draft) }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Runs build.test.ts (spawns the real `bun run build`, asserting the
+      # browser bundle succeeds + node-only optional peers stay external) and
+      # examples.test.ts (the public re-export surface).
+      - name: Build & test frontend SDK
+        run: bun test packages/frontend/test/
+
   # Aggregate gate: a single stable check to mark required in branch protection.
-  # Passes when e2e/template-tests succeed or are skipped; fails if either fails
-  # or is cancelled (or if the changes job itself failed).
+  # Passes when the gated jobs succeed or are skipped; fails if any fails or is
+  # cancelled (or if the changes job itself failed).
   ci-ok:
-    needs: [changes, e2e, template-tests]
+    needs: [changes, e2e, template-tests, frontend-build]
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -87,11 +117,14 @@ jobs:
           echo "changes=${{ needs.changes.result }}"
           echo "e2e=${{ needs.e2e.result }}"
           echo "template-tests=${{ needs.template-tests.result }}"
+          echo "frontend-build=${{ needs.frontend-build.result }}"
           if [ "${{ needs.changes.result }}" = "failure" ] || \
              [ "${{ needs.e2e.result }}" = "failure" ] || \
              [ "${{ needs.e2e.result }}" = "cancelled" ] || \
              [ "${{ needs.template-tests.result }}" = "failure" ] || \
-             [ "${{ needs.template-tests.result }}" = "cancelled" ]; then
+             [ "${{ needs.template-tests.result }}" = "cancelled" ] || \
+             [ "${{ needs.frontend-build.result }}" = "failure" ] || \
+             [ "${{ needs.frontend-build.result }}" = "cancelled" ]; then
             echo "::error::A required job failed or was cancelled."
             exit 1
           fi

--- a/packages/frontend/build.ts
+++ b/packages/frontend/build.ts
@@ -1,46 +1,94 @@
 import { resolve, dirname } from "path";
 
-const externalDeps = new Set<string>();
-const visited = new Set<string>();
+/**
+ * Walk the dependency tree rooted at `entryPkgPath` and decide what stays
+ * external in the browser bundle.
+ *
+ * Rules:
+ *  - Internal `@effectstream/*` *dependencies* are bundled (we recurse into them
+ *    so the SDK ships self-contained), and their third-party deps are marked
+ *    external.
+ *  - Every `peerDependency` / `optionalDependency` is marked external — these are
+ *    provided by the consumer at runtime, never bundled. This includes
+ *    `@effectstream/*` peers. It is the critical rule: `@effectstream/wallets`
+ *    declares `@effectstream/midnight-contracts` as an OPTIONAL peer dep and
+ *    reaches it only via `import("@effectstream/midnight-contracts/wallet-info")`.
+ *    That module is node-only (`node:util` `parseArgs`, `node:fs`); bundling it
+ *    into a `target: "browser"` build fails with
+ *    "Browser polyfill for module 'node:util' doesn't have a matching export
+ *    named 'parseArgs'". Externalizing keeps the dynamic import as a runtime
+ *    import the consumer's bundler resolves (or the source's `.catch()` handles
+ *    when absent).
+ */
+export function collectExternals(entryPkgPath: string): Set<string> {
+  const externalDeps = new Set<string>();
+  const visited = new Set<string>();
 
-function collectExternals(pkgPath: string) {
-  if (visited.has(pkgPath)) return;
-  visited.add(pkgPath);
+  function walk(pkgPath: string) {
+    if (visited.has(pkgPath)) return;
+    visited.add(pkgPath);
 
-  const pkg = require(pkgPath);
-  for (const name of Object.keys(pkg.dependencies ?? {})) {
-    if (!name.startsWith("@effectstream/")) {
+    const pkg = require(pkgPath);
+
+    // Peer + optional deps are never bundled — add the bare name AND a subpath
+    // wildcard so subpath imports (e.g. `@effectstream/midnight-contracts/wallet-info`)
+    // stay external too.
+    for (const name of [
+      ...Object.keys(pkg.peerDependencies ?? {}),
+      ...Object.keys(pkg.optionalDependencies ?? {}),
+    ]) {
       externalDeps.add(name);
-    } else {
-      try {
-        const resolved = require.resolve(name + "/package.json", {
-          paths: [dirname(pkgPath)],
-        });
-        collectExternals(resolved);
-      } catch {
-        // workspace package not resolvable, skip
+      externalDeps.add(name + "/*");
+    }
+
+    for (const name of Object.keys(pkg.dependencies ?? {})) {
+      if (!name.startsWith("@effectstream/")) {
+        externalDeps.add(name);
+      } else {
+        try {
+          const resolved = require.resolve(name + "/package.json", {
+            paths: [dirname(pkgPath)],
+          });
+          walk(resolved);
+        } catch {
+          // workspace package not resolvable, skip
+        }
       }
     }
   }
+
+  walk(entryPkgPath);
+  return externalDeps;
 }
 
-collectExternals(resolve(import.meta.dir, "package.json"));
+/** Build the browser bundle for `@effectstream/frontend-sdk`. */
+export async function buildFrontend() {
+  const externalDeps = collectExternals(resolve(import.meta.dir, "package.json"));
 
-const result = await Bun.build({
-  entrypoints: ["./src/mod.ts"],
-  outdir: "./dist",
-  target: "browser",
-  format: "esm",
-  external: [...externalDeps],
-});
+  const result = await Bun.build({
+    entrypoints: [resolve(import.meta.dir, "src/mod.ts")],
+    outdir: resolve(import.meta.dir, "dist"),
+    target: "browser",
+    format: "esm",
+    external: [...externalDeps],
+  });
 
-if (!result.success) {
-  console.error("Build failed:");
-  for (const log of result.logs) {
-    console.error(log);
+  return { result, externalDeps };
+}
+
+// Only run the build when invoked as a script (`bun run build.ts`), not when
+// imported by tests.
+if (import.meta.main) {
+  const { result, externalDeps } = await buildFrontend();
+
+  if (!result.success) {
+    console.error("Build failed:");
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
   }
-  process.exit(1);
-}
 
-console.log("Built frontend to dist/");
-console.log("External deps:", [...externalDeps].sort().join(", "));
+  console.log("Built frontend to dist/");
+  console.log("External deps:", [...externalDeps].sort().join(", "));
+}

--- a/packages/frontend/test/build.test.ts
+++ b/packages/frontend/test/build.test.ts
@@ -1,0 +1,72 @@
+// Regression guard for the browser build of @effectstream/frontend-sdk.
+//
+// This is the ONLY package that needs a build before publish, and that build
+// (`bun run build`, target: "browser") was never exercised by push/PR CI —
+// only at release-publish time. A node-only module leaking into the browser
+// bundle therefore passed every check and only blew up the release.
+//
+// That is exactly what happened (releases v0.100.19–v0.100.22 all failed to
+// publish): @effectstream/wallets declares @effectstream/midnight-contracts as
+// an OPTIONAL peer dep and reaches it only via
+// `import("@effectstream/midnight-contracts/wallet-info")`. That module is
+// node-only (`import { parseArgs } from "node:util"`), so bundling it into a
+// browser build failed with:
+//   "Browser polyfill for module 'node:util' doesn't have a matching export
+//    named 'parseArgs'".
+//
+// Two checks:
+//  1. A fast, pure assertion on the externalization invariant (`collectExternals`).
+//  2. The real `bun run build` as a subprocess — this mirrors exactly what the
+//     publish script does (`cd <pkg> && bun run build`). It runs in a clean
+//     process on purpose: invoking `Bun.build` in-process inside `bun test`
+//     fails to resolve workspace `.ts` sources (test-runner resolver
+//     interference), which is unrelated to the bundle's correctness.
+
+import { test, expect } from "bun:test";
+import { resolve } from "path";
+import { collectExternals } from "../build.ts";
+
+const FRONTEND_DIR = resolve(import.meta.dir, "..");
+
+test("optional/peer deps are externalized, never bundled into the browser build", () => {
+  const externals = collectExternals(resolve(FRONTEND_DIR, "package.json"));
+
+  // The dep whose node-only `parseArgs` import broke the release publish.
+  expect(externals.has("@effectstream/midnight-contracts")).toBe(true);
+  // Subpath wildcard, so `import(".../wallet-info")` stays external too.
+  expect(externals.has("@effectstream/midnight-contracts/*")).toBe(true);
+
+  // The other node-only optional peers of @effectstream/wallets must also stay
+  // external (they ship WASM / use node:crypto and have no place in a browser
+  // bundle).
+  for (const dep of [
+    "@lucid-evolution/lucid",
+    "@midnight-ntwrk/ledger-v8",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet",
+  ]) {
+    expect(externals.has(dep)).toBe(true);
+  }
+});
+
+test("frontend-sdk browser build succeeds (`bun run build`)", async () => {
+  const proc = Bun.spawn(["bun", "run", "build"], {
+    cwd: FRONTEND_DIR,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    // Surface the bundler output so the failure is actionable in CI.
+    throw new Error(
+      `frontend-sdk browser build failed (exit ${exitCode}):\n${stdout}\n${stderr}`,
+    );
+  }
+
+  expect(exitCode).toBe(0);
+}, 180_000);


### PR DESCRIPTION
## What failed

The **Release Publish** workflow failed for `v0.100.19`–`v0.100.22` at the `bun run build` step for `@effectstream/frontend-sdk` (the only package built before publish):

```
@effectstream/frontend-sdk build failed ✗
error: Browser polyfill for module "node:util" doesn't have a matching export named "parseArgs"
   at packages/chains/midnight-contracts/src/get-wallet-info.ts:2:10
```

## Root cause

`@effectstream/wallets` declares `@effectstream/midnight-contracts` as an **optional peer dependency** and reaches it only via a dynamic `import("@effectstream/midnight-contracts/wallet-info")`. `frontend/build.ts`'s `collectExternals` only walked `dependencies`, so the peer dep was neither externalized nor recursed-into. `Bun.build({ target: "browser" })` then followed the dynamic import and tried to **bundle** the node-only `get-wallet-info.ts` (`import { parseArgs } from "node:util"`) into the browser bundle, which has no `parseArgs` polyfill.

## Why CI didn't catch it

The frontend browser build runs **only** inside the publish script (`BUILD_PACKAGES` in `.github/publish-bun.effectstream.ts`), which fires only on a published GitHub Release. No push/PR job ever ran it, and the one existing frontend test imported `src/mod.ts` (source entry), not the browser bundle — so the break was invisible until release time.

## Fix

- **`packages/frontend/build.ts`** — externalize every `peerDependency` / `optionalDependency` (bare name **and** `/*` subpath wildcard, so subpath imports like `.../wallet-info` stay external). This matches the runtime design: the dynamic import already `.catch()`es a missing optional peer. Build now exits 0, with all node-only midnight/lucid WASM peers correctly externalized.
- **`packages/frontend/test/build.test.ts`** — regression test that (1) asserts the externalization invariant and (2) spawns the real `bun run build` and asserts success. Verified **red without the fix** (reproduces the exact `parseArgs` error) and **green with it**.
- **`.github/workflows/main.yaml`** — new `frontend-build` job (gated on `core` changes, wired into the `ci-ok` required gate) runs `bun test packages/frontend/test/`, so this class of failure surfaces in PRs instead of at release.

## Verification

- `bun run build` in `packages/frontend` → exit 0, zero polyfill errors.
- `bun test packages/frontend/test/` → 5 pass / 0 fail (reliable across repeated runs).
- Confirmed the test fails without the fix, reproducing the exact CI error.

## Note on re-releasing

The failed runs left versions slightly out of sync (npm `frontend-sdk@0.100.20`, root `package.json` at `0.100.21`). The publish script rewrites per-package versions from the release tag, so re-releasing with a tag **> 0.100.20** will reconcile it — just don't reuse a tag at/below what's already on npm.
