### PR TITLE
docs(wallets): document local (in-browser) wallet modes

### DIFF
--- a/docs/site/docs/home/100-components/112-wallets.md
+++ b/docs/site/docs/home/100-components/112-wallets.md
@@ -63,6 +63,39 @@ The `WalletMode` enum allows you to support a broad range of ecosystems, enablin
 | **`Mina`** | Mina | Connects to the Auro wallet for the Mina Protocol. |
 | **`AvailJs`** | Avail | Connects to wallets for the Avail network. |
 | **`Midnight`** | Midnight | Connects to Lace Wallet |
+| **`CardanoLocal`** | Cardano | In-browser local wallet: a BIP-39 key-pair generated and managed by the library. No extension required. |
+| **`MidnightLocal`** | Midnight | In-browser local wallet from a generated hex seed. No extension required. |
+| **`EvmViem`** | EVM | In-browser local wallet from a viem `0x` private key. No extension required. |
+
+### Local (in-browser) wallets
+
+For Cardano you have two options, both managed by `@effectstream/wallets`:
+
+1. **Connect a real wallet** (`WalletMode.Cardano`) - the user signs with
+   their CIP-30 extension (Lace, Eternl, Nami, NuFi, ...).
+2. **Use a local wallet** (`WalletMode.CardanoLocal`) - the library
+   generates and manages a key-pair in the browser, with no extension. The
+   code for this lives in `packages/effectstream-sdk/wallets/src/cardano/`.
+
+```ts
+import { WalletMode, walletLogin, signMessage } from '@effectstream/wallets';
+
+// A fresh BIP-39 seed is generated in the browser when `seedPhrase` is omitted.
+const wallet = await walletLogin({
+  mode: WalletMode.CardanoLocal,
+  network: 'Preview', // 'Mainnet' | 'Preprod' | 'Preview' | 'Custom'
+});
+if (!wallet.success) throw new Error(wallet.errorMessage);
+
+console.log('Local address:', wallet.result.walletAddress); // addr_test1...
+const signature = await signMessage(wallet.result, 'hello effectstream');
+```
+
+The local key never leaves the browser. Combined with the [Account
+System](#wallets-and-the-effectstream-account-system)'s `&linkAddress`
+delegation, a real wallet can authorise the local key to sign non-financial
+inputs - so the player signs once and subsequent actions need no pop-up. The
+same pattern is available on EVM (`EvmViem`) and Midnight (`MidnightLocal`).
 
 ## EffectStreamConfig
 

--- a/docs/site/docs/home/500-packages/510-sdk/wallets.md
+++ b/docs/site/docs/home/500-packages/510-sdk/wallets.md
@@ -18,6 +18,7 @@ Avail.
 - Spans MetaMask + injected EVM, Cardano (CIP-30), Midnight, Mina, Polkadot, Algorand, Avail.
 - Used together with `@effectstream/crypto` (server-side verification).
 - High-level helpers `walletLogin` and `sendTransaction` hide the polling loop.
+- Also supports **local (in-browser) wallets** that need no extension: `CardanoLocal`, `EvmViem`, `MidnightLocal`.
 
 ## Install
 
@@ -68,6 +69,40 @@ const evmOptions = available[WalletMode.EvmInjected]; // [{ metadata, ... }, …
 > Cardano CIP-30 API, etc. - it won't load in plain Node. Server-side
 > signature verification is `@effectstream/crypto`.
 
+## Local wallets (no extension required)
+
+Besides connecting an injected/extension wallet, `@effectstream/wallets`
+can generate and manage a key-pair **locally, in the browser**. The local
+modes return the same `Wallet` handle as the injected ones, so `signMessage`
+and `sendTransaction` work identically:
+
+- `WalletMode.CardanoLocal` - BIP-39 seed generated in-browser (via Lucid).
+- `WalletMode.EvmViem` - viem account from a `0x` private key.
+- `WalletMode.MidnightLocal` - hex seed generated in-browser.
+
+```typescript
+import { walletLogin, WalletMode, signMessage } from "@effectstream/wallets";
+
+// A fresh BIP-39 seed is generated in the browser when `seedPhrase` is omitted.
+const wallet = await walletLogin({
+  mode: WalletMode.CardanoLocal,
+  network: "Preview", // "Mainnet" | "Preprod" | "Preview" | "Custom"
+});
+if (!wallet.success) throw new Error(wallet.errorMessage);
+
+wallet.result.walletAddress; // addr_test1...
+const signature = await signMessage(wallet.result, "hello effectstream");
+```
+
+These modes need no browser extension (no `window.ethereum`, no CIP-30) -
+the key material is created client-side and never touches a server. Pair a
+local key with the account-linking delegation (`&linkAddress`) so a real
+wallet (Cardano CIP-30, MetaMask, ...) can authorise it to sign
+non-financial inputs: this is the basis of the device-key / frictionless
+signing flow. Source: [`src/cardano/local.ts`](https://github.com/effectstream/effectstream/blob/main/packages/effectstream-sdk/wallets/src/cardano/local.ts)
+and the runnable [`src/cardano/local.test.ts`](https://github.com/effectstream/effectstream/blob/main/packages/effectstream-sdk/wallets/src/cardano/local.test.ts)
+(generate -> sign -> verify with `@effectstream/crypto`).
+
 ## Inside EffectStream
 
 The client-side counterpart to `@effectstream/crypto`. Frontends
@@ -95,7 +130,7 @@ Sending transactions:
 
 Wallet discovery / identification:
 
-- `WalletMode`: enum of `EvmInjected`, `EvmEthers`, `Midnight`, `Cardano`, `Polkadot`, `Algorand`, `Mina`, `AvailJs`.
+- `WalletMode`: enum of `EvmInjected`, `EvmEthers`, `EvmViem`, `Cardano`, `CardanoLocal`, `Midnight`, `MidnightLocal`, `Polkadot`, `Algorand`, `Mina`, `AvailJs`. The `*Local` and `EvmViem` modes are in-browser wallets that need no extension.
 - `WalletNameMap`: `Record<WalletMode, string>` for display.
 - `allInjectedWallets(config)` lists installed wallets in the browser.
 - `getAddressType(walletMode)` maps a `WalletMode` to its `@effectstream/utils` `AddressType`.

--- a/packages/effectstream-sdk/wallets/README.md
+++ b/packages/effectstream-sdk/wallets/README.md
@@ -10,6 +10,7 @@ Avail.
 - Spans MetaMask + injected EVM, Cardano (CIP-30), Midnight, Mina, Polkadot, Algorand, Avail.
 - Used together with `@effectstream/crypto` (server-side verification).
 - High-level helpers `walletLogin` and `sendTransaction` hide the polling loop.
+- Also supports **local (in-browser) wallets** that need no extension: `CardanoLocal`, `EvmViem`, `MidnightLocal`.
 
 ## Install
 
@@ -60,6 +61,40 @@ const evmOptions = available[WalletMode.EvmInjected]; // [{ metadata, ... }, …
 > Cardano CIP-30 API, etc. - it won't load in plain Node. Server-side
 > signature verification is `@effectstream/crypto`.
 
+## Local wallets (no extension required)
+
+Besides connecting an injected/extension wallet, `@effectstream/wallets`
+can generate and manage a key-pair **locally, in the browser**. The local
+modes return the same `Wallet` handle as the injected ones, so `signMessage`
+and `sendTransaction` work identically:
+
+- `WalletMode.CardanoLocal` - BIP-39 seed generated in-browser (via Lucid).
+- `WalletMode.EvmViem` - viem account from a `0x` private key.
+- `WalletMode.MidnightLocal` - hex seed generated in-browser.
+
+```typescript
+import { walletLogin, WalletMode, signMessage } from "@effectstream/wallets";
+
+// A fresh BIP-39 seed is generated in the browser when `seedPhrase` is omitted.
+const wallet = await walletLogin({
+  mode: WalletMode.CardanoLocal,
+  network: "Preview", // "Mainnet" | "Preprod" | "Preview" | "Custom"
+});
+if (!wallet.success) throw new Error(wallet.errorMessage);
+
+wallet.result.walletAddress; // addr_test1...
+const signature = await signMessage(wallet.result, "hello effectstream");
+```
+
+These modes need no browser extension (no `window.ethereum`, no CIP-30) -
+the key material is created client-side and never touches a server. Pair a
+local key with the account-linking delegation (`&linkAddress`) so a real
+wallet (Cardano CIP-30, MetaMask, ...) can authorise it to sign
+non-financial inputs: this is the basis of the device-key / frictionless
+signing flow. Source: [`src/cardano/local.ts`](https://github.com/effectstream/effectstream/blob/main/packages/effectstream-sdk/wallets/src/cardano/local.ts)
+and the runnable [`src/cardano/local.test.ts`](https://github.com/effectstream/effectstream/blob/main/packages/effectstream-sdk/wallets/src/cardano/local.test.ts)
+(generate -> sign -> verify with `@effectstream/crypto`).
+
 ## Inside EffectStream
 
 The client-side counterpart to `@effectstream/crypto`. Frontends
@@ -87,7 +122,7 @@ Sending transactions:
 
 Wallet discovery / identification:
 
-- `WalletMode`: enum of `EvmInjected`, `EvmEthers`, `Midnight`, `Cardano`, `Polkadot`, `Algorand`, `Mina`, `AvailJs`.
+- `WalletMode`: enum of `EvmInjected`, `EvmEthers`, `EvmViem`, `Cardano`, `CardanoLocal`, `Midnight`, `MidnightLocal`, `Polkadot`, `Algorand`, `Mina`, `AvailJs`. The `*Local` and `EvmViem` modes are in-browser wallets that need no extension.
 - `WalletNameMap`: `Record<WalletMode, string>` for display.
 - `allInjectedWallets(config)` lists installed wallets in the browser.
 - `getAddressType(walletMode)` maps a `WalletMode` to its `@effectstream/utils` `AddressType`.


### PR DESCRIPTION
## What

Documents the local (in-browser) wallet modes managed by `@effectstream/wallets` - `CardanoLocal`, `EvmViem`, `MidnightLocal` - which were previously undocumented. The docs only described injected/extension wallets (Cardano CIP-30, MetaMask, ...).

## Why

For Cardano you can either connect a real CIP-30 wallet (`WalletMode.Cardano`) or have the library generate and manage a key-pair locally in the browser (`WalletMode.CardanoLocal`); the code lives in `packages/effectstream-sdk/wallets/src/cardano/`. The local wallet is the basis of the device-key / frictionless signing flow, so it should be discoverable from the docs.

Context: it is the deliverable behind Catalyst project 1000055 M3. A reviewer reading the linked docs could not trace the local-key path because only injected modes were documented.

## Changes

- `packages/effectstream-sdk/wallets/README.md` - new "Local wallets" section + runnable `CardanoLocal` example; `WalletMode` exports list now includes the local modes.
- `docs/site/docs/home/100-components/112-wallets.md` - `WalletMode` table rows + "Local (in-browser) wallets" subsection.
- `docs/site/docs/home/500-packages/510-sdk/wallets.md` - regenerated from the README (`bun run sync-readmes`).

All examples use the real public API (`walletLogin({ mode: WalletMode.CardanoLocal, network })` + `signMessage`), matching the runnable `src/cardano/local.test.ts` (generate -> sign -> verify with `@effectstream/crypto`).

## Note

Docs-only. Pre-existing staleness in `112-wallets.md` (`login()` / `EffectStreamConfig`, now `walletLogin` / `EffectstreamConfig`) is left untouched to keep scope tight - happy to fix in a follow-up.