### PR TITLE
feat(preorder): admin EVM-gating + post-sale mint dry-run preview

### DIFF
--- a/templates/preorder/packages/frontend/client/src/App.tsx
+++ b/templates/preorder/packages/frontend/client/src/App.tsx
@@ -32,7 +32,8 @@ export function App() {
           background: "#010409", color: "#e6edf3",
         }}>
           <div style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "hidden" }}>
-            <Header walletType={walletType} />
+            {/* On /admin, force the EVM-only wallet UI (Cardano hidden) and relabel the connect button. */}
+            <Header walletType={isAdmin ? "evm" : walletType} admin={isAdmin} />
             <main style={{ flex: 1, overflowY: "auto" }}>
               {isAdmin ? (
                 <AdminPanel apiUrl={API_URL} />

--- a/templates/preorder/packages/frontend/client/src/layout/Header.tsx
+++ b/templates/preorder/packages/frontend/client/src/layout/Header.tsx
@@ -36,7 +36,7 @@ type PendingConnect = {
   action: () => void;
 };
 
-export function Header({ walletType }: { walletType?: "evm" | "cardano" } = {}) {
+export function Header({ walletType, admin }: { walletType?: "evm" | "cardano"; admin?: boolean } = {}) {
   const w = useWallet();
   const isEvm = w.mode.startsWith("evm");
   const address = isEvm ? w.evmAddress : w.cardanoAddress;
@@ -93,7 +93,7 @@ export function Header({ walletType }: { walletType?: "evm" | "cardano" } = {}) 
               <div style={{ position: "relative" }}>
                 <button data-testid="connect-evm-btn" onClick={() => setOpenMenu(openMenu === "evm" ? null : "evm")}
                   style={{ ...pillBtnStyle, background: "#1f3a5f", color: "#58a6ff", border: "1px solid #264a78" }}>
-                  {w.isConnecting ? "Connecting..." : "Connect EVM"}
+                  {w.isConnecting ? "Connecting..." : admin ? "Connect Admin Wallet" : "Connect EVM"}
                 </button>
                 {openMenu === "evm" && (
                   <div style={dropdownStyle}>

--- a/templates/preorder/packages/frontend/client/src/pages/AdminPanel.tsx
+++ b/templates/preorder/packages/frontend/client/src/pages/AdminPanel.tsx
@@ -5,6 +5,7 @@ import { adminAddress, createCampaign, setProduct, endCampaign, setCoin, mintNft
 import { WalletConfirmModal } from "../wallet/WalletConfirmModal.tsx";
 import { AddressChip } from "../components/AddressChip.tsx";
 import { useLog } from "../logs/LogContext.tsx";
+import { useWallet } from "../wallet/WalletContext.tsx";
 
 const CAMPAIGN_ID = "test-launchpad-1";
 
@@ -108,10 +109,33 @@ type AppConfig = {
   coins?: AdminCoin[];
 };
 
+// Dry-run result from GET /api/admin/mint-preview/:slug — what mint-nfts WOULD enqueue.
+type MintPreview = {
+  campaign: { slug: string; campaignId: string; status: string };
+  willEnqueue: boolean;
+  totals: {
+    tokens: number; buyers: number; jobs: number;
+    newTokens: number; newJobs: number; alreadyEnqueuedJobs: number;
+  };
+  byChain: { chain: string; tokens: number; buyers: number; newTokens: number }[];
+  byItem: { itemId: number; name: string; tokens: number; buyers: number }[];
+  rows: {
+    chain: string; wallet: string; itemId: number; itemName: string;
+    quantity: number; alreadyEnqueued: boolean; existingStatus: string | null;
+  }[];
+};
+
 export function AdminPanel({ apiUrl }: { apiUrl: string }) {
   const { addLog } = useLog();
+  const w = useWallet();
+  // Admin actions are gated on a connected EVM wallet (the admin signer). The Cardano wallet is
+  // hidden from /admin via the Header's walletType="evm". Without an EVM connection every action
+  // button below is disabled and a notice prompts the user to connect.
+  const evmConnected = w.mode.startsWith("evm") && !!w.evmAddress;
   const [config, setConfig] = useState<AppConfig | null>(null);
   const l2 = (config?.effectStreamL2 ?? null) as Address | null;
+  // A command can only be submitted with the L2 inbox loaded AND an EVM wallet connected.
+  const canAct = !!l2 && evmConnected;
   const [status, setStatus] = useState<AdminStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [tick, setTick] = useState(0);
@@ -119,6 +143,9 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
   // key, so — like a purchase — we surface a Sign Transaction modal before submitting on-chain).
   const [confirmTx, setConfirmTx] = useState<{ summary: string; run: () => Promise<void> } | null>(null);
   const [adminBalance, setAdminBalance] = useState("0");
+  // Dry-run mint preview (GET /api/admin/mint-preview) — populated by "Simulate mint".
+  const [mintPreview, setMintPreview] = useState<MintPreview | null>(null);
+  const [previewBusy, setPreviewBusy] = useState(false);
 
   // Campaign form
   const [campaignId, setCampaignId] = useState(CAMPAIGN_ID);
@@ -256,6 +283,26 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
     }
   };
 
+  // Dry-run: ask the API who/what/how many NFTs mint-nfts would produce — no state change.
+  const loadMintPreview = async () => {
+    setPreviewBusy(true);
+    try {
+      const res = await fetch(`${apiUrl}/api/admin/mint-preview/${CAMPAIGN_ID}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const p = (await res.json()) as MintPreview;
+      setMintPreview(p);
+      addLog(
+        "info",
+        `Mint preview: ${p.totals.newTokens} new token(s) to ${p.totals.buyers} buyer(s)`,
+        `${p.totals.alreadyEnqueuedJobs} already enqueued · total eligible ${p.totals.tokens}`,
+      );
+    } catch (e: any) {
+      addLog("error", "mint-preview failed", e.message);
+    } finally {
+      setPreviewBusy(false);
+    }
+  };
+
   const submitMintNfts = async () => {
     if (!l2) return;
     setBusy(true);
@@ -343,6 +390,21 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
         Acting as admin: {adminAddress()} · L2: {l2 ?? "loading..."}
       </p>
 
+      {/* Admin actions require a connected EVM wallet — use “Connect Admin Wallet” in the header. */}
+      {!evmConnected && (
+        <div data-testid="admin-connect-notice" style={{
+          display: "flex", alignItems: "center", gap: 10, marginBottom: 24, padding: "12px 16px",
+          background: "#2d2410", border: "1px solid #5a4708", borderRadius: 8,
+          color: "#f0c674", fontSize: 13,
+        }}>
+          <span style={{ fontSize: 16 }}>🔒</span>
+          <span>
+            Connect the admin (EVM) wallet to perform actions — click <strong>“Connect Admin Wallet”</strong> in
+            the top-right. All admin actions are disabled until a wallet is connected.
+          </span>
+        </div>
+      )}
+
       {/* Contracts & wallets — informative */}
       <section style={cardStyle}>
         <h2 style={h2Style}>Contracts &amp; wallets</h2>
@@ -381,7 +443,7 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
           <Field label="Description"><input style={inputStyle} value={description} onChange={(e) => setDescription(e.target.value)} /></Field>
           <Field label="Referrer reward bps"><input style={inputStyle} type="number" value={referrerRewardBps} onChange={(e) => setReferrerRewardBps(Number(e.target.value))} /></Field>
         </div>
-        <button data-testid="admin-update-campaign" style={btnStyle} disabled={busy || !l2}
+        <button data-testid="admin-update-campaign" style={btnStyle} disabled={busy || !canAct}
           onClick={() => requestConfirm(`update-campaign · ${campaignId}`, submitCampaign)}>
           {busy ? "Submitting…" : "Update campaign"}
         </button>
@@ -511,7 +573,7 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
           <Field label="Supply (blank = unlimited)"><input style={inputStyle} value={pSupply} onChange={(e) => setPSupply(e.target.value)} /></Field>
           <Field label="Image URL (blank = default effect)"><input style={inputStyle} value={pImage} placeholder="https://… (optional)" onChange={(e) => setPImage(e.target.value)} /></Field>
         </div>
-        <button data-testid="admin-set-product" style={btnStyle} disabled={busy || !l2}
+        <button data-testid="admin-set-product" style={btnStyle} disabled={busy || !canAct}
           onClick={() => requestConfirm(`${isEditMode ? "update" : "add"}-product · item ${pId}`, submitProduct)}>
           {busy ? "Submitting…" : isEditMode ? `Update product #${pId}` : "Add product"}
         </button>
@@ -576,7 +638,7 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
           <Field label="Multiplier x"><input style={inputStyle} value={cX} onChange={(e) => setCX(e.target.value)} /></Field>
           <Field label="Exponent n (10^n)"><input style={inputStyle} type="number" value={cN} onChange={(e) => setCN(e.target.value)} /></Field>
         </div>
-        <button data-testid="admin-set-coin" style={btnStyle} disabled={busy || !l2}
+        <button data-testid="admin-set-coin" style={btnStyle} disabled={busy || !canAct}
           onClick={() => requestConfirm(`set-coin · ${cToken} x=${cX} n=${cN}`, submitCoin)}>
           {busy ? "Submitting…" : "Update coin"}
         </button>
@@ -616,20 +678,106 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
         <h2 style={h2Style}>Post-sale NFT minting</h2>
         <p style={{ color: "#8b949e", fontSize: 12, marginBottom: 12 }}>
           After the campaign ends, mint an item NFT to every buyer for each item they own. Jobs are
-          submitted to the batcher, which holds funds and performs the actual mint.
+          submitted to the batcher, which holds funds and performs the actual mint. Run a
+          <strong> Simulate mint </strong> first to preview exactly who/what/how many would be minted —
+          it's a read-only dry-run that enqueues nothing.
         </p>
-        <button
-          data-testid="admin-mint-nfts"
-          style={{ ...btnStyle, background: "#1f6f5f", border: "1px solid #2ea08c" }}
-          disabled={busy || !l2 || status?.campaign.status !== "ended"}
-          onClick={() => requestConfirm(`mint-nfts · ${campaignId}`, submitMintNfts)}
-        >
-          {busy
-            ? "Submitting…"
-            : status?.campaign.status === "ended"
-              ? "Mint item NFTs"
-              : "End campaign first"}
-        </button>
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+          {/* Read-only dry-run — works before the campaign ends so you can preview ahead of time. */}
+          <button
+            data-testid="admin-simulate-mint"
+            style={{ ...btnStyle, background: "#1f3a5f", border: "1px solid #264a78" }}
+            disabled={previewBusy || !canAct}
+            onClick={loadMintPreview}
+          >
+            {previewBusy ? "Simulating…" : "Simulate mint (preview)"}
+          </button>
+          <button
+            data-testid="admin-mint-nfts"
+            style={{ ...btnStyle, background: "#1f6f5f", border: "1px solid #2ea08c" }}
+            disabled={busy || !canAct || status?.campaign.status !== "ended"}
+            onClick={() => requestConfirm(`mint-nfts · ${campaignId}`, submitMintNfts)}
+          >
+            {busy
+              ? "Submitting…"
+              : status?.campaign.status === "ended"
+                ? "Mint item NFTs"
+                : "End campaign first"}
+          </button>
+        </div>
+
+        {mintPreview && (
+          <div data-testid="mint-preview" style={{
+            marginTop: 16, padding: 16, background: "#0b1622",
+            border: "1px solid #1f3a5f", borderRadius: 8,
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12, flexWrap: "wrap", gap: 8 }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "#58a6ff" }}>
+                Simulation — {mintPreview.totals.newTokens} new token(s) for {mintPreview.totals.buyers} buyer(s)
+              </span>
+              <button onClick={() => setMintPreview(null)} style={{
+                background: "none", border: "none", color: "#6e7681", cursor: "pointer", fontSize: 16, lineHeight: 1,
+              }}>×</button>
+            </div>
+
+            {!mintPreview.willEnqueue && (
+              <div style={{ marginBottom: 12, padding: "8px 12px", background: "#2d2410", border: "1px solid #5a4708", borderRadius: 6, color: "#f0c674", fontSize: 12 }}>
+                Campaign status is <strong>{mintPreview.campaign.status}</strong> — “Mint item NFTs” only runs once
+                the campaign has <strong>ended</strong>. This is a preview of what it would enqueue.
+              </div>
+            )}
+
+            {/* Totals */}
+            <div style={{ display: "flex", gap: 24, flexWrap: "wrap", marginBottom: 14, fontSize: 12, fontFamily: "monospace" }}>
+              <span style={{ color: "#3fb950" }}>new: {mintPreview.totals.newTokens}</span>
+              <span style={{ color: "#8b949e" }}>already enqueued: {mintPreview.totals.alreadyEnqueuedJobs}</span>
+              <span style={{ color: "#c9d1d9" }}>total eligible: {mintPreview.totals.tokens}</span>
+              <span style={{ color: "#c9d1d9" }}>buyers: {mintPreview.totals.buyers}</span>
+            </div>
+
+            {/* Per-chain + per-item summaries */}
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 18, marginBottom: 14 }}>
+              <div>
+                <div style={subHeadStyle}>By chain</div>
+                {mintPreview.byChain.map((c) => (
+                  <KV key={c.chain} label={c.chain}
+                    value={`${c.tokens} token(s) · ${c.buyers} buyer(s) · ${c.newTokens} new`} mono />
+                ))}
+                {mintPreview.byChain.length === 0 && <span style={{ color: "#8b949e", fontSize: 12 }}>nothing eligible</span>}
+              </div>
+              <div>
+                <div style={subHeadStyle}>By item</div>
+                {mintPreview.byItem.map((it) => (
+                  <KV key={it.itemId} label={`#${it.itemId} ${it.name}`}
+                    value={`${it.tokens} token(s) · ${it.buyers} buyer(s)`} mono />
+                ))}
+                {mintPreview.byItem.length === 0 && <span style={{ color: "#8b949e", fontSize: 12 }}>nothing eligible</span>}
+              </div>
+            </div>
+
+            {/* Per-buyer detail */}
+            {mintPreview.rows.length > 0 && (
+              <table data-testid="mint-preview-rows" style={tableStyle}>
+                <thead>
+                  <tr>{["chain", "wallet", "item", "qty", "state"].map((h) => (<th key={h} style={thStyle}>{h}</th>))}</tr>
+                </thead>
+                <tbody>
+                  {mintPreview.rows.slice(0, 50).map((r, i) => (
+                    <tr key={`${r.chain}-${r.wallet}-${r.itemId}-${i}`}>
+                      <td style={tdStyle}>{r.chain}</td>
+                      <td style={tdStyle}><AddressChip value={r.wallet} /></td>
+                      <td style={tdStyle}>#{r.itemId} {r.itemName}</td>
+                      <td style={tdStyle}>{r.quantity}</td>
+                      <td style={{ ...tdStyle, color: r.alreadyEnqueued ? "#8b949e" : "#3fb950", fontWeight: 600 }}>
+                        {r.alreadyEnqueued ? `already (${r.existingStatus})` : "new"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
         {status?.nftMintSummary && Object.keys(status.nftMintSummary).length > 0 && (
           <div data-testid="nft-mint-summary" style={{ display: "flex", gap: 16, marginTop: 12, fontSize: 12, fontFamily: "monospace" }}>
             {Object.entries(status.nftMintSummary).map(([s, n]) => (
@@ -663,7 +811,7 @@ export function AdminPanel({ apiUrl }: { apiUrl: string }) {
       {/* End campaign */}
       <section style={cardStyle}>
         <h2 style={h2Style}>End campaign</h2>
-        <button data-testid="admin-end-campaign" style={{ ...btnStyle, background: "#5f1f2a", border: "1px solid #78263a" }} disabled={busy || !l2}
+        <button data-testid="admin-end-campaign" style={{ ...btnStyle, background: "#5f1f2a", border: "1px solid #78263a" }} disabled={busy || !canAct}
           onClick={() => requestConfirm(`end-campaign · ${campaignId}`, submitEnd)}>
           {busy ? "Submitting…" : `End ${campaignId}`}
         </button>

--- a/templates/preorder/packages/node/api.ts
+++ b/templates/preorder/packages/node/api.ts
@@ -16,6 +16,7 @@ import {
   getPaymentsByStatus,
   getPaymentsByWallet,
   getReferralRewardsByCampaign,
+  getMintableItems,
 } from "@preorder/database";
 import { MOCK_USDC_ADDRESS } from "./launchpad-config.ts";
 import { EXTRA_ADDRESSES } from "./addresses.ts";
@@ -405,6 +406,97 @@ export const apiRouter: StartConfigApiRouter = async function (
     );
     reply.send({ nfts: result.rows });
   });
+
+  // Dry-run preview of `mint-nfts`: report WHO gets WHAT and HOW MANY NFTs would be minted,
+  // WITHOUT enqueuing anything. Mirrors the STM's eligibility (getMintableItems by launchpad)
+  // and accounts for idempotency — rows already present in nft_mints (the STM inserts ON
+  // CONFLICT DO NOTHING) are flagged so the admin sees the *net new* mints a click would create.
+  server.get<{ Params: { slug: string } }>(
+    "/api/admin/mint-preview/:slug",
+    async (request, reply) => {
+      const [campaign] = await runPreparedQuery(
+        getCampaignBySlug.run({ slug: request.params.slug }, dbConn),
+        "/api/admin/mint-preview/campaign",
+      );
+      if (!campaign) {
+        reply.code(404).send({ error: "Launchpad not found" });
+        return;
+      }
+
+      // Exactly the rows the STM would enqueue: every (buyer, chain, item) a wallet owns.
+      const eligible = await runPreparedQuery(
+        getMintableItems.run({ launchpad: campaign.launchpad_address }, dbConn),
+        "/api/admin/mint-preview/eligible",
+      );
+
+      // Jobs already enqueued (re-running mint-nfts won't duplicate these).
+      const existingRes = await dbConn.query(
+        `SELECT chain, wallet, item_id, status FROM nft_mints WHERE campaign_id = $1`,
+        [campaign.campaign_id],
+      );
+      const existing = new Map<string, string>();
+      for (const r of existingRes.rows) existing.set(`${r.chain}:${r.wallet}:${r.item_id}`, r.status);
+
+      // Item names for a friendlier summary.
+      const products = await runPreparedQuery(
+        getProductsByCampaign.run({ campaign_id: campaign.campaign_id }, dbConn),
+        "/api/admin/mint-preview/products",
+      );
+      const nameById = new Map<number, string>();
+      for (const p of products) nameById.set(p.item_id, p.name);
+
+      const rows = eligible.map((e) => {
+        const key = `${e.chain}:${e.wallet}:${e.item_id}`;
+        const already = existing.has(key);
+        return {
+          chain: e.chain,
+          wallet: e.wallet,
+          itemId: e.item_id,
+          itemName: nameById.get(e.item_id) ?? `Item #${e.item_id}`,
+          quantity: Number(e.quantity),
+          alreadyEnqueued: already,
+          existingStatus: already ? existing.get(key) ?? null : null,
+        };
+      });
+
+      const newRows = rows.filter((r) => !r.alreadyEnqueued);
+      const sumQty = (rs: typeof rows) => rs.reduce((a, r) => a + r.quantity, 0);
+      const distinctBuyers = (rs: typeof rows) => new Set(rs.map((r) => r.wallet)).size;
+
+      const byChainMap: Record<string, { chain: string; tokens: number; buyers: Set<string>; newTokens: number }> = {};
+      const byItemMap: Record<number, { itemId: number; name: string; tokens: number; buyers: Set<string> }> = {};
+      for (const r of rows) {
+        const c = (byChainMap[r.chain] ||= { chain: r.chain, tokens: 0, buyers: new Set(), newTokens: 0 });
+        c.tokens += r.quantity;
+        c.buyers.add(r.wallet);
+        if (!r.alreadyEnqueued) c.newTokens += r.quantity;
+        const it = (byItemMap[r.itemId] ||= { itemId: r.itemId, name: r.itemName, tokens: 0, buyers: new Set() });
+        it.tokens += r.quantity;
+        it.buyers.add(r.wallet);
+      }
+
+      reply.send({
+        campaign: { slug: campaign.slug, campaignId: campaign.campaign_id, status: campaign.status },
+        // The STM only enqueues once the campaign has ended; surface that so the UI can warn.
+        willEnqueue: campaign.status === "ended",
+        totals: {
+          tokens: sumQty(rows),
+          buyers: distinctBuyers(rows),
+          jobs: rows.length,
+          newTokens: sumQty(newRows),
+          newJobs: newRows.length,
+          alreadyEnqueuedJobs: rows.length - newRows.length,
+        },
+        byChain: Object.values(byChainMap).map((c) => ({
+          chain: c.chain, tokens: c.tokens, buyers: c.buyers.size, newTokens: c.newTokens,
+        })),
+        byItem: Object.values(byItemMap)
+          .map((it) => ({ itemId: it.itemId, name: it.name, tokens: it.tokens, buyers: it.buyers.size }))
+          .sort((a, b) => a.itemId - b.itemId),
+        rows,
+      });
+    },
+  );
 
   // Marketplace integration — item metadata.
   server.get<{ Params: { slug: string } }>(


### PR DESCRIPTION
## Summary
Builds on the already-merged preorder work (#753 admin/config, #756 post-sale NFT minting, #757 Cardano purchase receipt). Two additions to the **/admin** console:

### 1. Admin page is EVM-only and gated on a connected wallet
- `App.tsx` forces `walletType="evm"` on `/admin` — the **Cardano connect button is hidden** there — and passes an `admin` flag to the Header.
- `Header.tsx` relabels the EVM connect button to **"Connect Admin Wallet"** in admin mode.
- `AdminPanel.tsx` gates every command (update-campaign / product / coin, **mint-nfts**, end-campaign) on `canAct = (L2 loaded) && (EVM wallet connected)`, with a 🔒 notice prompting connection when disconnected.

### 2. Post-sale mint dry-run / simulation
- New **`GET /api/admin/mint-preview/:slug`** — a read-only dry-run that mirrors the `mint-nfts` STM eligibility (`getMintableItems` by launchpad) and is **idempotency-aware**: rows already in `nft_mints` are flagged, so the admin sees the *net-new* mints a click would create. Returns totals (`tokens`/`buyers`/`newTokens`/`alreadyEnqueuedJobs`), per-chain, per-item, and per-buyer detail. Enqueues nothing.
- `AdminPanel.tsx` adds a **"Simulate mint (preview)"** button before "Mint item NFTs" that renders the breakdown. Works before the campaign ends too.

## Test plan
- `/admin` with no wallet: 🔒 notice shown, all actions disabled, only "Connect Admin Wallet" in the header (no Cardano option).
- Connect the admin (EVM) wallet → actions enable.
- Click **Simulate mint** → preview panel shows who/what/how-many, marking each row `new` vs `already (status)`; no `nft_mints` rows are written.
- Verified live against a seeded campaign: 11 eligible tokens, 2 buyers (4 EVM / 7 Cardano), correctly reported `0 new` when already minted.

## Notes
- No e2e assertion for `/api/admin/mint-preview` yet — happy to add one as a follow-up.