### PR TITLE
feat(midnight): TokenMint primitive — map token ids to minting contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -215,6 +215,7 @@
         "@effectstream/runtime": "workspace:*",
         "@effectstream/sm": "workspace:*",
         "@effectstream/utils": "workspace:*",
+        "@midnight-ntwrk/ledger-v8": "8.0.3",
         "@sinclair/typebox": "^0.34.30",
         "effection": "^3.5.0",
         "pg": "^8.14.0",
@@ -456,7 +457,7 @@
     },
     "packages/batcher": {
       "name": "@effectstream/batcher-sdk",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/event-client": "workspace:*",
@@ -499,7 +500,7 @@
     },
     "packages/binaries/avail-light-client": {
       "name": "@effectstream/npm-avail-light-client",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "npm-avail-light-client": "index.js",
       },
@@ -510,7 +511,7 @@
     },
     "packages/binaries/avail-node": {
       "name": "@effectstream/npm-avail-node",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "npm-avail-node": "index.js",
       },
@@ -521,7 +522,7 @@
     },
     "packages/binaries/bitcoin-core": {
       "name": "@effectstream/bitcoin-core",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "bitcoin-core": "./index.js",
       },
@@ -531,7 +532,7 @@
     },
     "packages/binaries/celestia": {
       "name": "@effectstream/celestia",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "celestia": "./index.js",
       },
@@ -541,7 +542,7 @@
     },
     "packages/binaries/grafana-alloy": {
       "name": "@effectstream/grafana-alloy",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "grafana-alloy": "index.js",
       },
@@ -551,7 +552,7 @@
     },
     "packages/binaries/grafana-loki": {
       "name": "@effectstream/grafana-loki",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "grafana-loki": "index.js",
       },
@@ -561,7 +562,7 @@
     },
     "packages/binaries/midnight-indexer": {
       "name": "@effectstream/npm-midnight-indexer",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "npm-midnight-indexer": "index.js",
       },
@@ -574,7 +575,7 @@
     },
     "packages/binaries/midnight-node": {
       "name": "@effectstream/npm-midnight-node",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "npm-midnight-node": "index.js",
       },
@@ -586,7 +587,7 @@
     },
     "packages/binaries/midnight-proof-server": {
       "name": "@effectstream/npm-midnight-proof-server",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "npm-midnight-proof-server": "index.js",
       },
@@ -597,7 +598,7 @@
     },
     "packages/binaries/near-sandbox": {
       "name": "@effectstream/near-sandbox",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "near-sandbox": "./index.js",
       },
@@ -607,7 +608,7 @@
     },
     "packages/binaries/ord": {
       "name": "@effectstream/ord",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "ord": "./index.js",
       },
@@ -642,7 +643,7 @@
     },
     "packages/build-tools/orchestrator": {
       "name": "@effectstream/orchestrator",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "bin": {
         "orchestrator": "src/cli.ts",
       },
@@ -652,11 +653,11 @@
     },
     "packages/chains/avail-contracts": {
       "name": "@effectstream/avail-contracts",
-      "version": "0.100.18",
+      "version": "0.100.22",
     },
     "packages/chains/bitcoin-contracts": {
       "name": "@effectstream/bitcoin-contracts",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "bitcoinjs-lib": "^7.0.0",
         "ecpair": "^3.0.0",
@@ -665,11 +666,11 @@
     },
     "packages/chains/cardano-contracts": {
       "name": "@effectstream/cardano-contracts",
-      "version": "0.100.18",
+      "version": "0.100.22",
     },
     "packages/chains/evm-contracts": {
       "name": "@effectstream/evm-contracts",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@nomicfoundation/hardhat-ignition": "3.0.2",
         "@nomicfoundation/hardhat-ignition-viem": "3.0.2",
@@ -684,7 +685,7 @@
     },
     "packages/chains/evm-hardhat": {
       "name": "@effectstream/evm-hardhat",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -701,7 +702,7 @@
     },
     "packages/chains/midnight-contracts": {
       "name": "@effectstream/midnight-contracts",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@midnight-ntwrk/compact-js": "2.5.0",
@@ -732,14 +733,14 @@
     },
     "packages/effectstream-sdk/chain-types": {
       "name": "@effectstream/chain-types",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/concise": {
       "name": "@effectstream/concise",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -750,7 +751,7 @@
     },
     "packages/effectstream-sdk/config": {
       "name": "@effectstream/config",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@dcspark/carp-client": "^3.3.0",
         "@dcspark/cip34-js": "3.0.1",
@@ -767,7 +768,7 @@
     },
     "packages/effectstream-sdk/coroutine": {
       "name": "@effectstream/coroutine",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@pgtyped/parser": "2.4.2",
@@ -779,7 +780,7 @@
     },
     "packages/effectstream-sdk/crypto": {
       "name": "@effectstream/crypto",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
         "@effectstream/utils": "workspace:*",
@@ -806,7 +807,7 @@
     },
     "packages/effectstream-sdk/events": {
       "name": "@effectstream/event-client",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -820,7 +821,7 @@
     },
     "packages/effectstream-sdk/log": {
       "name": "@effectstream/log",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
@@ -842,14 +843,14 @@
     },
     "packages/effectstream-sdk/precompile": {
       "name": "@effectstream/precompile",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/utils": {
       "name": "@effectstream/utils",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@foxglove/crc": "^1.0.1",
@@ -870,7 +871,7 @@
     },
     "packages/effectstream-sdk/wallets": {
       "name": "@effectstream/wallets",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@aurowallet/mina-provider": "^1.0.12",
         "@effectstream/concise": "workspace:*",
@@ -925,14 +926,14 @@
     },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/wallets": "workspace:*",
       },
     },
     "packages/node-sdk/db": {
       "name": "@effectstream/db",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/coroutine": "workspace:*",
         "@effectstream/log": "workspace:*",
@@ -955,7 +956,7 @@
     },
     "packages/node-sdk/db-emulator": {
       "name": "@effectstream/db-emulator",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@pgtyped/runtime": "2.4.2",
         "effection": "^3.5.0",
@@ -964,7 +965,7 @@
     },
     "packages/node-sdk/events": {
       "name": "@effectstream/event-server",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -972,7 +973,7 @@
     },
     "packages/node-sdk/node": {
       "name": "@effectstream/node-sdk",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/chain-types": "workspace:*",
         "@effectstream/concise": "workspace:*",
@@ -990,7 +991,7 @@
     },
     "packages/node-sdk/runtime": {
       "name": "@effectstream/runtime",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1022,7 +1023,7 @@
     },
     "packages/node-sdk/sm": {
       "name": "@effectstream/sm",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1043,7 +1044,7 @@
     },
     "packages/node-sdk/sync": {
       "name": "@effectstream/sync",
-      "version": "0.100.18",
+      "version": "0.100.22",
       "dependencies": {
         "@cardano-sdk/core": "^0.46.11",
         "@cardano-sdk/util": "^0.17.1",

--- a/e2e/midnight/config.ts
+++ b/e2e/midnight/config.ts
@@ -13,6 +13,7 @@ import {
   PrimitiveTypeMidnightNullifier,
   PrimitiveTypeMidnightUnshieldedCreate,
   PrimitiveTypeMidnightZswapRoot,
+  PrimitiveTypeMidnightTokenMint,
 } from "@effectstream/sm/builtin";
 import * as CounterContract from "@e2e/midnight-contract-counter-basic/contract";
 import * as SimpleTokenContract from "@e2e/midnight-contract-eip-20/contract";
@@ -160,6 +161,16 @@ export const config = new ConfigBuilder()
           type: PrimitiveTypeMidnightZswapRoot,
           startBlockHeight: 1,
           stateMachinePrefix: "midnightZswapRootState",
+          networkId: midnightNetworkConfig.id,
+        }),
+      )
+      .addPrimitive(
+        (syncProtocols) => (syncProtocols as any).parallelMidnight,
+        (network, deployments, syncProtocol) => ({
+          name: "Midnight-TokenMint",
+          type: PrimitiveTypeMidnightTokenMint,
+          startBlockHeight: 1,
+          stateMachinePrefix: "midnightTokenMintState",
           networkId: midnightNetworkConfig.id,
         }),
       )

--- a/e2e/midnight/database/migrations/create-user-tables.sql
+++ b/e2e/midnight/database/migrations/create-user-tables.sql
@@ -28,3 +28,20 @@ CREATE TABLE IF NOT EXISTS midnight_zswap_roots (
   root TEXT NOT NULL UNIQUE,
   tx_hash TEXT
 );
+
+-- Token-mint registry: token id ("color") → the contract + domain separator
+-- that minted it. The mapping columns are immutable (token_type is a pure
+-- function of (domain_sep, contract_address)); total_minted accumulates
+-- across mints; tx_hash/block_height keep first-mint provenance. kind is in
+-- the key because shielded and unshielded share the derivation formula.
+CREATE TABLE IF NOT EXISTS midnight_token_mints (
+  id SERIAL PRIMARY KEY,
+  token_type TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('shielded', 'unshielded')),
+  contract_address TEXT NOT NULL,
+  domain_sep TEXT NOT NULL,
+  total_minted NUMERIC NOT NULL,
+  tx_hash TEXT,
+  block_height INTEGER NOT NULL,
+  UNIQUE (token_type, kind)
+);

--- a/e2e/midnight/grammar.ts
+++ b/e2e/midnight/grammar.ts
@@ -8,4 +8,5 @@ export const grammar = {
   "midnightNullifierState": [["payload", Type.Any()]],
   "midnightUnshieldedCreateState": [["payload", Type.Any()]],
   "midnightZswapRootState": [["payload", Type.Any()]],
+  "midnightTokenMintState": [["payload", Type.Any()]],
 } as const satisfies GrammarDefinition;

--- a/e2e/midnight/node.ts
+++ b/e2e/midnight/node.ts
@@ -90,6 +90,28 @@ stm.addStateTransition("midnightZswapRootState", function* (data) {
   ));
 });
 
+// MidnightTokenMint: registry of token id ("color") → minting contract +
+// domain separator (payload: { txHash, contractAddress, domainSep,
+// rawTokenType, kind, amount, entryPoint }). The mapping is immutable, so
+// conflicts only accumulate the running total.
+stm.addStateTransition("midnightTokenMintState", function* (data) {
+  const { payload } = data.parsedInput;
+  const tokenType = String(payload?.rawTokenType ?? "");
+  const kind = String(payload?.kind ?? "");
+  const contractAddress = String(payload?.contractAddress ?? "");
+  const domainSep = String(payload?.domainSep ?? "");
+  const amount = String(payload?.amount ?? "0");
+  const txHash = String(payload?.txHash ?? "");
+  console.log(`[STM] midnightTokenMintState: token=${tokenType.slice(0, 16)}… kind=${kind} contract=${contractAddress.slice(0, 16)}… amount=${amount}`);
+  yield* World.promise(pool.query(
+    `INSERT INTO midnight_token_mints (block_height, token_type, kind, contract_address, domain_sep, total_minted, tx_hash)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (token_type, kind)
+     DO UPDATE SET total_minted = midnight_token_mints.total_minted + EXCLUDED.total_minted`,
+    [data.blockHeight, tokenType, kind, contractAddress, domainSep, amount, txHash],
+  ));
+});
+
 const gameStateTransitions: StartConfigGameStateTransitions = function* (
   blockHeight: number,
   input: BaseStfInput,

--- a/e2e/midnight/package.json
+++ b/e2e/midnight/package.json
@@ -23,6 +23,7 @@
     "@effectstream/sm": "workspace:*",
     "@effectstream/utils": "workspace:*",
     "@effectstream/db": "workspace:*",
+    "@midnight-ntwrk/ledger-v8": "8.0.3",
     "@sinclair/typebox": "^0.34.30",
     "effection": "^3.5.0",
     "pg": "^8.14.0"

--- a/e2e/midnight/run-tests.ts
+++ b/e2e/midnight/run-tests.ts
@@ -22,6 +22,7 @@ import {
 } from "@e2e/engine";
 import type { Client } from "pg";
 import path from "path";
+import type { MintedTokens } from "../shared/contracts/midnight/trigger-token-mints.ts";
 
 const LAUNCHER_PATH = path.resolve(import.meta.dirname!, "./launcher.cli.ts");
 
@@ -136,6 +137,27 @@ async function doTriggerUnshieldedCreates(): Promise<void> {
   }
 }
 
+// -- Token-mint trigger: mint custom tokens via the counter contract ----------
+
+async function doTriggerTokenMints(): Promise<MintedTokens | undefined> {
+  try {
+    const { midnightNetworkConfig } = await import("@effectstream/midnight-contracts/midnight-env");
+    const { triggerTokenMints } = await import("../shared/contracts/midnight/trigger-token-mints.ts");
+    return await triggerTokenMints(
+      {
+        indexer: midnightNetworkConfig.indexer,
+        indexerWS: midnightNetworkConfig.indexerWS,
+        node: midnightNetworkConfig.node,
+        proofServer: midnightNetworkConfig.proofServer,
+      },
+      midnightNetworkConfig.id,
+    );
+  } catch (e) {
+    console.error("Failed to trigger token mints (non-fatal):", e);
+    return undefined;
+  }
+}
+
 // -- Indexer GraphQL helper (fidelity cross-checks) ----------------------------
 
 const INDEXER_GRAPHQL_URL = "http://localhost:8088/api/v3/graphql";
@@ -177,7 +199,7 @@ async function findIndexerRootForTx(txHash: string, maxBlocksBack = 600): Promis
 
 // -- Sync Tests (STM value validation) ----------------------------------------
 
-async function runSyncTests(db: Client): Promise<void> {
+async function runSyncTests(db: Client, minted?: MintedTokens): Promise<void> {
   console.log("\n--- Phase 3: Sync Tests (STM value validation) ---\n");
 
   await assertSQL<{ id: number; primitive_name: string; payload_json: string }>(
@@ -324,6 +346,121 @@ async function runSyncTests(db: Client): Promise<void> {
       return indexerRoot === last.root;
     },
   );
+
+  // ── TokenMint primitive: token id → minting contract registry ──────────────
+
+  // L1: the primitive ran at all.
+  await assertSQL<{ primitive_name: string }>(
+    "Midnight: primitive_accounting has Midnight-TokenMint entries",
+    db,
+    `SELECT primitive_name FROM effectstream.primitive_accounting
+     WHERE primitive_name = 'Midnight-TokenMint'
+     LIMIT 1;`,
+    (res) => res.rows.length >= 1,
+    (res) => res.rows[0].primitive_name === "Midnight-TokenMint",
+  );
+
+  // L2: the registry has shape-valid rows for both mint kinds.
+  const mintsResult = await assertSQL<{
+    token_type: string;
+    kind: string;
+    contract_address: string;
+    domain_sep: string;
+    total_minted: string;
+    tx_hash: string | null;
+  }>(
+    "Midnight: midnight_token_mints has shape-valid shielded + unshielded rows",
+    db,
+    `SELECT token_type, kind, contract_address, domain_sep, total_minted, tx_hash
+     FROM midnight_token_mints ORDER BY id ASC;`,
+    (res) => res.rows.length >= 2,
+    (res) => {
+      console.log(`  Token-mint count: ${res.rows.length}`);
+      const kinds = new Set(res.rows.map((r) => r.kind));
+      return (
+        kinds.has("shielded") &&
+        kinds.has("unshielded") &&
+        res.rows.every((r) =>
+          /^[0-9a-f]{64}$/.test(r.token_type) &&
+          /^[0-9a-f]{64}$/.test(r.domain_sep) &&
+          r.contract_address.length > 0 &&
+          (r.tx_hash ?? "").length > 0 &&
+          Number(r.total_minted) > 0
+        )
+      );
+    },
+  );
+
+  // L3a: derivation fidelity — recompute rawTokenType(domain_sep, contract)
+  // with ledger-v8 for every row and require byte-equality with the stored
+  // token_type. Proves the fetcher's derivation (and the row pairing) exact.
+  await assert(
+    "Midnight: every stored token_type equals rawTokenType(domain_sep, contract_address)",
+    async () => {
+      const { rawTokenType } = await import("@midnight-ntwrk/ledger-v8");
+      const hexToBytes = (hex: string) =>
+        Uint8Array.from(Buffer.from(hex.replace(/^0x/, ""), "hex"));
+      const normalize = (s: string) => s.replace(/^0x/, "").toLowerCase();
+      for (const row of mintsResult.rows) {
+        const derived = normalize(
+          String(rawTokenType(hexToBytes(row.domain_sep), row.contract_address)),
+        );
+        if (derived !== normalize(row.token_type)) {
+          console.error(
+            `  MISMATCH kind=${row.kind}: derived=${derived} stored=${row.token_type}`,
+          );
+          return false;
+        }
+      }
+      return mintsResult.rows.length > 0;
+    },
+  );
+
+  // L3b: the user's use case — the wallet-visible colors returned by the mint
+  // trigger must resolve through the registry to the minting contract.
+  await assert(
+    "Midnight: trigger's wallet-visible colors resolve to the counter contract via the registry",
+    async () => {
+      if (!minted) {
+        console.error("  No minted-token info from the trigger");
+        return false;
+      }
+      const normalize = (s: string) => s.replace(/^0x/, "").toLowerCase();
+      const sameAddress = (a: string, b: string) => {
+        const an = normalize(a), bn = normalize(b);
+        const longest = Math.max(an.length, bn.length);
+        // Addresses length can be padded by 0's
+        return an.padStart(longest, "0") === bn.padStart(longest, "0");
+      };
+      for (
+        const [kind, expected] of [
+          ["shielded", minted.shielded],
+          ["unshielded", minted.unshielded],
+        ] as const
+      ) {
+        const row = mintsResult.rows.find(
+          (r) => r.kind === kind && normalize(r.token_type) === normalize(expected.color),
+        );
+        if (!row) {
+          console.error(`  No registry row for ${kind} color ${expected.color}`);
+          return false;
+        }
+        if (normalize(row.domain_sep) !== normalize(expected.domainSep)) {
+          console.error(`  ${kind} domain_sep mismatch: ${row.domain_sep} != ${expected.domainSep}`);
+          return false;
+        }
+        if (!sameAddress(row.contract_address, minted.contractAddress)) {
+          console.error(`  ${kind} contract mismatch: ${row.contract_address} != ${minted.contractAddress}`);
+          return false;
+        }
+        if (row.total_minted !== minted.amount) {
+          console.error(`  ${kind} total_minted ${row.total_minted} != minted ${minted.amount}`);
+          return false;
+        }
+      }
+      return true;
+    },
+  );
 }
 
 // -- Main ---------------------------------------------------------------------
@@ -352,13 +489,16 @@ async function test() {
     console.log("Sync node is healthy.\n");
 
     // 4.5. Trigger a shielded transfer to produce nullifier events on-chain,
-    // then an unshielded self-transfer to produce unshielded-create events
+    // an unshielded self-transfer to produce unshielded-create events, then
+    // contract mints to produce token-mint events. (To run the TokenMint
+    // negative check, skip the mint trigger and confirm its assertions fail.)
     await doTriggerNullifiers();
     await doTriggerUnshieldedCreates();
+    const minted = await doTriggerTokenMints();
 
     // 5. Connect to DB and run sync tests
     db = getDBConnection();
-    await runSyncTests(db);
+    await runSyncTests(db, minted);
 
     // 6. Wait for batcher + run batcher tests
     try {

--- a/e2e/shared/contracts/midnight/contract-counter/src/counter.compact
+++ b/e2e/shared/contracts/midnight/contract-counter/src/counter.compact
@@ -25,3 +25,27 @@ export circuit add_entry(_id: Bytes<32>, _value: Uint<128>): [] {
   map_of_map.insert(id, default<Map<Bytes<32>, Uint<128>>>);
   map_of_map.lookup(id).insert(id, value);
 }
+
+// Native token mints (exercised by the Midnight:TokenMint primitive e2e):
+// minting records `domain_sep → amount` in the call's effects, and the token
+// type ("color") is derived as rawTokenType(domain_sep, contract_address).
+export circuit mint_shielded(
+  domain_sep: Bytes<32>,
+  amount: Uint<64>,
+  nonce: Uint<128>,
+): ShieldedCoinInfo {
+  return mintShieldedToken(
+    disclose(domain_sep),
+    disclose(amount),
+    evolveNonce(disclose(nonce), disclose(domain_sep)),
+    left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey())
+  );
+}
+
+export circuit mint_unshielded(
+  domain_sep: Bytes<32>,
+  amount: Uint<64>,
+  recipient: UserAddress
+): Bytes<32> {
+  return mintUnshieldedToken(disclose(domain_sep), disclose(amount), right<ContractAddress, UserAddress>(disclose(recipient)));
+}

--- a/e2e/shared/contracts/midnight/trigger-token-mints.ts
+++ b/e2e/shared/contracts/midnight/trigger-token-mints.ts
@@ -1,0 +1,184 @@
+// Trigger for the Midnight:TokenMint primitive e2e: mint one shielded and one
+// unshielded custom token via the deployed counter contract's mint circuits
+// (callTx → proof server → regular Midnight transaction). Returns the
+// wallet-visible token ids ("colors") so the test can assert they match the
+// registry the primitive built — the exact token-id → contract mapping the
+// primitive exists to provide.
+//
+// Ported from templates/zswap-da/packages/contracts-midnight/mint-test-tokens.ts.
+
+import { dirname, resolve } from "node:path";
+import { findDeployedContract } from "@midnight-ntwrk/midnight-js-contracts";
+import { CompiledContract } from "@midnight-ntwrk/compact-js";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { MidnightBech32m } from "@midnight-ntwrk/wallet-sdk-address-format";
+import { configureMidnightNodeProviders } from "@effectstream/midnight-contracts";
+import { readMidnightContract } from "@effectstream/midnight-contracts/read-contract";
+// Path import (not the package name): the package's `.` export points at a
+// non-existent `_index.ts` — same workaround as contract-counter-deploy.ts.
+import {
+  Counter,
+  witnesses,
+  type CounterPrivateState,
+} from "./contract-counter/src/index.ts";
+import {
+  buildWalletFacade,
+  registerNightForDust,
+  syncAndWaitForFunds,
+} from "./faucet.ts";
+
+const TAG = "[trigger-token-mints]";
+
+globalThis.WebSocket = WebSocket;
+
+// Fixed domain separators (distinct from zswap-da's a1/b2/c3) → deterministic
+// per-deployment token colors.
+const SHIELDED_SEP = new Uint8Array(32).fill(0xd4);
+const UNSHIELDED_SEP = new Uint8Array(32).fill(0xe5);
+export const MINT_AMOUNT = 1_000_000n;
+
+const currentDir = resolve(dirname(new URL(import.meta.url).pathname));
+
+const contractConfig = {
+  privateStateStoreName: "counter-private-state",
+  zkConfigPath: resolve(currentDir, "contract-counter", "src", "managed"),
+};
+
+const compiledContract = CompiledContract.make(
+  "contract-counter",
+  Counter.Contract as any,
+).pipe(
+  CompiledContract.withWitnesses(witnesses as unknown as never),
+  CompiledContract.withCompiledFileAssets(contractConfig.zkConfigPath),
+);
+
+const toHex = (u: Uint8Array): string =>
+  Array.from(u, (x) => x.toString(16).padStart(2, "0")).join("");
+
+const colorToHex = (raw: unknown, fallback: Uint8Array): string =>
+  (raw instanceof Uint8Array
+    ? toHex(raw)
+    : String(raw ?? toHex(fallback)).replace(/^0x/, "")).toLowerCase();
+
+function unshieldedToUserAddressBytes(unshieldedAddr: string): Uint8Array {
+  if (!unshieldedAddr.startsWith("mn_addr_")) {
+    throw new Error(
+      `expected mn_addr_ bech32m unshielded address, got "${unshieldedAddr}"`,
+    );
+  }
+  const parsed = MidnightBech32m.parse(unshieldedAddr);
+  return Uint8Array.prototype.slice.call(parsed.data, 0, 32);
+}
+
+export interface MintedTokens {
+  contractAddress: string;
+  amount: string;
+  shielded: { domainSep: string; color: string };
+  unshielded: { domainSep: string; color: string };
+}
+
+export async function triggerTokenMints(
+  networkUrls: {
+    indexer: string;
+    indexerWS: string;
+    node: string;
+    proofServer: string;
+  },
+  networkId: string,
+): Promise<MintedTokens> {
+  setNetworkId(networkId as any);
+
+  const { contractAddress } = readMidnightContract("contract-counter", {
+    networkId,
+  });
+  console.log(`${TAG} minting via counter contract at ${contractAddress}`);
+
+  const walletResult = await buildWalletFacade(
+    networkUrls as any,
+    process.env["MIDNIGHT_WALLET_SEED"] ??
+      "0000000000000000000000000000000000000000000000000000000000000001",
+    networkId as any,
+  );
+  const wallet = walletResult.wallet;
+
+  try {
+    await syncAndWaitForFunds(wallet, { logLabel: "trigger-token-mints" });
+
+    // Dust pays the circuit-call fees; tolerate prior registration.
+    try {
+      await registerNightForDust(walletResult);
+    } catch (e) {
+      console.warn(
+        `${TAG} registerNightForDust: ${
+          e instanceof Error ? e.message : String(e)
+        } (continuing)`,
+      );
+    }
+
+    const providers = (await configureMidnightNodeProviders(
+      wallet,
+      walletResult.zswapSecretKeys,
+      walletResult.walletZswapSecretKeys,
+      walletResult.dustSecretKey,
+      walletResult.walletDustSecretKey,
+      networkUrls,
+      contractConfig.privateStateStoreName,
+      contractConfig.zkConfigPath,
+      walletResult.unshieldedKeystore,
+    )) as any;
+
+    const deployed = await findDeployedContract(providers, {
+      contractAddress,
+      compiledContract: compiledContract as any,
+      privateStateId: "counterPrivateState",
+      initialPrivateState: { privateCounter: 0 } as CounterPrivateState,
+    });
+    console.log(`${TAG} joined contract`);
+
+    // Nonces must be unique per run: re-minting the same (domain_sep, nonce)
+    // recreates the identical coin commitment and the node rejects it as a
+    // duplicate. Same separator + fresh nonce = same token color, new coins.
+    const nonce = BigInt(Date.now());
+
+    let t0 = Date.now();
+    const stx = await (deployed.callTx as any).mint_shielded(
+      SHIELDED_SEP,
+      MINT_AMOUNT,
+      nonce,
+    );
+    const sCoin = stx.private?.result;
+    const shieldedColor = colorToHex(sCoin?.color ?? sCoin?.type, SHIELDED_SEP);
+    console.log(
+      `${TAG} ✅ mint_shielded color=${shieldedColor.slice(0, 16)}… (${
+        ((Date.now() - t0) / 1000).toFixed(1)
+      }s)`,
+    );
+
+    const recipientBytes = unshieldedToUserAddressBytes(
+      walletResult.unshieldedAddress,
+    );
+    t0 = Date.now();
+    const utx = await (deployed.callTx as any).mint_unshielded(
+      UNSHIELDED_SEP,
+      MINT_AMOUNT,
+      { bytes: recipientBytes },
+    );
+    const unshieldedColor = colorToHex(utx.private?.result, UNSHIELDED_SEP);
+    console.log(
+      `${TAG} ✅ mint_unshielded color=${unshieldedColor.slice(0, 16)}… (${
+        ((Date.now() - t0) / 1000).toFixed(1)
+      }s)`,
+    );
+
+    const result: MintedTokens = {
+      contractAddress,
+      amount: MINT_AMOUNT.toString(),
+      shielded: { domainSep: toHex(SHIELDED_SEP), color: shieldedColor },
+      unshielded: { domainSep: toHex(UNSHIELDED_SEP), color: unshieldedColor },
+    };
+    console.log(`${TAG} MINTED ${JSON.stringify(result)}`);
+    return result;
+  } finally {
+    await (wallet as any).stop?.().catch(() => {});
+  }
+}

--- a/packages/node-sdk/sm/primitives/src/builtin.ts
+++ b/packages/node-sdk/sm/primitives/src/builtin.ts
@@ -5,6 +5,7 @@ export const PrimitiveTypeMidnightNullifier = "Midnight:Nullifier" as const;
 export const PrimitiveTypeMidnightUnshieldedSpend = "Midnight:UnshieldedSpend" as const;
 export const PrimitiveTypeMidnightUnshieldedCreate = "Midnight:UnshieldedCreate" as const;
 export const PrimitiveTypeMidnightZswapRoot = "Midnight:ZswapRoot" as const;
+export const PrimitiveTypeMidnightTokenMint = "Midnight:TokenMint" as const;
 
 export const PrimitiveTypeUtxorpcGeneric = "Utxorpc:Generic" as const;
 export const PrimitiveTypeCardanoMintBurn = "Cardano:MintBurn" as const;
@@ -38,6 +39,7 @@ type BuiltInPrimitives =
     typeof PrimitiveTypeMidnightUnshieldedSpend |
     typeof PrimitiveTypeMidnightUnshieldedCreate |
     typeof PrimitiveTypeMidnightZswapRoot |
+    typeof PrimitiveTypeMidnightTokenMint |
     typeof PrimitiveTypeEVMEffectstreamL2 |
     typeof PrimitiveTypeEVMERC721 |
     typeof PrimitiveTypeEVMERC20 |

--- a/packages/node-sdk/sm/primitives/src/midnight-token-mint/midnight-token-mint-grammar.ts
+++ b/packages/node-sdk/sm/primitives/src/midnight-token-mint/midnight-token-mint-grammar.ts
@@ -1,0 +1,8 @@
+import { Type } from "@sinclair/typebox";
+
+export const midnightTokenMintGrammar = [
+  [
+    "payload",
+    Type.Any(),
+  ],
+] as const;

--- a/packages/node-sdk/sm/primitives/src/midnight-token-mint/midnight-token-mint.ts
+++ b/packages/node-sdk/sm/primitives/src/midnight-token-mint/midnight-token-mint.ts
@@ -1,0 +1,126 @@
+import { Primitive } from "@effectstream/sm";
+import {
+  type AddressAndType,
+  AddressType,
+  type EffectstreamBlockNumber,
+} from "@effectstream/utils";
+import type { StaticDecode } from "@sinclair/typebox";
+import {
+  type CommandTuple,
+  generateRawStmInput,
+  type ParamToData,
+} from "@effectstream/concise";
+import type {
+  ConfigSyncProtocolType,
+  FlattenSyncProtocolIOFor,
+  ProtocolPrimitiveMap,
+} from "@effectstream/config";
+import type { SyncStateUpdateStream } from "@effectstream/coroutine";
+import { PrimitiveTypeMidnightTokenMint } from "../builtin.ts";
+import { midnightTokenMintGrammar } from "./midnight-token-mint-grammar.ts";
+
+/**
+ * MidnightTokenMintPrimitive
+ *
+ * Watches custom token *mints* on the Midnight ledger. A contract call's
+ * effects record minted tokens as `domain_sep → amount` maps (shielded and
+ * unshielded), and the resulting token type ("color") is derived as
+ * `rawTokenType(domain_sep, contract_address)` — so this primitive is the
+ * only way for a consumer to map a wallet-visible token id back to the
+ * contract that minted it. The fetcher deserializes each regular
+ * transaction's raw bytes with ledger-v8, walks the contract calls, and
+ * emits one state-machine input per `(tx, call, domainSep, kind)` — only
+ * for effects that actually applied on chain (failed segments roll back).
+ *
+ * The mint nonce is NOT part of token identity (it only randomizes coin
+ * commitments) and is never public for shielded mints, so it is not part
+ * of the payload.
+ *
+ * Usage:
+ *   stm.addStateTransition("myPrefix", function* (data) {
+ *     const { payload } = data.parsedInput;
+ *     // payload = { txHash, contractAddress, domainSep, rawTokenType,
+ *     //             kind: "shielded" | "unshielded", amount, entryPoint }
+ *     // amount is a decimal string (u64 mints can exceed MAX_SAFE_INTEGER)
+ *   });
+ */
+export class MidnightTokenMintPrimitive extends Primitive<
+  ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+  typeof midnightTokenMintGrammar
+> {
+  readonly internalTypeName = PrimitiveTypeMidnightTokenMint;
+  override readonly grammar = midnightTokenMintGrammar;
+
+  override dynamicTables = undefined;
+  override getIntermediatePrefix(): string[] {
+    return [];
+  }
+  override getViewPrefix(): string[] {
+    return [];
+  }
+
+  constructor(config: {
+    instanceName: string;
+    startBlockHeight: number;
+    stateMachinePrefix: string;
+  }) {
+    super(config);
+  }
+
+  override *getPayload(
+    _: EffectstreamBlockNumber,
+    primitiveTransactionData: FlattenSyncProtocolIOFor<
+      ConfigSyncProtocolType.MIDNIGHT_PARALLEL
+    >,
+  ): SyncStateUpdateStream<{
+    isBatched: boolean;
+    data: {
+      fromAddressAndType: AddressAndType;
+      stateMachinePayload:
+        | StaticDecode<CommandTuple<string, typeof midnightTokenMintGrammar>>
+        | null;
+      accountingPayload: ParamToData<typeof midnightTokenMintGrammar>;
+    }[];
+  }> {
+    const payload = primitiveTransactionData.output.payload;
+
+    const accountingPayload: ParamToData<typeof this.grammar> = {
+      payload,
+    };
+
+    const stateMachinePayload:
+      | StaticDecode<CommandTuple<string, typeof this.grammar>>
+      | null = this.stateMachinePrefix
+      ? generateRawStmInput(
+        this.grammar,
+        this.stateMachinePrefix,
+        accountingPayload,
+      )
+      : null;
+
+    return {
+      isBatched: false,
+      data: [
+        {
+          fromAddressAndType: {
+            type: AddressType.NONE,
+            address: "0x0",
+          },
+          accountingPayload,
+          stateMachinePayload,
+        },
+      ],
+    };
+  }
+
+  override getConfig(): ProtocolPrimitiveMap[
+    ConfigSyncProtocolType.MIDNIGHT_PARALLEL
+  ] {
+    return {
+      name: this.instanceName,
+      type: this.internalTypeName,
+      startBlockHeight: this.startBlockHeight,
+      scheduledPrefix: this.stateMachinePrefix ?? "",
+    } as const;
+  }
+}

--- a/packages/node-sdk/sm/primitives/src/mod.ts
+++ b/packages/node-sdk/sm/primitives/src/mod.ts
@@ -4,6 +4,7 @@ import {
   PrimitiveTypeMidnightUnshieldedSpend,
   PrimitiveTypeMidnightUnshieldedCreate,
   PrimitiveTypeMidnightZswapRoot,
+  PrimitiveTypeMidnightTokenMint,
   PrimitiveTypeEVMEffectstreamL2,
   PrimitiveTypeEVMERC721,
   PrimitiveTypeEVMERC20,
@@ -31,6 +32,7 @@ import { MidnightNullifierPrimitive } from "./midnight-nullifier/midnight-nullif
 import { MidnightUnshieldedSpendPrimitive } from "./midnight-unshielded-spend/midnight-unshielded-spend.ts";
 import { MidnightUnshieldedCreatePrimitive } from "./midnight-unshielded-create/midnight-unshielded-create.ts";
 import { MidnightZswapRootPrimitive } from "./midnight-zswap-root/midnight-zswap-root.ts";
+import { MidnightTokenMintPrimitive } from "./midnight-token-mint/midnight-token-mint.ts";
 import { EffectstreamL2Primitive } from "./evm-effectstream-l2/effectstream-l2-primitive.ts";
 import { Erc721Primitive } from "./evm-erc721/erc721-primitive.ts";
 import { Erc20Primitive } from "./evm-erc20/erc20-primitive.ts";
@@ -58,6 +60,7 @@ const builtInPrimitivesMap = {
   [PrimitiveTypeMidnightUnshieldedSpend]: MidnightUnshieldedSpendPrimitive,
   [PrimitiveTypeMidnightUnshieldedCreate]: MidnightUnshieldedCreatePrimitive,
   [PrimitiveTypeMidnightZswapRoot]: MidnightZswapRootPrimitive,
+  [PrimitiveTypeMidnightTokenMint]: MidnightTokenMintPrimitive,
   [PrimitiveTypeEVMEffectstreamL2]: EffectstreamL2Primitive,
   [PrimitiveTypeEVMERC721]: Erc721Primitive,
   [PrimitiveTypeEVMERC20]: Erc20Primitive,
@@ -90,6 +93,7 @@ export {
   MidnightUnshieldedSpendPrimitive,
   MidnightUnshieldedCreatePrimitive,
   MidnightZswapRootPrimitive,
+  MidnightTokenMintPrimitive,
   EffectstreamL2Primitive,
   Erc721Primitive,
   Erc20Primitive,

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/MidnightClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/MidnightClient.ts
@@ -40,6 +40,14 @@ export interface MidnightGqlBlockState {
       // Present only on RegularTransaction (selected via inline fragment): the
       // coin-commitment Merkle tree root after this transaction.
       zswapMerkleTreeRoot?: string;
+      // Selected only for MidnightTokenMintPrimitive: the serialized
+      // transaction bytes (Transaction interface) and the apply result
+      // (RegularTransaction only — absent on system transactions).
+      raw?: string;
+      transactionResult?: {
+        status: "SUCCESS" | "PARTIAL_SUCCESS" | "FAILURE";
+        segments?: { id: number; success: boolean }[] | null;
+      };
     }[];
   };
 };
@@ -55,6 +63,8 @@ export interface BlockFetchOptions {
   unshieldedCreatedOutputs?: boolean;
   /** Include `... on RegularTransaction { zswapMerkleTreeRoot }` (needed for MidnightZswapRootPrimitive). Default: false */
   zswapRoots?: boolean;
+  /** Include tx `raw` + `... on RegularTransaction { transactionResult }` (needed for MidnightTokenMintPrimitive). Default: false */
+  tokenMints?: boolean;
 }
 
 type PublicDataProvider = ReturnType<typeof indexerPublicDataProvider>;
@@ -182,6 +192,7 @@ export class MidnightClient {
       unshieldedSpentOutputs = false,
       unshieldedCreatedOutputs = false,
       zswapRoots = false,
+      tokenMints = false,
     } = options;
     const contractActionsField = contractActions
       ? `contractActions { address state }`
@@ -200,6 +211,14 @@ export class MidnightClient {
     const zswapRootFragment = zswapRoots
       ? `... on RegularTransaction { zswapMerkleTreeRoot }`
       : "";
+    // `raw` is on the Transaction interface; `transactionResult` is
+    // RegularTransaction-only (system transactions have neither result nor
+    // contract calls, so they are skipped downstream). Duplicate inline
+    // fragments merge legally in GraphQL.
+    const tokenMintFields = tokenMints
+      ? `raw
+         ... on RegularTransaction { transactionResult { status segments { id success } } }`
+      : "";
     const query = `query {
       block(offset: { height: ${blockHeight} }) {
         hash
@@ -216,6 +235,7 @@ export class MidnightClient {
           ${unshieldedSpentField}
           ${unshieldedCreatedField}
           ${zswapRootFragment}
+          ${tokenMintFields}
         }
       }
     }`;

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
@@ -19,6 +19,7 @@ import { bound } from "@effectstream/utils";
 import { MidnightClient, type BlockFetchOptions, type MidnightGqlBlockState } from "./MidnightClient.ts";
 import { ContractState, StateValue } from "@midnight-ntwrk/onchain-runtime";
 import { decodeZswapInputEvent } from "./zswap-decoder.ts";
+import { decodeTokenMints } from "./mint-decoder.ts";
 
 export class MidnightFetcher extends BaseDataFetcher<
   Input,
@@ -86,7 +87,8 @@ export class MidnightFetcher extends BaseDataFetcher<
           p.primitive.type !== "Midnight:Nullifier" &&
           p.primitive.type !== "Midnight:UnshieldedSpend" &&
           p.primitive.type !== "Midnight:UnshieldedCreate" &&
-          p.primitive.type !== "Midnight:ZswapRoot",
+          p.primitive.type !== "Midnight:ZswapRoot" &&
+          p.primitive.type !== "Midnight:TokenMint",
       ),
       zswapLedgerEvents: this.config.primitives.some(
         (p) => p.primitive.type === "Midnight:Nullifier",
@@ -99,6 +101,9 @@ export class MidnightFetcher extends BaseDataFetcher<
       ),
       zswapRoots: this.config.primitives.some(
         (p) => p.primitive.type === "Midnight:ZswapRoot",
+      ),
+      tokenMints: this.config.primitives.some(
+        (p) => p.primitive.type === "Midnight:TokenMint",
       ),
     };
     const self = this;
@@ -192,6 +197,8 @@ export class MidnightFetcher extends BaseDataFetcher<
         syncResults.push(...this.fetchUnshieldedCreates(height, primitiveEntry, block));
       } else if (primitiveEntry.primitive.type === "Midnight:ZswapRoot") {
         syncResults.push(...this.fetchZswapRoots(height, primitiveEntry, block));
+      } else if (primitiveEntry.primitive.type === "Midnight:TokenMint") {
+        syncResults.push(...this.fetchTokenMints(height, primitiveEntry, block));
       } else {
         asyncOps.push(
           this.fetchContractState(height, client, primitiveEntry, block),
@@ -337,6 +344,42 @@ export class MidnightFetcher extends BaseDataFetcher<
         },
       },
     ];
+  }
+
+  // Decode custom token mints out of each regular transaction's raw bytes
+  // (ledger-v8 deserialize → contract call transcript effects). One input per
+  // (tx, call, domainSep, kind) that actually applied on chain — see
+  // mint-decoder.ts for the segment semantics. System transactions carry no
+  // transactionResult and are skipped.
+  @bound
+  fetchTokenMints(
+    height: number,
+    primitiveEntry: PrimitiveEntryType,
+    block: MidnightGqlBlockState,
+  ): PrimitiveType[] {
+    const results: PrimitiveType[] = [];
+    for (const tx of block.block.transactions) {
+      if (!tx.raw || !tx.transactionResult) continue;
+      for (const mint of decodeTokenMints(tx.raw, tx.transactionResult)) {
+        results.push({
+          syncProtocol: {
+            name: primitiveEntry.syncProtocol,
+            blockNumber: height,
+            transactionHash: tx.hash,
+            contractAddress: mint.contractAddress,
+          },
+          primitive: primitiveEntry.primitive.name,
+          output: {
+            payloadType: "midnight-token-mint",
+            payload: {
+              ...mint,
+              txHash: tx.hash,
+            },
+          },
+        });
+      }
+    }
+    return results;
   }
 
   @bound

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/mint-decoder.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/mint-decoder.ts
@@ -1,0 +1,151 @@
+import { Buffer } from "node:buffer";
+import * as ledger from "@midnight-ntwrk/ledger-v8";
+
+// Decodes custom token mints out of a raw Midnight transaction. A contract
+// call's transcript effects record mints as `domain_sep → amount` maps
+// (`shieldedMints` / `unshieldedMints`); the resulting token type ("color")
+// is `rawTokenType(domain_sep, contract_address)`. Neither the indexer's
+// GraphQL nor the wallet expose this mapping, so the only route is
+// deserializing the transaction bytes with ledger-v8 — same approach as
+// zswap-decoder.ts for nullifier events.
+//
+// Mirrors zswap-decoder.ts tolerance: never throws — an undecodable
+// transaction logs a warning and contributes nothing.
+
+export interface TokenMintRecord {
+  /** Address of the minting contract, hex */
+  contractAddress: string;
+  /** 32-byte domain separator pre-image, hex */
+  domainSep: string;
+  /** Derived token type ("color") = rawTokenType(domainSep, contractAddress), hex */
+  rawTokenType: string;
+  kind: "shielded" | "unshielded";
+  /** Total minted for this (call, domainSep, kind), as a decimal string (u64 exceeds MAX_SAFE_INTEGER) */
+  amount: string;
+  /** Contract entry point that minted, when printable */
+  entryPoint?: string;
+}
+
+export interface TxResultLike {
+  status: "SUCCESS" | "PARTIAL_SUCCESS" | "FAILURE";
+  segments?: { id: number; success: boolean }[] | null;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return Uint8Array.from(Buffer.from(clean, "hex"));
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function normalizeHex(value: string): string {
+  return value.replace(/^0x/, "").toLowerCase();
+}
+
+/**
+ * Extract every applied token mint from a raw serialized transaction.
+ *
+ * Segment semantics (failed segments roll back on chain):
+ * - no `result` (system transactions) or status FAILURE → nothing applied;
+ * - SUCCESS → guaranteed + all fallible transcripts applied;
+ * - PARTIAL_SUCCESS → guaranteed transcripts applied, fallible only where
+ *   the intent's segment (the `intents` map key) succeeded.
+ */
+export function decodeTokenMints(
+  rawHex: string,
+  result?: TxResultLike | null,
+): TokenMintRecord[] {
+  if (!result || result.status === "FAILURE") return [];
+
+  let tx: any;
+  try {
+    tx = ledger.Transaction.deserialize(
+      "signature",
+      "proof",
+      "binding",
+      hexToBytes(rawHex),
+    );
+  } catch (e) {
+    console.warn(
+      `[mint-decoder] undecodable transaction, skipping: ${
+        (e as Error)?.message ?? e
+      }`,
+    );
+    return [];
+  }
+
+  const records: TokenMintRecord[] = [];
+  for (const [segmentId, intent] of tx.intents ?? new Map()) {
+    const fallibleApplied = result.status === "SUCCESS" ||
+      (result.segments?.some((s) => s.id === Number(segmentId) && s.success) ??
+        false);
+    for (const action of intent.actions ?? []) {
+      // Only contract calls carry transcripts; deploys and maintenance
+      // updates cannot mint.
+      if (!(action instanceof ledger.ContractCall)) continue;
+      try {
+        records.push(...mintsOfCall(action, fallibleApplied));
+      } catch (e) {
+        console.warn(
+          `[mint-decoder] failed to read mints of call to ${
+            (action as any)?.address ?? "?"
+          }: ${(e as Error)?.message ?? e}`,
+        );
+      }
+    }
+  }
+  return records;
+}
+
+function mintsOfCall(
+  call: any,
+  fallibleApplied: boolean,
+): TokenMintRecord[] {
+  // Accumulate domainSep|kind → amount across the applied transcripts. The
+  // guaranteed transcript applied whenever the transaction wasn't a FAILURE
+  // (the caller filters those); the fallible transcript only if its segment
+  // succeeded.
+  const totals = new Map<string, bigint>();
+  const transcripts = [
+    call.guaranteedTranscript,
+    ...(fallibleApplied ? [call.fallibleTranscript] : []),
+  ];
+  for (const transcript of transcripts) {
+    const effects = transcript?.effects;
+    if (!effects) continue;
+    for (
+      const [kind, mints] of [
+        ["shielded", effects.shieldedMints],
+        ["unshielded", effects.unshieldedMints],
+      ] as const
+    ) {
+      for (const [sepHex, amount] of mints ?? new Map()) {
+        const key = `${normalizeHex(String(sepHex))}|${kind}`;
+        totals.set(key, (totals.get(key) ?? 0n) + BigInt(amount));
+      }
+    }
+  }
+
+  const records: TokenMintRecord[] = [];
+  for (const [key, amount] of totals) {
+    const [domainSep, kind] = key.split("|") as [
+      string,
+      "shielded" | "unshielded",
+    ];
+    records.push({
+      contractAddress: normalizeHex(String(call.address)),
+      domainSep,
+      rawTokenType: normalizeHex(
+        String(ledger.rawTokenType(hexToBytes(domainSep), call.address)),
+      ),
+      kind,
+      amount: amount.toString(),
+      entryPoint: typeof call.entryPoint === "string"
+        ? call.entryPoint
+        : bytesToHex(call.entryPoint),
+    });
+  }
+  return records;
+}

--- a/packages/node-sdk/sync/test/mint-decoder.test.ts
+++ b/packages/node-sdk/sync/test/mint-decoder.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { decodeTokenMints } from "../src/sync-protocols/midnight/mint-decoder.ts";
+
+// Tolerance contract: the decoder must never throw — an undecodable or
+// inapplicable transaction contributes nothing (the fetcher's per-height
+// error path would otherwise wedge the sync loop).
+describe("decodeTokenMints — tolerance", () => {
+  test("no transactionResult (system tx) → []", () => {
+    expect(decodeTokenMints("deadbeef", undefined)).toEqual([]);
+    expect(decodeTokenMints("deadbeef", null)).toEqual([]);
+  });
+
+  test("status FAILURE → [] (everything rolled back, incl. guaranteed)", () => {
+    expect(
+      decodeTokenMints("deadbeef", { status: "FAILURE", segments: [] }),
+    ).toEqual([]);
+  });
+
+  test("garbage bytes with SUCCESS status → [] without throwing", () => {
+    expect(
+      decodeTokenMints("not-even-hex", { status: "SUCCESS" }),
+    ).toEqual([]);
+    expect(
+      decodeTokenMints("00".repeat(64), { status: "SUCCESS" }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds a new built-in Midnight sync primitive, **`Midnight:TokenMint`**, that maps a token id ("color") back to the **contract that minted it** plus the **domain separator** — the mapping wallets cannot provide (they only surface the 64-hex token type, and the derivation `rawTokenType = H(domain_sep, contract_address)` is one-way without this registry).

### How it works

A contract call's ledger `Effects` record mints as `domain_sep → amount` maps (`shieldedMints` / `unshieldedMints`). The indexer doesn't expose effects via GraphQL, so the fetcher selects the transaction `raw` bytes + `transactionResult`, deserializes with **ledger-v8** (same approach as the existing nullifier event decoder), walks `intents → actions → ContractCall` transcripts, and derives the token type with ledger-v8's own `rawTokenType()`. One event per `(tx, call, domainSep, kind)`.

Correctness details:
- **Failed segments roll back on chain** — the decoder consults `transactionResult`: `FAILURE` emits nothing; `PARTIAL_SUCCESS` applies guaranteed transcripts + only successful fallible segments (intent map key = segment id). System transactions (no `transactionResult`) are skipped — native NIGHT issuance is not a contract mint.
- Only `ContractCall` carries transcripts (deploys/maintenance updates cannot mint).
- Amounts travel as **decimal strings** (u64 mints exceed `MAX_SAFE_INTEGER`).
- The decoder never throws (tolerant like `zswap-decoder.ts`) — an undecodable tx logs and contributes nothing, so it can't wedge the fetch loop.
- The mint **nonce is not part of token identity** (it only randomizes coin commitments, and is never public for shielded mints) — the registry key is `(token_type, kind)`; `kind` matters because shielded/unshielded share the derivation formula.

### Changes

**SDK** (`packages/node-sdk/`):
- `sm/primitives`: `PrimitiveTypeMidnightTokenMint` + `midnight-token-mint/` module + registry entry (mirrors UnshieldedCreate).
- `sync/midnight`: new `mint-decoder.ts`; `MidnightClient` gains a flag-gated `raw` + `... on RegularTransaction { transactionResult }` selection; fetcher gains the dispatch branch, the fetch flag, **and the `contractActions` exclusion** (without it, an addressless primitive falls into the contract-state else-branch and crashes on `contractAddress!`).
- `sync/test/mint-decoder.test.ts`: tolerance unit tests (garbage bytes / FAILURE / missing result → `[]`).

**E2E** (`e2e/`, workspace deps — proves the primitive pre-publish):
- `counter.compact` gains `mint_shielded` / `mint_unshielded` circuits (copied from zswap-da's offer-files contract; compiles clean — launcher recompiles + redeploys per run; `ledger` declarations untouched so existing contract-state assertions are unaffected).
- New `trigger-token-mints.ts` (ported from zswap-da's `mint-test-tokens.ts`): mints one shielded + one unshielded token via `callTx` and returns the **wallet-visible colors**.
- Config/grammar/STM handler/table: registry `midnight_token_mints` with `UNIQUE (token_type, kind)`; on conflict `total_minted` accumulates (mapping + first-mint provenance immutable).
- Four assertion layers in `run-tests.ts`:
  1. `primitive_accounting` has `Midnight-TokenMint`;
  2. registry has shape-valid shielded + unshielded rows;
  3. **derivation fidelity** — every stored `token_type` byte-equals `rawTokenType(domain_sep, contract_address)` recomputed via ledger-v8;
  4. **the use case** — the trigger's wallet-visible colors resolve through the registry to the counter contract, with matching domain sep and exact `total_minted`.

## Verification

- `bun run e2e/runner.ts midnight` — green including the 4 new TokenMint assertions and all pre-existing ones (contract-state, Nullifier, UnshieldedCreate, ZswapRoot, batcher).
- **Negative check**: suite run with `doTriggerTokenMints()` disabled — the TokenMint assertions fail while the rest stays green (proves they exercise the real pipeline).
- `bun test ./packages`: 144 pass / 2 fail — the 2 failures are **pre-existing on v-next** (verified by stash-baseline: clean v-next = 141 pass / same 2 fail; this branch adds 3 passing decoder tests).
- Compact compile of the extended counter contract: clean (5 circuits).

## Notes

- WASM cost: one `Transaction.deserialize` per regular tx per block, **only when the primitive is configured** (flag-gated; nothing changes for existing consumers).
- Template adoption (e.g. zswap-da auto-registering mint provenance for `known_tokens`) is a **follow-up after the next publish** — templates pin published `0.100.22`.
- `contract-counter`'s `.` package export points at a non-existent `_index.ts` (pre-existing); the trigger imports by path like `contract-counter-deploy.ts` does.
