### PR TITLE
Fix/sync batcher wallet increased batch size

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1092,6 +1092,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@midnight-ntwrk/wallet-sdk-dust-wallet@3.0.0": "patches/@midnight-ntwrk%2Fwallet-sdk-dust-wallet@3.0.0.patch",
+  },
   "overrides": {
     "@effect/platform": "0.96.1",
     "@midnight-ntwrk/ledger-v8": "8.0.3",
@@ -4131,11 +4134,15 @@
 
     "@e2e/engine/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
 
+    "@e2e/evm-batcher/viem": ["viem@2.52.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.29", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew=="],
+
     "@e2e/evm-contracts/@effectstream/evm-contracts": ["@effectstream/evm-contracts@file:packages/chains/evm-contracts", { "dependencies": { "@nomicfoundation/hardhat-ignition": "3.0.2", "@nomicfoundation/hardhat-ignition-viem": "3.0.2", "@nomicfoundation/hardhat-viem": "3.0.0", "@opentelemetry/sdk-node": "0.56.0", "@openzeppelin/contracts": "5.1.0", "@openzeppelin/contracts-upgradeable": "^5.1.0", "@wagmi/cli": "2.3.1", "hardhat": "3.0.4", "jsonc-parser": "^3.3.1" } }],
 
     "@e2e/wallets-ui/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@effectstream/batcher-sdk/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
+
+    "@effectstream/batcher-sdk/viem": ["viem@2.52.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.29", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew=="],
 
     "@effectstream/bitcoin-contracts/bitcoinjs-lib": ["bitcoinjs-lib@7.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bech32": "^2.0.0", "bip174": "^3.0.0", "bs58check": "^4.0.0", "uint8array-tools": "^0.0.9", "valibot": "^1.2.0", "varuint-bitcoin": "^2.0.0" } }, "sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww=="],
 
@@ -4767,6 +4774,26 @@
 
     "@e2e/bitcoin-contracts/bitcoinjs-lib/bs58check": ["bs58check@3.0.1", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^5.0.0" } }, "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ=="],
 
+    "@e2e/evm-batcher/viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@e2e/evm-batcher/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
+    "@e2e/evm-batcher/viem/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
+    "@e2e/evm-batcher/viem/ox": ["ox@0.14.29", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg=="],
+
+    "@e2e/evm-batcher/viem/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "@effectstream/batcher-sdk/viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@effectstream/batcher-sdk/viem/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
+    "@effectstream/batcher-sdk/viem/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
+    "@effectstream/batcher-sdk/viem/ox": ["ox@0.14.29", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg=="],
+
+    "@effectstream/batcher-sdk/viem/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
     "@effectstream/bitcoin-contracts/bitcoinjs-lib/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@effectstream/bitcoin-contracts/bitcoinjs-lib/bip174": ["bip174@3.0.0", "", { "dependencies": { "uint8array-tools": "^0.0.9", "varuint-bitcoin": "^2.0.0" } }, "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw=="],
@@ -5174,6 +5201,14 @@
     "@coinbase/cdp-sdk/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "@e2e/bitcoin-contracts/bitcoinjs-lib/bs58check/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "@e2e/evm-batcher/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "@e2e/evm-batcher/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@effectstream/batcher-sdk/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "@effectstream/batcher-sdk/viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "@effectstream/bitcoin-contracts/bitcoinjs-lib/varuint-bitcoin/uint8array-tools": ["uint8array-tools@0.0.8", "", {}, "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g=="],
 

--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -20,7 +20,7 @@ const proc = Bun.spawn(
     cwd: repoRoot,
     stdout: "inherit",
     stderr: "inherit",
-    env: { ...process.env },
+    env: { PGLITE: "true", ...process.env },
   },
 );
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "@effectstream/grafana-loki": "workspace:*",
     "bun-types": "^1.3.11",
     "wait-on": "8.0.3"
+  },
+  "patchedDependencies": {
+    "@midnight-ntwrk/wallet-sdk-dust-wallet@3.0.0": "patches/@midnight-ntwrk%2Fwallet-sdk-dust-wallet@3.0.0.patch"
   }
 }

--- a/packages/batcher/DUST_SYNC_PATCH.md
+++ b/packages/batcher/DUST_SYNC_PATCH.md
@@ -1,0 +1,123 @@
+# Dust wallet sync memory/throughput patch
+
+## TL;DR
+
+If you install `@effectstream/batcher` as a dependency and run Midnight fee
+wallets, you should apply the patch below to
+`@midnight-ntwrk/wallet-sdk-dust-wallet@3.0.0`. **Without it, the batcher's dust
+sync tuning is silently ignored** and the wallet syncs with browser-tuned
+defaults that are slow and allocation-heavy for a backend.
+
+> Patches are **not** transitive. The patch shipped in this monorepo
+> (`patches/` + `patchedDependencies` in the root `package.json`) only applies
+> to *our* installs. When you install `@effectstream/batcher` from npm, your
+> package manager resolves a clean, unpatched `wallet-sdk-dust-wallet@3.0.0`,
+> so you must re-apply the patch in your own project.
+
+## The problem
+
+The batcher builds Midnight fee wallets in `dust-only` sync mode — the shielded
+and unshielded sub-wallet subscriptions are torn down, so **the dust wallet is
+the only thing actively syncing** and is the dominant memory consumer. With more
+than one fee wallet this multiplies, and even a single wallet has a noticeable
+footprint.
+
+`@midnight-ntwrk/wallet-sdk-dust-wallet@3.0.0` hard-codes its sync batching to
+values tuned for keeping a browser UI responsive:
+
+- batch **size** `10` — emit a new wallet-state snapshot every 10 events
+- batch **timeout** `1ms`
+- batch **spacing** `4ms` — sleep 4ms between *every* batch
+
+In a headless backend this is wasteful: tiny batches mean far more short-lived
+intermediate state objects (allocation churn / GC pressure), and the 4ms
+per-batch throttle dramatically slows initial catch-up sync (e.g. ~40s of pure
+imposed sleep over a 100k-event history vs ~1s with the patched values).
+
+`wallet-sdk-dust-wallet@4.0.0+` makes these configurable via a `batchUpdates`
+field. We pin `3.0.0` (a `4.x` bump requires `ledger-v8 ^8.1.0` and a
+coordinated upgrade of the whole Midnight SDK set), so we backport just the
+config wiring via a patch.
+
+## What the patch does
+
+It changes `makeDefaultSyncService` in `dist/v1/Sync.js` to read the batch
+parameters from `config.batchUpdates` (falling back to the original 10/1ms/4ms
+defaults), and lets `spacing: 0` disable the inter-batch throttle entirely. This
+is a straight backport of the logic already present in `4.1.0`.
+
+The batcher already passes the config — see
+[`packages/chains/midnight-contracts/src/get-wallet-info.ts`](../chains/midnight-contracts/src/get-wallet-info.ts)
+(`resolveDustBatchUpdates` → `buildDustWallet`). Defaults: **size 100 / timeout
+1ms / spacing 1ms**, overridable per-deployment with:
+
+| env var                              | default | meaning                                            |
+| ------------------------------------ | ------- | -------------------------------------------------- |
+| `MIDNIGHT_DUST_SYNC_BATCH_SIZE`      | `100`   | max events per batch before emitting a snapshot    |
+| `MIDNIGHT_DUST_SYNC_BATCH_TIMEOUT_MS`| `1`     | max wait before flushing a partial batch           |
+| `MIDNIGHT_DUST_SYNC_BATCH_SPACING_MS`| `1`     | min delay between batches (`0` disables throttling) |
+
+> Keep `spacing > 0` unless you run the wallet in a worker thread. The batcher
+> syncs on the main event loop, so `spacing: 0` would starve the HTTP server /
+> tx pipeline during the initial catch-up sync. `1ms` is enough to interleave.
+
+## How to apply it in your project
+
+The patch (`dist/v1/Sync.js`):
+
+```diff
+         updates: (state, secretKey) => {
+-            const batchSize = 10;
+-            const batchTimeout = Duration.millis(1);
+-            return pipe(indexerSyncService.subscribeWallet(state), Stream.groupedWithin(batchSize, batchTimeout), Stream.map(Chunk.toArray), Stream.map((data) => WalletSyncUpdate.create(data, secretKey, new Date())), Stream.schedule(Schedule.spaced(Duration.millis(4))), Stream.provideSomeLayer(indexerSyncService.connectionLayer()));
++            const batchSize = config.batchUpdates?.size ?? 10;
++            const batchTimeout = Duration.millis(config.batchUpdates?.timeout ?? 1);
++            const batchSpacing = config.batchUpdates?.spacing ?? 4;
++            return pipe(indexerSyncService.subscribeWallet(state), Stream.groupedWithin(batchSize, batchTimeout), Stream.map(Chunk.toArray), Stream.map((data) => WalletSyncUpdate.create(data, secretKey, new Date())), batchSpacing > 0
++                ? Stream.schedule(Schedule.spaced(Duration.millis(batchSpacing)))
++                : (eventsStream) => eventsStream, Stream.provideSomeLayer(indexerSyncService.connectionLayer()));
+         },
+```
+
+### Bun
+
+```bash
+bun patch @midnight-ntwrk/wallet-sdk-dust-wallet@3.0.0
+# edit node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet/dist/v1/Sync.js per the diff above
+bun patch --commit node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet
+```
+
+This writes a patch file under `patches/` and adds `patchedDependencies` to your
+`package.json`. Commit both — they re-apply on every `bun install`.
+
+### npm / yarn / pnpm (via `patch-package`)
+
+```bash
+npm i -D patch-package
+# edit node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet/dist/v1/Sync.js per the diff above
+npx patch-package @midnight-ntwrk/wallet-sdk-dust-wallet
+# add to package.json scripts: "postinstall": "patch-package"
+```
+
+Commit the generated `patches/@midnight-ntwrk+wallet-sdk-dust-wallet+3.0.0.patch`.
+
+## Verifying it applied
+
+```bash
+grep -q "config.batchUpdates?.size" \
+  node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet/dist/v1/Sync.js \
+  && echo PATCHED || echo "NOT patched"
+```
+
+Make sure the **copy your build actually resolves** is patched — in hoisted
+layouts there may be multiple physical copies under different peer-dependency
+hashes. Only the one your wallet-building code (`@effectstream/midnight-contracts`)
+resolves matters; a type-only copy nested under `wallet-sdk-facade` is never
+executed and does not need patching.
+
+## When to remove it
+
+This patch is pinned to `wallet-sdk-dust-wallet@3.0.0`. If/when the dependency
+moves to `4.x`, `batchUpdates` is supported natively — drop the patch. Bun/
+`patch-package` will error if the package version no longer matches, which is
+the intended signal.

--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -16,6 +16,12 @@ bun add @effectstream/batcher-sdk
 npm install @effectstream/batcher-sdk
 ```
 
+> **Midnight fee wallets:** if you run the Midnight adapter, see
+> [DUST_SYNC_PATCH.md](./DUST_SYNC_PATCH.md). The dust wallet's sync batching is
+> hard-coded for browser responsiveness in the pinned SDK version; a small,
+> non-transitive patch is required to apply the batcher's backend tuning and
+> reduce its memory footprint. You must re-apply it in your own project.
+
 ## Standalone usage
 
 A minimal end-to-end example using `FileStorage`, the EffectstreamL2 adapter, and the bundled HTTP server.

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -827,6 +827,42 @@ function buildShieldedWallet(config: DefaultConfiguration, seed: Uint8Array) {
   return ShieldedWallet(config as any).startWithSeed(seed);
 }
 
+/**
+ * Sync batching tuning for the dust wallet.
+ *
+ * The wallet SDK's default sync settings (batch size 10, 1ms timeout, 4ms
+ * spacing) are tuned to keep a browser UI responsive — they emit many small
+ * state snapshots and throttle 4ms between every batch. In a headless backend
+ * (e.g. the batcher's fee wallets) that is wasteful: it slows initial sync and
+ * produces a lot of short-lived intermediate state, inflating memory churn.
+ *
+ * We collect larger batches (fewer intermediate snapshots) with minimal
+ * spacing. Spacing is kept >0 because the batcher syncs on the main event loop
+ * rather than in a worker — spacing 0 would starve other work during the
+ * initial catch-up sync.
+ *
+ * NOTE: `batchUpdates` is only honoured by `wallet-sdk-dust-wallet >= 4.0.0`.
+ * On the currently-pinned 3.0.0 these values are ignored unless the package is
+ * patched (see patches/). Plumbing them here is harmless on 3.0.0.
+ */
+function resolveDustBatchUpdates(): {
+  size: number;
+  timeout: number;
+  spacing: number;
+} {
+  const num = (name: string, fallback: number): number => {
+    const raw = getEnv(name);
+    if (raw == null || raw === "") return fallback;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+  };
+  return {
+    size: num("MIDNIGHT_DUST_SYNC_BATCH_SIZE", 100),
+    timeout: num("MIDNIGHT_DUST_SYNC_BATCH_TIMEOUT_MS", 1),
+    spacing: num("MIDNIGHT_DUST_SYNC_BATCH_SPACING_MS", 1),
+  };
+}
+
 function buildDustWallet(
   config: DefaultConfiguration,
   seed: Uint8Array,
@@ -834,6 +870,7 @@ function buildDustWallet(
 ) {
   const dustConfig = {
     ...config,
+    batchUpdates: resolveDustBatchUpdates(),
     costParameters: {
       ledgerParams: LedgerParameters.initialParameters(),
       additionalFeeOverhead: CONSTANTS.DUST_FEE_OVERHEAD,

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -225,7 +225,9 @@ function cleanupOrphanedClusters(bin: string, env: Record<string, string | undef
  * so they don't accumulate and exhaust system resources.
  */
 function ensureCluster(): Promise<Cluster> {
-  if (clusterPromise) return clusterPromise;
+  // If the cluster was stopped (last harness tore down), start a fresh one.
+  if (clusterPromise && !clusterStopped) return clusterPromise;
+  clusterPromise = undefined;
   clusterPromise = (async () => {
     const bin = resolvePgBinDir()!;
     clusterBin = bin;
@@ -499,9 +501,6 @@ async function setupPostgresHarness(): Promise<Harness> {
   });
   await admin.query(`CREATE DATABASE "${dbName}"`);
   await admin.end();
-
-  // Parent assertions go through poll.ts's `q`; PGLITE=false → plain queries.
-  process.env.PGLITE = "false";
 
   const dbEnv = {
     PGLITE: "false",

--- a/patches/@midnight-ntwrk%2Fwallet-sdk-dust-wallet@3.0.0.patch
+++ b/patches/@midnight-ntwrk%2Fwallet-sdk-dust-wallet@3.0.0.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/v1/Sync.js b/dist/v1/Sync.js
+index 26f3e2affd6e488487e8b8491ddf1acc4b828384..79418e34ed4e375428664174a8fbe3f4164c3c70 100644
+--- a/dist/v1/Sync.js
++++ b/dist/v1/Sync.js
+@@ -67,9 +67,12 @@ export const makeDefaultSyncService = (config) => {
+     const indexerSyncService = makeIndexerSyncService(config);
+     return {
+         updates: (state, secretKey) => {
+-            const batchSize = 10;
+-            const batchTimeout = Duration.millis(1);
+-            return pipe(indexerSyncService.subscribeWallet(state), Stream.groupedWithin(batchSize, batchTimeout), Stream.map(Chunk.toArray), Stream.map((data) => WalletSyncUpdate.create(data, secretKey, new Date())), Stream.schedule(Schedule.spaced(Duration.millis(4))), Stream.provideSomeLayer(indexerSyncService.connectionLayer()));
++            const batchSize = config.batchUpdates?.size ?? 10;
++            const batchTimeout = Duration.millis(config.batchUpdates?.timeout ?? 1);
++            const batchSpacing = config.batchUpdates?.spacing ?? 4;
++            return pipe(indexerSyncService.subscribeWallet(state), Stream.groupedWithin(batchSize, batchTimeout), Stream.map(Chunk.toArray), Stream.map((data) => WalletSyncUpdate.create(data, secretKey, new Date())), batchSpacing > 0
++                ? Stream.schedule(Schedule.spaced(Duration.millis(batchSpacing)))
++                : (eventsStream) => eventsStream, Stream.provideSomeLayer(indexerSyncService.connectionLayer()));
+         },
+         blockData: () => {
+             return Effect.gen(function* () {


### PR DESCRIPTION
The batcher's Midnight fee wallets run in dust-only mode, so the dust wallet is the only thing actively syncing — and its sync batching is hard-coded in `wallet-sdk-dust-wallet@3.0.0` for browser responsiveness (size 10 / 4ms spacing), causing high allocation churn and slow catch-up sync.

- Patch `wallet-sdk-dust-wallet@3.0.0` to read batchUpdates from config (backport of the native 4.x API; avoids a coordinated ledger-v8 8.1.x bump).
- Plumb the config in get-wallet-info.ts with backend-tuned defaults (size 100 / timeout 1ms / spacing 1ms), overridable via `MIDNIGHT_DUST_SYNC_BATCH_*` env vars.
- Document in `packages/batcher/DUST_SYNC_PATCH.md` (+ `README` pointer) that the patch is non-transitive — downstream consumers must re-apply it.

_Also includes an unrelated e2e harness tweak (fresh cluster on stop, default `PGLITE=true`)._