### PR TITLE
feat(zswap-da): bottom console dock + real order book / trade history + market seed script

### DIFF
--- a/templates/zswap-da/package.json
+++ b/templates/zswap-da/package.json
@@ -9,6 +9,7 @@
     "dev": "NODE_ENV=development bunx orchestrator start",
     "start:mainnet": "bun run start.mainnet.ts",
     "test": "bun run packages/tests/run-tests.ts",
+    "seed:market": "bun run packages/tests/seed-market.ts",
     "build:midnight": "bun run --filter @zswap-da/contract-offer-files compact",
     "build:pgtypes": "bun run --filter @zswap-da/database pgtyped:update"
   },

--- a/templates/zswap-da/packages/frontend-new/src/App.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/App.tsx
@@ -2,10 +2,11 @@
 // Step 1: design system + static nav. Step 2: real wallet connect + balances.
 // Screens/data wired in from Step 3 onward via the `st` adapter (useZSwapApp).
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import './styles/tokens.css';
 import { Wordmark, Icon } from './ui/icons';
 import { Footer } from './ui/Footer';
+import { ConsoleDock } from './ui/ConsoleDock';
 import { ConnectModal } from './ui/ConnectModal';
 import { Toasts } from './ui/Toasts';
 import { WalletMenu } from './ui/WalletMenu';
@@ -13,19 +14,16 @@ import { NetworkMenu } from './ui/NetworkMenu';
 import { useZSwapApp } from './state/useZSwapApp';
 import { Market } from './screens/Market';
 import { Faucet } from './screens/Faucet';
-import { Swap } from './screens/Swap';
-import { MyTrades } from './screens/MyTrades';
 import { HowItWorks } from './screens/HowItWorks';
 import { ConfirmModal } from './ui/ConfirmModal';
 import { shortToken } from './utils';
 import { fmtBalance } from './state/format';
 
-type PageId = 'market' | 'swap' | 'trades' | 'how' | 'faucet';
+// Place Order + My trades live in the bottom console dock, not in the top nav.
+type PageId = 'market' | 'how' | 'faucet';
 
 const TABS: [PageId, string][] = [
   ['market', 'Order book'],
-  ['swap', 'Place Order'],
-  ['trades', 'My trades'],
   ['how', 'How it works'],
   ['faucet', 'Faucet'],
 ];
@@ -55,7 +53,19 @@ function BalancesCard({ title, balances }: { title: string; balances: Record<str
 export default function App() {
   const [page, setPage] = useState<PageId>('market');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [consoleOpen, setConsoleOpen] = useState(true);
+  const [payPickerOpen, setPayPickerOpen] = useState(false);
+  const dockRef = useRef<HTMLElement>(null);
   const st = useZSwapApp();
+
+  // Links that used to navigate to the Place Order screen now reveal the console.
+  const openConsole = () => {
+    setConsoleOpen(true);
+    setTimeout(() => dockRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }), 60);
+  };
+  // "Start an order" CTAs: reveal the console AND pop the Pay-with token picker
+  // so the flow begins immediately.
+  const startOrder = () => { openConsole(); setPayPickerOpen(true); };
 
   return (
     <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
@@ -73,7 +83,7 @@ export default function App() {
             <div style={{ flex: 1 }} />
             <NetworkMenu value={st.network} onChange={st.setNetwork} />
             <span className="zs-badge-shield" title="Private session"><Icon.shield /> Private session</span>
-            {st.wallet ? <WalletMenu st={st} /> : <button className="zs-btn zs-btn--primary" onClick={st.connect}>Connect wallet</button>}
+            {st.wallet ? <WalletMenu st={st} /> : <button className="zs-btn zs-btn--secondary" onClick={st.connect}>Connect wallet</button>}
           </div>
 
           {/* mobile burger */}
@@ -94,13 +104,13 @@ export default function App() {
               <hr className="zs-hr" style={{ margin: '6px 0' }} />
               {st.wallet
                 ? <button className="zs-btn zs-btn--block" style={{ padding: 13 }} onClick={() => { setMenuOpen(false); st.disconnect(); }}>Disconnect</button>
-                : <button className="zs-btn zs-btn--primary zs-btn--block" onClick={() => { setMenuOpen(false); st.connect(); }}>Connect wallet</button>}
+                : <button className="zs-btn zs-btn--secondary zs-btn--block" onClick={() => { setMenuOpen(false); st.connect(); }}>Connect wallet</button>}
             </div>
           )}
         </div>
       </header>
 
-      <main style={{ flex: 1, width: '100%', maxWidth: 1180, margin: '0 auto', padding: '32px 24px 80px', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      <main style={{ flex: 1, width: '100%', maxWidth: 1180, margin: '0 auto', padding: '32px 24px 40px', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
         {page === 'market' && (
           <div>
             {st.wallet ? (
@@ -109,14 +119,15 @@ export default function App() {
                 <BalancesCard title="Unshielded balances" balances={st.unshieldedBalances} />
               </div>
             ) : null}
-            <Market st={st} onGo={setPage} />
+            <Market st={st} onStartOrder={startOrder} />
           </div>
         )}
-        {page === 'swap' && <Swap st={st} />}
-        {page === 'trades' && <MyTrades st={st} />}
-        {page === 'how' && <HowItWorks st={st} onGo={setPage} />}
+        {page === 'how' && <HowItWorks st={st} onGo={startOrder} />}
         {page === 'faucet' && <Faucet st={st} />}
       </main>
+
+      <ConsoleDock st={st} open={consoleOpen} onToggle={() => setConsoleOpen((o) => !o)} dockRef={dockRef}
+        requestPayPicker={payPickerOpen} onPayPickerHandled={() => setPayPickerOpen(false)} />
 
       <Footer />
 

--- a/templates/zswap-da/packages/frontend-new/src/lib/log.ts
+++ b/templates/zswap-da/packages/frontend-new/src/lib/log.ts
@@ -1,0 +1,59 @@
+// Lightweight in-app debug log. Buffers timestamped lines in memory, mirrors to
+// the browser console, and (once installed) also captures console.error/warn so
+// third-party failures (Lace / midnight-js proof errors) land in the same place.
+//
+// Copy it from the console dock's "Copy log" button, or from the devtools
+// console via `zlog.dump()` / `zlog.copy()`.
+
+interface Line { t: string; level: string; msg: string }
+
+const BUF: Line[] = [];
+const MAX = 800;
+
+function stamp(): string {
+  // HH:MM:SS.mmm — argless new Date() is fine in app code (only workflow scripts forbid it).
+  return new Date().toISOString().slice(11, 23);
+}
+
+function fmt(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (a instanceof Error) return `${a.name}: ${a.message}${a.stack ? `\n${a.stack}` : ''}`;
+      if (typeof a === 'object' && a !== null) {
+        try { return JSON.stringify(a, (_k, v) => (typeof v === 'bigint' ? `${v}n` : v)); } catch { return String(a); }
+      }
+      return String(a);
+    })
+    .join(' ');
+}
+
+function push(level: string, args: unknown[]): void {
+  BUF.push({ t: stamp(), level, msg: fmt(args) });
+  if (BUF.length > MAX) BUF.shift();
+}
+
+export const log = {
+  info: (...a: unknown[]) => { push('INFO', a); console.info(...a); },
+  warn: (...a: unknown[]) => { push('WARN', a); console.warn(...a); },
+  error: (...a: unknown[]) => { push('ERROR', a); console.error(...a); },
+  /** Full buffer as plain text, ready to paste. */
+  dump: () => BUF.map((l) => `${l.t} ${l.level}  ${l.msg}`).join('\n'),
+  clear: () => { BUF.length = 0; },
+  /** Copy the buffer to the clipboard; resolves false if the API is unavailable. */
+  copy: async (): Promise<boolean> => {
+    try { await navigator.clipboard.writeText(log.dump()); return true; } catch { return false; }
+  },
+};
+
+let captured = false;
+/** Mirror console.error/warn into the buffer so external errors are captured too. */
+export function installConsoleCapture(): void {
+  if (captured) return;
+  captured = true;
+  (['error', 'warn'] as const).forEach((level) => {
+    const orig = console[level].bind(console);
+    console[level] = (...args: unknown[]) => { push(level.toUpperCase(), args); orig(...args); };
+  });
+  (globalThis as unknown as { zlog?: typeof log }).zlog = log;
+  log.info('[log] capture installed —', navigator.userAgent);
+}

--- a/templates/zswap-da/packages/frontend-new/src/main.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/main.tsx
@@ -2,6 +2,9 @@ import './shims/crypto';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
+import { installConsoleCapture } from './lib/log';
+
+installConsoleCapture();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/templates/zswap-da/packages/frontend-new/src/screens/Market.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/screens/Market.tsx
@@ -1,20 +1,23 @@
 // Order book tab — pair header + 24h stats + depth book (asks/bids, click-to-
-// select range → Take) + trade history. Pair discovery comes from REAL open
-// orders (st.orders); the depth ladder / stats / history come from the backend
-// GET /api/chart/** endpoints (synthetic for now behind the API — the frontend
-// no longer fabricates them). The depth "Take" is indicative (the rows are
-// aggregate market data, not individual offers) → it routes you to live offers
-// you can actually settle from Place Order.
+// select range → Take) + trade history. Pair discovery AND the order-book ladder
+// (price / amount / total) are built from REAL open offers (st.orders); only the
+// 24h stats + trade history still come from the backend GET /api/chart/** routes.
+// Selecting price levels and pressing "Take" settles the underlying real offers
+// via the shared confirm dialog (st.requestTakeMany); your own offers are
+// skipped (you can't take your own ZSwap).
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Coin, Icon, isShielded } from '../ui/icons';
-import { api, type ChartDepth, type ChartHistoryRow, type ChartStats } from '../services/api';
+import { api, type ChartHistoryRow, type ChartStats } from '../services/api';
 import { shortToken } from '../utils';
-import type { ZSwapApp } from '../state/useZSwapApp';
+import type { Order, ZSwapApp } from '../state/useZSwapApp';
 
 type Side = 'ask' | 'bid';
 type View = 'both' | 'asks' | 'bids';
 interface Pair { base: string; quote: string }
+// A real order-book level — keeps the underlying offers so it can be taken.
+interface BookRow { price: number; amt: number; total: number; orders: Order[] }
+interface Book { mid: number; asks: BookRow[]; bids: BookRow[]; maxTotal: number; spread: number }
 
 function fmtPrice(p: number): string {
   if (!Number.isFinite(p)) return '0';
@@ -39,7 +42,7 @@ function Stat({ label, children, sub }: { label: string; children: React.ReactNo
   );
 }
 
-export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => void }) {
+export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () => void }) {
   const [pair, setPair] = useState<Pair | null>(null);
   const [view, setView] = useState<View>('both');
   const [nonce, setNonce] = useState(0);
@@ -58,22 +61,22 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
   const baseColor = colorByName[base] ?? base;
   const quoteColor = colorByName[quote] ?? quote;
 
-  const [depth, setDepth] = useState<ChartDepth | null>(null);
   const [stats, setStats] = useState<ChartStats | null>(null);
   const [history, setHistory] = useState<ChartHistoryRow[]>([]);
   const [loading, setLoading] = useState(false);
 
+  // Stats (24h/high/low/volume) + trade history are still served by the backend;
+  // the order-book ladder itself is now built from real open offers (below).
   useEffect(() => {
-    if (!pair) { setDepth(null); setStats(null); setHistory([]); return; }
+    if (!pair) { setStats(null); setHistory([]); return; }
     let cancelled = false;
     setLoading(true);
     Promise.all([
-      api.getChartDepth(baseColor, quoteColor),
       api.getChartStats(baseColor, quoteColor),
       api.getChartHistory(baseColor, quoteColor),
     ])
-      .then(([d, s, h]) => { if (!cancelled) { setDepth(d); setStats(s); setHistory(h); } })
-      .catch(() => { if (!cancelled) { setDepth(null); setStats(null); setHistory([]); } })
+      .then(([s, h]) => { if (!cancelled) { setStats(s); setHistory(h); } })
+      .catch(() => { if (!cancelled) { setStats(null); setHistory([]); } })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -86,32 +89,70 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
   }, []);
 
   // Pairs with liquidity from real open orders; opposite directions merge.
+  // `mine` marks pairs that include one of your own offers.
   const liquidPairs = useMemo(() => {
     const orders = st.orders || [];
-    const m: Record<string, { count: number; dirs: Record<string, number> }> = {};
+    const m: Record<string, { count: number; dirs: Record<string, number>; mine: boolean }> = {};
     orders.forEach((o) => {
       const key = [o.from, o.to].sort().join('/');
-      if (!m[key]) m[key] = { count: 0, dirs: {} };
+      if (!m[key]) m[key] = { count: 0, dirs: {}, mine: false };
       m[key].count++;
+      if (o.isMine) m[key].mine = true;
       const dk = o.from + '/' + o.to;
       m[key].dirs[dk] = (m[key].dirs[dk] || 0) + 1;
     });
     return Object.values(m).map((p) => {
       const [top] = Object.entries(p.dirs).sort((a, b) => b[1] - a[1]);
       const [b0, q0] = top[0].split('/');
-      return { base: b0, quote: q0, count: p.count };
+      return { base: b0, quote: q0, count: p.count, mine: p.mine };
     }).sort((a, b) => b.count - a.count).slice(0, 24);
   }, [st.orders]);
 
   const q = pairQuery.trim().toLowerCase();
   const shownPairs = q ? liquidPairs.filter((p) => (p.base + ' ' + p.quote).toLowerCase().includes(q)) : liquidPairs;
 
+  // Real order book built from the open offers for this pair (st.orders):
+  //  - ask = an offer GIVING base, WANTING quote (selling base); price = quote/base
+  //  - bid = an offer GIVING quote, WANTING base (buying base);  price = quote/base
+  // Same-price offers aggregate into one level; totals accumulate outward from mid
+  // (asks: best/lowest sits just above mid; bids: best/highest just below).
+  const realDepth = useMemo<Book | null>(() => {
+    if (!pair) return null;
+    const askAt = new Map<number, Order[]>();
+    const bidAt = new Map<number, Order[]>();
+    const push = (m: Map<number, Order[]>, price: number, o: Order) => {
+      const arr = m.get(price); if (arr) arr.push(o); else m.set(price, [o]);
+    };
+    for (const o of st.orders) {
+      if (!(o.amtFrom > 0 && o.amtTo > 0)) continue;
+      if (o.from === base && o.to === quote) push(askAt, o.amtTo / o.amtFrom, o);
+      else if (o.from === quote && o.to === base) push(bidAt, o.amtFrom / o.amtTo, o);
+    }
+    const mkRows = (m: Map<number, Order[]>, side: Side): BookRow[] =>
+      [...m.entries()]
+        .map(([price, orders]) => ({ price, amt: orders.reduce((s, o) => s + (side === 'ask' ? o.amtFrom : o.amtTo), 0), total: 0, orders }))
+        .sort((a, b) => b.price - a.price);
+    const asks = mkRows(askAt, 'ask');
+    const bids = mkRows(bidAt, 'bid');
+    if (!asks.length && !bids.length) return null;
+    let ta = 0;
+    for (let i = asks.length - 1; i >= 0; i--) { ta += asks[i].amt; asks[i].total = ta; }
+    let tb = 0;
+    for (const r of bids) { tb += r.amt; r.total = tb; }
+    const bestAsk = asks.length ? asks[asks.length - 1].price : 0;
+    const bestBid = bids.length ? bids[0].price : 0;
+    const mid = bestAsk && bestBid ? (bestAsk + bestBid) / 2 : (bestAsk || bestBid);
+    const spread = bestAsk && bestBid ? bestAsk - bestBid : 0;
+    const maxTotal = Math.max(1, asks.length ? asks[0].total : 0, bids.length ? bids[bids.length - 1].total : 0);
+    return { mid, asks, bids, maxTotal, spread };
+  }, [st.orders, pair, base, quote]);
+
   // depth-derived locals (empty-safe)
-  const asks = depth?.asks ?? [];
-  const bids = depth?.bids ?? [];
-  const mid = depth?.mid ?? 0;
-  const maxTotal = depth?.maxTotal ?? 1;
-  const spread = depth?.spread ?? 0;
+  const asks = realDepth?.asks ?? [];
+  const bids = realDepth?.bids ?? [];
+  const mid = realDepth?.mid ?? 0;
+  const maxTotal = realDepth?.maxTotal ?? 1;
+  const spread = realDepth?.spread ?? 0;
   const change24 = stats?.change24 ?? 0;
   const lastUp = change24 >= 0;
 
@@ -159,16 +200,20 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
       ? { pay: quoteAmt, paySym: quote, get: baseAmt, getSym: base, n: rows.length, preview: !committed }
       : { pay: baseAmt, paySym: base, get: quoteAmt, getSym: quote, n: rows.length, preview: !committed };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, hover, base, quote, depth]);
+  }, [active, hover, base, quote, realDepth]);
 
   const takeDepth = () => {
-    // Depth rows are aggregate market data, not individual settle-able offers.
-    // Point the user at real offers (Place Order suggestions / Take).
-    st.toast('Depth is indicative — take a live offer from Place Order.');
-    onGo?.('swap');
+    // Settle the real offers behind the selected price levels via the shared
+    // confirm dialog (st.requestTakeMany filters out your own offers + guards
+    // the wallet, then opens the Take popup).
+    const side = activeSide;
+    if (!side) return;
+    const rows = side === 'ask' ? asks : bids;
+    const orders = rows.filter((_, i) => isActive(side, i)).flatMap((r) => r.orders);
+    st.requestTakeMany(orders);
   };
 
-  const Row = ({ r, side, idx }: { r: ChartDepth['asks'][number]; side: Side; idx: number }) => {
+  const Row = ({ r, side, idx }: { r: BookRow; side: Side; idx: number }) => {
     const pct = Math.min(100, (r.total / maxTotal) * 100);
     const col = side === 'ask' ? 'var(--neg)' : 'var(--pos)';
     const bg = side === 'ask' ? 'rgba(229,72,77,.09)' : 'rgba(14,159,110,.10)';
@@ -198,9 +243,11 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
 
   return (
     <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 16 }}>
-      {/* pair header + stats */}
+      {/* pair selector header — ALWAYS visible. When no pair is picked, the
+          "Markets with liquidity" picker lives inside this same card (below a
+          divider) so the dropdown and the picker read as one connected unit. */}
       <div className="zs-card" style={{ padding: '18px 20px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: pair ? 18 : 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 18 }}>
           <div ref={pickRef} style={{ position: 'relative' }}>
             <button onClick={() => setPickOpen((o) => !o)} style={{ display: 'inline-flex', alignItems: 'center', gap: 9, background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 'var(--r-pill)', padding: pair ? '7px 14px 7px 9px' : '10px 16px', cursor: 'pointer', fontFamily: 'var(--font-ui)', fontWeight: 700, fontSize: 16, color: 'var(--ink)' }}>
               {pair ? (
@@ -222,7 +269,8 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
                     <button key={i} onClick={() => { setPair({ base: p.base, quote: p.quote }); setPickOpen(false); }} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 10, padding: '9px 10px', border: 'none', background: pair && pair.base === p.base && pair.quote === p.quote ? 'var(--surface-2)' : 'transparent', borderRadius: 10, cursor: 'pointer', textAlign: 'left' }}>
                       <div style={{ display: 'flex', alignItems: 'center', flex: '0 0 auto' }}><Coin sym={p.base} size="sm" /><span style={{ margin: '0 3px', color: 'var(--ink-3)', fontSize: 11, position: 'relative', zIndex: 2 }}>→</span><Coin sym={p.quote} size="sm" /></div>
                       <span style={{ flex: 1, fontWeight: 700, fontSize: 13.5 }}>{p.base}<span style={{ color: 'var(--ink-3)', fontWeight: 500 }}> / {p.quote}</span></span>
-                      <span className="zs-num" style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>{p.count} open</span>
+                      {p.mine && <span className="zs-pill" style={{ padding: '2px 7px', fontSize: 10, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)', flex: '0 0 auto' }}>Yours</span>}
+                      <span className="zs-num" style={{ fontSize: 11.5, color: 'var(--ink-3)', flex: '0 0 auto' }}>{p.count} open</span>
                     </button>
                   ))}
                 </div>
@@ -251,27 +299,20 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
             <Stat label={base + ' asset ID'}>{shortToken(baseColor)}</Stat>
           </div>
         )}
-      </div>
 
-      {/* book + history — or suggestions when no pair is selected */}
-      {!pair ? (
-        <div className="zs-card" style={{ padding: 22, minHeight: 420, display: 'flex', flexDirection: 'column' }}>
+        {/* picker lives inside the header card when no pair is selected */}
+        {!pair && (
+        <div style={{ borderTop: '1px solid var(--line)', paddingTop: 18 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
             <Icon.spark style={{ color: 'var(--accent)' }} />
             <span style={{ fontWeight: 800, fontSize: 17, letterSpacing: '-.02em' }}>Markets with liquidity</span>
           </div>
-          <p style={{ fontSize: 13.5, color: 'var(--ink-2)', margin: '0 0 16px' }}>Pick a pair to open its order book and trade history. These have open ZSwaps right now.</p>
-
-          <div className="zs-field" style={{ padding: '11px 14px', display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, maxWidth: 360 }}>
-            <Icon.search style={{ color: 'var(--ink-3)', flex: '0 0 auto' }} />
-            <input value={pairQuery} onChange={(e) => setPairQuery(e.target.value)} placeholder="Search token or pair" style={{ border: 'none', background: 'transparent', outline: 'none', flex: 1, minWidth: 0, fontFamily: 'var(--font-ui)', fontSize: 14, color: 'var(--ink)' }} />
-            {pairQuery && <button onClick={() => setPairQuery('')} style={{ border: 'none', background: 'transparent', color: 'var(--ink-3)', cursor: 'pointer', padding: 0, fontSize: 14, flex: '0 0 auto' }}>✕</button>}
-          </div>
+          <p style={{ fontSize: 13.5, color: 'var(--ink-2)', margin: '0 0 16px' }}>Pick a pair to open its order book and trade history — use “Select a pair” above to search. These have open ZSwaps right now.</p>
 
           {shownPairs.length === 0 ? (
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', gap: 12, padding: '30px 0' }}>
               <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink-2)' }}>{q ? `No pairs match “${pairQuery}”` : 'No open liquidity right now'}</div>
-              <button className="zs-btn zs-btn--primary" onClick={() => onGo?.('swap')}>Create the first order <Icon.arrow /></button>
+              <button className="zs-btn zs-btn--primary" onClick={() => onStartOrder?.()}>Create the first order <Icon.arrow /></button>
             </div>
           ) : (
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 12 }}>
@@ -283,22 +324,23 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
                       <span style={{ display: 'inline-flex', alignItems: 'center' }}><Coin sym={p.base} /><span style={{ margin: '0 4px', color: 'var(--ink-3)', position: 'relative', zIndex: 2 }}>→</span><Coin sym={p.quote} /></span>
                       <span style={{ fontWeight: 700, fontSize: 14.5 }}>{p.base}<span style={{ color: 'var(--ink-3)', fontWeight: 500 }}> / {p.quote}</span></span>
                     </div>
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
                       <span className="zs-tag">Open ZSwaps</span>
-                      <span className={sh ? 'zs-badge-shield' : 'zs-pill'} style={{ padding: '4px 9px', fontSize: 11 }}>{p.count} open</span>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                        {p.mine && <span className="zs-pill" style={{ padding: '3px 8px', fontSize: 10.5, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)' }}>Yours</span>}
+                        <span className={sh ? 'zs-badge-shield' : 'zs-pill'} style={{ padding: '4px 9px', fontSize: 11 }}>{p.count} open</span>
+                      </span>
                     </div>
                   </button>
                 );
               })}
             </div>
           )}
-
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginTop: 'auto', paddingTop: 18, flexWrap: 'wrap' }}>
-            <span style={{ fontSize: 13, color: 'var(--ink-2)' }}>Don't see the pair you want?</span>
-            <button className="zs-btn zs-btn--primary" style={{ padding: '9px 16px', fontSize: 13.5 }} onClick={() => onGo?.('swap')}>Add your own · Swap now <Icon.arrow /></button>
-          </div>
         </div>
-      ) : (
+        )}
+      </div>
+
+      {pair && (
         <div className="zs-grid2" style={{ gap: 16, alignItems: 'start' }}>
           {/* ORDER BOOK */}
           <div className="zs-card" style={{ overflow: 'hidden' }} onMouseLeave={() => setHover(null)}>
@@ -316,8 +358,8 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
               <span>Price ({quote})</span><span style={{ textAlign: 'right' }}>Amount ({base})</span><span style={{ textAlign: 'right' }}>Total ({base})</span>
             </div>
 
-            {!depth ? (
-              <div style={{ padding: '48px 0', textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>{loading ? 'Loading order book…' : 'No market data.'}</div>
+            {!realDepth ? (
+              <div style={{ padding: '48px 0', textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>{st.ordersLoading ? 'Loading order book…' : 'No open orders for this pair yet.'}</div>
             ) : (
               <>
                 {view !== 'bids' && asks.map((r, i) => <Row key={'a' + i} r={r} side="ask" idx={i} />)}
@@ -350,12 +392,7 @@ export function Market({ st, onGo }: { st: ZSwapApp; onGo?: (page: 'swap') => vo
                       </div>
                     )}
                   </div>
-                ) : (
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '14px 16px', borderTop: '1px solid var(--line)', background: 'var(--surface-2)', flexWrap: 'wrap' }}>
-                    <span style={{ fontSize: 13, color: 'var(--ink-2)' }}>You don't find a trade for you?</span>
-                    <button className="zs-btn zs-btn--primary" style={{ padding: '9px 16px', fontSize: 13.5 }} onClick={() => onGo?.('swap')}>Add your own · Swap now <Icon.arrow /></button>
-                  </div>
-                )}
+                ) : null}
               </>
             )}
           </div>

--- a/templates/zswap-da/packages/frontend-new/src/screens/MyTrades.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/screens/MyTrades.tsx
@@ -45,7 +45,7 @@ function Cell({ amt, sym, accent }: { amt: number; sym: string; accent?: boolean
   );
 }
 
-export function MyTrades({ st }: { st: ZSwapApp }) {
+export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
   const trades = st.myTrades;
   const [filter, setFilter] = useState<'all' | 'open' | 'completed'>('all');
   const [viewing, setViewing] = useState<MyTrade | null>(null);
@@ -76,46 +76,36 @@ export function MyTrades({ st }: { st: ZSwapApp }) {
     }
   };
 
-  return (
-    <div style={{ maxWidth: 1000, margin: '0 auto', width: '100%' }}>
-      <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 14, marginBottom: 16, flexWrap: 'wrap' }}>
-        <div>
-          <h1 style={{ fontSize: 28, fontWeight: 800, letterSpacing: '-.03em', margin: 0 }}>My trades</h1>
-          <p style={{ fontSize: 14, color: 'var(--ink-2)', margin: '6px 0 0' }}>Every order you post or take, kept on this device.</p>
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button className="zs-btn zs-btn--primary" onClick={() => { setImportErr(null); setImportOpen(true); }} style={{ padding: '9px 14px', fontSize: 13 }}><Icon.arrow style={{ transform: 'rotate(-90deg)' }} /> Import ZSwap</button>
-          {trades.length > 0 && (
-            <button className="zs-btn" onClick={st.clearAllTrades} style={{ padding: '9px 14px', fontSize: 13 }}>Clear all</button>
-          )}
-        </div>
-      </div>
+  const filterSeg = (
+    <div className="zs-seg" style={{ background: 'var(--bg-tint)' }}>
+      {([['all', 'All'], ['open', 'Open'], ['completed', 'Completed']] as const).map(([id, lbl]) => (
+        <button key={id} className="zs-nav-tab" aria-selected={filter === id} onClick={() => setFilter(id)}
+          style={filter === id ? { background: 'var(--surface)', color: 'var(--ink)', boxShadow: '0 1px 3px rgba(10,12,20,.08)' } : { background: 'transparent', color: 'var(--ink-2)' }}>
+          {lbl} <span className="zs-num" style={{ color: 'var(--ink-3)', fontWeight: 600 }}>{counts[id]}</span>
+        </button>
+      ))}
+    </div>
+  );
 
-      <div style={{ display: 'flex', gap: 11, padding: '13px 15px', borderRadius: 'var(--r-field)', background: 'var(--warn-soft)', border: '1px solid color-mix(in srgb, var(--warn) 22%, transparent)', marginBottom: 18 }}>
-        <span style={{ color: 'var(--warn)', fontWeight: 800, fontSize: 15, flex: '0 0 auto', lineHeight: 1.3 }}>!</span>
-        <div style={{ fontSize: 12.5, color: 'var(--ink-2)', lineHeight: 1.5 }}>
-          This list is stored <b style={{ color: 'var(--ink)' }}>only in your browser</b>. Shielded ZSwaps are secret — if you clear it, it <b style={{ color: 'var(--ink)' }}>cannot be recovered</b>.
+  const actions = (
+    <div style={{ display: 'flex', gap: 8 }}>
+      <button className="zs-btn zs-btn--secondary" onClick={() => { setImportErr(null); setImportOpen(true); }} style={{ padding: '9px 14px', fontSize: 13 }}>Import ZSwap</button>
+      {trades.length > 0 && (
+        <button className="zs-btn" onClick={st.clearAllTrades} style={{ padding: '9px 14px', fontSize: 13 }}>Clear all</button>
+      )}
+    </div>
+  );
+
+  const tableCard = (
+    <div className="zs-card" style={compact ? { padding: '8px 6px 6px', maxHeight: 380, overflowY: 'auto' } : { padding: '16px 8px 8px' }}>
+      {rows.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: compact ? '34px 16px' : '48px 20px' }}>
+          <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink-2)' }}>No trades yet</div>
+          <div style={{ fontSize: 13, color: 'var(--ink-3)', margin: '6px 0 16px' }}>Post or take a ZSwap and it'll show up here.</div>
         </div>
-      </div>
-
-      <div className="zs-seg" style={{ background: 'var(--bg-tint)', marginBottom: 16 }}>
-        {([['all', 'All'], ['open', 'Open'], ['completed', 'Completed']] as const).map(([id, lbl]) => (
-          <button key={id} className="zs-nav-tab" aria-selected={filter === id} onClick={() => setFilter(id)}
-            style={filter === id ? { background: 'var(--surface)', color: 'var(--ink)', boxShadow: '0 1px 3px rgba(10,12,20,.08)' } : { background: 'transparent', color: 'var(--ink-2)' }}>
-            {lbl} <span className="zs-num" style={{ color: 'var(--ink-3)', fontWeight: 600 }}>{counts[id]}</span>
-          </button>
-        ))}
-      </div>
-
-      <div className="zs-card" style={{ padding: '16px 8px 8px' }}>
-        {rows.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '48px 20px' }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink-2)' }}>No trades yet</div>
-            <div style={{ fontSize: 13, color: 'var(--ink-3)', margin: '6px 0 16px' }}>Post or take a ZSwap and it'll show up here.</div>
-          </div>
-        ) : (
-          <div style={{ overflowX: 'auto' }}>
-            <table className="zs-table">
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="zs-table">
               <thead><tr>
                 <th>Offered</th><th>Requested</th><th style={{ textAlign: 'right' }}>Price</th><th>Date</th><th>Status</th><th></th>
               </tr></thead>
@@ -150,7 +140,10 @@ export function MyTrades({ st }: { st: ZSwapApp }) {
           </div>
         )}
       </div>
+  );
 
+  const modals = (
+    <>
       {/* offer-file blob viewer */}
       <Modal open={!!viewing} onClose={() => setViewing(null)} width={520}>
         {viewing && (
@@ -200,6 +193,43 @@ export function MyTrades({ st }: { st: ZSwapApp }) {
           </div>
         </div>
       </Modal>
+    </>
+  );
+
+  if (compact) {
+    return (
+      <div style={{ width: '100%' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+          {filterSeg}
+          {actions}
+        </div>
+        {tableCard}
+        {modals}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 1000, margin: '0 auto', width: '100%' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 14, marginBottom: 16, flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ fontSize: 28, fontWeight: 800, letterSpacing: '-.03em', margin: 0 }}>My trades</h1>
+          <p style={{ fontSize: 14, color: 'var(--ink-2)', margin: '6px 0 0' }}>Every order you post or take, kept on this device.</p>
+        </div>
+        {actions}
+      </div>
+
+      <div style={{ display: 'flex', gap: 11, padding: '13px 15px', borderRadius: 'var(--r-field)', background: 'var(--warn-soft)', border: '1px solid color-mix(in srgb, var(--warn) 22%, transparent)', marginBottom: 18 }}>
+        <span style={{ color: 'var(--warn)', fontWeight: 800, fontSize: 15, flex: '0 0 auto', lineHeight: 1.3 }}>!</span>
+        <div style={{ fontSize: 12.5, color: 'var(--ink-2)', lineHeight: 1.5 }}>
+          This list is stored <b style={{ color: 'var(--ink)' }}>only in your browser</b>. Shielded ZSwaps are secret — if you clear it, it <b style={{ color: 'var(--ink)' }}>cannot be recovered</b>.
+        </div>
+      </div>
+
+      <div style={{ marginBottom: 16 }}>{filterSeg}</div>
+
+      {tableCard}
+      {modals}
     </div>
   );
 }

--- a/templates/zswap-da/packages/frontend-new/src/screens/Swap.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/screens/Swap.tsx
@@ -1,11 +1,12 @@
-// Place Order (Swap) — ported from the mock's swap.jsx SwapPanel + Suggestions,
-// wired to reality:
+// Place Order — ported from the mock's swap.jsx SwapPanel, wired to reality:
 //  - tokens come from the known-tokens registry (TokenPicker)
 //  - rate / market / discount / sponsorship / USD come from GET /api/quote
 //  - "Create order" builds a real maker offer (st.createOffer → makeIntent +
 //    encodeOffer + submit) and records it locally so it's excluded from books
-//  - the suggestions rail lists real open offers; "Take" opens the shared
-//    confirm dialog and settles via st.takeOffer.
+//
+// The form is exported as `PlaceOrderForm` so it can render both full-width and
+// inside the bottom console dock (`compact`). `Swap` keeps the standalone hero
+// layout for any full-page use.
 //
 // Amounts are integer base units (the ledger has no decimals). Requires the
 // browser wallet (Lace / ConnectedAPI); the local JS wallet can't makeIntent.
@@ -14,10 +15,11 @@ import { useEffect, useState } from 'react';
 import { Coin, Icon, Mark } from '../ui/icons';
 import { TokenPicker } from '../ui/TokenPicker';
 import { api, type Quote } from '../services/api';
-import { fmtAmt, fmtUsd, rateDisplay } from '../state/format';
+import { log } from '../lib/log';
+import { fmtUsd, rateDisplay } from '../state/format';
 import type { KnownToken } from '../types';
 import type { OfferLeg } from '../services/makerOffer';
-import type { Order, ZSwapApp } from '../state/useZSwapApp';
+import type { ZSwapApp } from '../state/useZSwapApp';
 
 const intize = (v: string) => v.replace(/[^0-9]/g, '');
 
@@ -32,13 +34,13 @@ function balanceFor(st: ZSwapApp, token: KnownToken | null): string | null {
   return map?.[token.token_color] ?? null;
 }
 
-function FieldRow({ label, token, value, onValue, onPick, onClear, readOnly, accent, balance, usd }: {
+function FieldRow({ label, token, value, onValue, onPick, onClear, readOnly, accent, balance, usd, compact }: {
   label: string; token: KnownToken | null; value: string; onValue?: (v: string) => void;
-  onPick: () => void; onClear?: () => void; readOnly?: boolean; accent?: boolean; balance?: string | null; usd?: number | null;
+  onPick: () => void; onClear?: () => void; readOnly?: boolean; accent?: boolean; balance?: string | null; usd?: number | null; compact?: boolean;
 }) {
   return (
     <div className="zs-field">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: compact ? 7 : 12 }}>
         <span className="zs-field-label">{label}</span>
         {token && balance != null && (
           <span style={{ fontSize: 12.5, color: 'var(--ink-3)' }}>Balance <span className="zs-num" style={{ color: 'var(--ink-2)' }}>{balance}</span>
@@ -48,7 +50,7 @@ function FieldRow({ label, token, value, onValue, onPick, onClear, readOnly, acc
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <input value={value} onChange={(e) => onValue?.(intize(e.target.value))} readOnly={readOnly} placeholder="0" inputMode="numeric"
-          className="zs-amount" style={{ color: value ? (accent ? 'var(--accent)' : 'var(--ink)') : 'var(--ink-4)', cursor: readOnly ? 'default' : 'text' }} />
+          className="zs-amount" style={{ fontSize: compact ? 24 : undefined, color: value ? (accent ? 'var(--accent)' : 'var(--ink)') : 'var(--ink-4)', cursor: readOnly ? 'default' : 'text' }} />
         {token ? (
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flex: '0 0 auto' }}>
             <button className="zs-token" onClick={onPick}><Coin sym={token.name} /> {token.name} <Icon.caret /></button>
@@ -56,51 +58,19 @@ function FieldRow({ label, token, value, onValue, onPick, onClear, readOnly, acc
               <svg viewBox="0 0 16 16" width="12" height="12" fill="none"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" /></svg>
             </button>
           </span>
-        ) : <button className="zs-token zs-token--empty" onClick={onPick}>Select token <Icon.caret /></button>}
+        ) : <button className="zs-btn" onClick={onPick} style={{ padding: '9px 12px', gap: 8 }}>Select token <Icon.caret style={{ color: 'var(--ink-3)' }} /></button>}
       </div>
       <div className="zs-num" style={{ fontSize: 12.5, color: 'var(--ink-3)', marginTop: 4 }}>{usd != null ? fmtUsd(usd) : '$0.00'}</div>
     </div>
   );
 }
 
-function FastTradeRow({ o, onTake, first }: { o: Order; onTake: (o: Order) => void; first: boolean }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 13, padding: '13px 12px', borderTop: first ? 'none' : '1px solid var(--line-2)' }}>
-      <div style={{ position: 'relative', width: 46, height: 46, flex: '0 0 auto' }}>
-        <span style={{ position: 'absolute', top: 0, left: 0, zIndex: 1 }}><Coin sym={o.to} size="sm" /></span>
-        <span style={{ position: 'absolute', bottom: 0, right: 0, zIndex: 1 }}><Coin sym={o.from} size="sm" /></span>
-      </div>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 13, whiteSpace: 'nowrap' }}><span style={{ color: 'var(--ink-3)' }}>Pay </span><span className="zs-num" style={{ fontWeight: 700, color: 'var(--ink)' }}>{fmtAmt(o.amtTo)}</span> <span style={{ fontWeight: 600 }}>{o.to}</span></div>
-        <div style={{ fontSize: 13, whiteSpace: 'nowrap', marginTop: 2 }}><span style={{ color: 'var(--ink-3)' }}>Receive </span><span className="zs-num" style={{ fontWeight: 700, color: 'var(--accent)' }}>{fmtAmt(o.amtFrom)}</span> <span style={{ fontWeight: 600 }}>{o.from}</span></div>
-      </div>
-      <button className="zs-btn zs-btn--primary" style={{ padding: '8px 16px', fontSize: 13, flex: '0 0 auto' }} onClick={() => onTake(o)}><Icon.bolt /> Take</button>
-    </div>
-  );
-}
-
-function Suggestions({ st, from, to }: { st: ZSwapApp; from: KnownToken | null; to: KnownToken | null }) {
-  // Counter-orders that let you swap from→to: they GIVE `to` and WANT `from`.
-  const matches = (from && to)
-    ? st.orders.filter((o) => o.from === to.name && o.to === from.name)
-    : [];
-  const list = (from && to) ? matches : st.orders;
-  const title = (from && to) ? `Open orders · ${from.name} → ${to.name}` : 'Open ZSwaps you can take';
-
-  return (
-    <div className="zs-card" style={{ padding: 8, minHeight: 320 }}>
-      <div style={{ padding: '12px 12px 10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontWeight: 700, fontSize: 14 }}><Icon.bolt style={{ color: 'var(--accent)' }} /> {title}</span>
-        <span className="zs-num" style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>live</span>
-      </div>
-      {list.length === 0
-        ? <div style={{ padding: '8px 14px 22px', fontSize: 13, color: 'var(--ink-3)', lineHeight: 1.5 }}>{(from && to) ? <>No open orders for <b>{from.name} → {to.name}</b> yet. Enter amounts to create the first one.</> : 'No open offers right now. Create one on the left.'}</div>
-        : list.slice(0, 8).map((o, i) => <FastTradeRow key={o.id} o={o} onTake={st.requestTake} first={i === 0} />)}
-    </div>
-  );
-}
-
-export function Swap({ st }: { st: ZSwapApp }) {
+/** The order-entry card on its own — used full-width and inside the console dock.
+ *  `requestPayPicker` is a one-shot signal (consumed via onPayPickerHandled) that
+ *  opens the "Pay with" token picker, so an external CTA can kick off the flow. */
+export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandled }: {
+  st: ZSwapApp; compact?: boolean; requestPayPicker?: boolean; onPayPickerHandled?: () => void;
+}) {
   const [from, setFrom] = useState<KnownToken | null>(null);
   const [to, setTo] = useState<KnownToken | null>(null);
   const [payAmt, setPayAmt] = useState('');
@@ -109,7 +79,14 @@ export function Swap({ st }: { st: ZSwapApp }) {
   const [picking, setPicking] = useState<'from' | 'to' | null>(null);
   const [quote, setQuote] = useState<Quote | null>(null);
   const [posting, setPosting] = useState(false);
+  const [postStatus, setPostStatus] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // External "start the order flow" trigger → open the Pay-with picker once.
+  useEffect(() => {
+    if (requestPayPicker) { setPicking('from'); onPayPickerHandled?.(); }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestPayPicker]);
 
   const pay = Number(payAmt) || 0;
   const recv = Number(recvAmt) || 0;
@@ -147,16 +124,30 @@ export function Swap({ st }: { st: ZSwapApp }) {
     if (!sameKind) { setError('Both tokens must be the same privacy kind (all shielded or all unshielded).'); return; }
     if (pay <= 0 || recv <= 0) { setError('Enter both amounts.'); return; }
     setPosting(true);
+    let phase = 'Building offer in wallet…';
+    const onStatus = (s: string) => { phase = s; setPostStatus(s); log.info('[create-offer]', s); };
+    onStatus(phase);
     try {
       const gives: OfferLeg[] = [{ kind: from.kind, color: from.token_color, amount: BigInt(pay) }];
       const wants: OfferLeg[] = [{ kind: to.kind, color: to.token_color, amount: BigInt(recv) }];
-      await st.createOffer(gives, wants);
+      log.info('[create-offer] start', { pay, recv, from: from.name, to: to.name, kind: from.kind, fromColor: from.token_color, toColor: to.token_color });
+      // Bound the whole flow so a hung wallet/proof step can't sit on "Creating…"
+      // forever — surface a clear, retryable error naming the phase it stuck on.
+      await Promise.race([
+        st.createOffer(gives, wants, { onStatus }),
+        new Promise((_, rej) => setTimeout(
+          () => rej(new Error(`Timed out during "${phase}" — that step didn't respond within 180s. Nothing was posted; please try again.`)),
+          180_000,
+        )),
+      ]);
       setPayAmt(''); setRecvAmt(''); setQuote(null);
     } catch (e: any) {
       const msg = e?.message ?? String(e);
+      log.error('[create-offer] failed during', phase, e);
       setError(msg);
     } finally {
       setPosting(false);
+      setPostStatus('');
     }
   };
 
@@ -170,7 +161,7 @@ export function Swap({ st }: { st: ZSwapApp }) {
     else if (!sameKind) { label = 'Tokens must share privacy kind'; disabled = true; action = () => {}; }
     else if (pay <= 0) { label = 'Enter the amount you pay'; disabled = true; action = () => {}; }
     else if (recv <= 0) { label = 'Enter the amount you want'; disabled = true; action = () => {}; }
-    else if (posting) { label = 'Creating…'; disabled = true; action = () => {}; }
+    else if (posting) { label = postStatus || 'Creating…'; disabled = true; action = () => {}; }
     else if (quote && !quote.sponsored) { label = 'Create offer file'; action = post; }
     else { label = bothShielded ? 'Create shielded order' : 'Create order'; action = post; }
   }
@@ -178,82 +169,85 @@ export function Swap({ st }: { st: ZSwapApp }) {
   const dPct = quote?.discount != null ? quote.discount * 100 : null;
 
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 460px) minmax(0, 1fr)', gap: 20, alignItems: 'start', width: '100%' }} className="zs-swap-grid">
-      <div style={{ width: '100%' }}>
-        {/* hero */}
-        <div style={{ background: 'var(--ink)', color: '#fff', padding: '26px 26px 38px', borderRadius: 'var(--r-card) var(--r-card) 0 0', position: 'relative', overflow: 'hidden' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 18, position: 'relative', zIndex: 1 }}>
-            <Mark size={20} color="#fff" /><span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '.12em', opacity: 0.75, whiteSpace: 'nowrap' }}>ZERO-KNOWLEDGE SWAP</span>
-          </div>
-          <div style={{ fontSize: 32, fontWeight: 800, letterSpacing: '-.03em', lineHeight: 1.02, position: 'relative', zIndex: 1 }}>Trade without a trace.</div>
-          <div style={{ position: 'absolute', right: -36, top: -46, width: 200, height: 200, borderRadius: '50%', border: '30px solid var(--accent)', opacity: 0.5, filter: 'blur(1px)' }} />
-          <div style={{ position: 'absolute', right: 60, bottom: -70, width: 120, height: 120, borderRadius: '50%', border: '18px solid var(--accent)', opacity: 0.22 }} />
+    <>
+      <div className="zs-card" style={{ marginTop: compact ? 0 : -22, position: 'relative', padding: 'var(--pad-card)', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <FieldRow label="You pay" token={from} value={payAmt} onValue={setPayAmt} onPick={() => setPicking('from')} onClear={() => { setFrom(null); setQuote(null); }} balance={balanceFor(st, from)} usd={quote?.from_usd ?? null} compact={compact} />
+        <div style={{ display: 'flex', justifyContent: 'center', margin: '-9px 0', position: 'relative', zIndex: 2 }}>
+          <button className="zs-switch" onClick={doSwitch} title="Switch"><Icon.swap /></button>
         </div>
+        <FieldRow label="You receive" token={to} value={recvAmt} onValue={(v) => { setAutoPrice(false); setRecvAmt(v); }} accent onPick={() => setPicking('to')} onClear={() => { setTo(null); setQuote(null); }} usd={quote?.to_usd ?? null} compact={compact} />
 
-        <div className="zs-card" style={{ marginTop: -22, position: 'relative', padding: 'var(--pad-card)', display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <FieldRow label="You pay" token={from} value={payAmt} onValue={setPayAmt} onPick={() => setPicking('from')} onClear={() => { setFrom(null); setQuote(null); }} balance={balanceFor(st, from)} usd={quote?.from_usd ?? null} />
-          <div style={{ display: 'flex', justifyContent: 'center', margin: '-9px 0', position: 'relative', zIndex: 2 }}>
-            <button className="zs-switch" onClick={doSwitch} title="Switch"><Icon.swap /></button>
-          </div>
-          <FieldRow label="You receive" token={to} value={recvAmt} onValue={(v) => { setAutoPrice(false); setRecvAmt(v); }} accent onPick={() => setPicking('to')} onClear={() => { setTo(null); setQuote(null); }} usd={quote?.to_usd ?? null} />
+        {bothSel && sameKind && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '10px 4px 2px' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 9, cursor: 'pointer', userSelect: 'none' }}>
+              <span onClick={() => setAutoPrice((a) => !a)} style={{ width: 18, height: 18, borderRadius: 5, flex: '0 0 auto', display: 'flex', alignItems: 'center', justifyContent: 'center', background: autoPrice ? 'var(--accent)' : 'var(--surface)', border: '1.5px solid ' + (autoPrice ? 'var(--accent)' : 'var(--line)') }}>
+                {autoPrice && <svg viewBox="0 0 16 16" width="11" height="11" fill="none"><path d="M3.5 8.5l3 3 6-7" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>}
+              </span>
+              <span onClick={() => setAutoPrice((a) => !a)} style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>Auto Market Price</span>
+              {!compact && <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>{autoPrice ? '· balances at the best fillable price' : '· set your own price'}</span>}
+            </label>
 
-          {bothSel && sameKind && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '10px 4px 2px' }}>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 9, cursor: 'pointer', userSelect: 'none' }}>
-                <span onClick={() => setAutoPrice((a) => !a)} style={{ width: 18, height: 18, borderRadius: 5, flex: '0 0 auto', display: 'flex', alignItems: 'center', justifyContent: 'center', background: autoPrice ? 'var(--accent)' : 'var(--surface)', border: '1.5px solid ' + (autoPrice ? 'var(--accent)' : 'var(--line)') }}>
-                  {autoPrice && <svg viewBox="0 0 16 16" width="11" height="11" fill="none"><path d="M3.5 8.5l3 3 6-7" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>}
-                </span>
-                <span onClick={() => setAutoPrice((a) => !a)} style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>Auto Market Price</span>
-                <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>{autoPrice ? '· balances at the best fillable price' : '· set your own price'}</span>
-              </label>
+            {pay > 0 && recv > 0 && quote && (
+              <>
+                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between', gap: '4px 14px', fontSize: 13 }}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}><Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} /> Your rate · 1 {from!.name} = <RateInline value={quote.implied_rate ?? 0} /> {to!.name}</span>
+                  {dPct != null && <span className="zs-num" style={{ color: dPct >= 0 ? 'var(--pos)' : 'var(--neg)', whiteSpace: 'nowrap', fontWeight: 600 }}>{dPct >= 0 ? '−' : '+'}{Math.abs(dPct).toFixed(1)}% vs market</span>}
+                </div>
+                {!autoPrice && <div style={{ fontSize: 11.5, color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>Market · 1 {from!.name} = <RateInline value={quote.market_rate} /> {to!.name}</div>}
 
-              {pay > 0 && recv > 0 && quote && (
-                <>
-                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between', gap: '4px 14px', fontSize: 13 }}>
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}><Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} /> Your rate · 1 {from!.name} = <RateInline value={quote.implied_rate ?? 0} /> {to!.name}</span>
-                    {dPct != null && <span className="zs-num" style={{ color: dPct >= 0 ? 'var(--pos)' : 'var(--neg)', whiteSpace: 'nowrap', fontWeight: 600 }}>{dPct >= 0 ? '−' : '+'}{Math.abs(dPct).toFixed(1)}% vs market</span>}
+                {quote.sponsored ? (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 11px', borderRadius: 11, background: 'var(--pos-soft)', border: '1px solid color-mix(in srgb, var(--pos) 25%, transparent)' }}>
+                    <Icon.shield style={{ color: 'var(--pos)', flex: '0 0 auto' }} />
+                    <span style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.4 }}><b style={{ color: 'var(--pos)' }}>Celestia fee sponsored.</b> Good trades get filled fast.</span>
                   </div>
-                  {!autoPrice && <div style={{ fontSize: 11.5, color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>Market · 1 {from!.name} = <RateInline value={quote.market_rate} /> {to!.name}</div>}
-
-                  {quote.sponsored ? (
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 11px', borderRadius: 11, background: 'var(--pos-soft)', border: '1px solid color-mix(in srgb, var(--pos) 25%, transparent)' }}>
-                      <Icon.shield style={{ color: 'var(--pos)', flex: '0 0 auto' }} />
-                      <span style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.4 }}><b style={{ color: 'var(--pos)' }}>Celestia fee sponsored.</b> Good trades get filled fast.</span>
+                ) : (
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '9px 11px', borderRadius: 11, background: 'var(--warn-soft)', border: '1px solid color-mix(in srgb, var(--warn) 22%, transparent)' }}>
+                    <span style={{ color: 'var(--warn)', fontWeight: 800, flex: '0 0 auto', lineHeight: 1.3 }}>!</span>
+                    <div style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>This price won't be sponsored to Celestia.
+                      <button onClick={() => setAutoPrice(true)} style={{ marginLeft: 6, border: 'none', background: 'transparent', color: 'var(--accent)', fontWeight: 700, fontSize: 12, cursor: 'pointer', padding: 0, textDecoration: 'underline' }}>Apply best price</button>
                     </div>
-                  ) : (
-                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '9px 11px', borderRadius: 11, background: 'var(--warn-soft)', border: '1px solid color-mix(in srgb, var(--warn) 22%, transparent)' }}>
-                      <span style={{ color: 'var(--warn)', fontWeight: 800, flex: '0 0 auto', lineHeight: 1.3 }}>!</span>
-                      <div style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>This price won't be sponsored to Celestia.
-                        <button onClick={() => setAutoPrice(true)} style={{ marginLeft: 6, border: 'none', background: 'transparent', color: 'var(--accent)', fontWeight: 700, fontSize: 12, cursor: 'pointer', padding: 0, textDecoration: 'underline' }}>Apply best price</button>
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
 
-          <button className={'zs-btn zs-btn--block' + (!disabled ? ' zs-btn--primary' : '')} onClick={action} disabled={disabled}
-            style={{ marginTop: 8, opacity: disabled ? 0.5 : 1, cursor: disabled ? 'default' : 'pointer', background: disabled ? 'var(--surface-2)' : undefined, color: disabled ? 'var(--ink-3)' : undefined, boxShadow: disabled ? 'none' : undefined }}>
-            {st.wallet && bothShielded && pay > 0 && recv > 0 && <Icon.shield />} {label}
-          </button>
+        <button className={'zs-btn zs-btn--block' + (!disabled ? ' zs-btn--primary' : '')} onClick={action} disabled={disabled}
+          style={{ marginTop: 8, padding: compact ? 13 : undefined, fontSize: compact ? 15 : undefined, opacity: disabled ? 0.5 : 1, cursor: disabled ? 'default' : 'pointer', background: disabled ? 'var(--surface-2)' : undefined, color: disabled ? 'var(--ink-3)' : undefined, boxShadow: disabled ? 'none' : undefined }}>
+          {st.wallet && bothShielded && pay > 0 && recv > 0 && <Icon.shield />} {label}
+        </button>
 
-          {error && <div style={{ fontSize: 12.5, color: 'var(--neg)', lineHeight: 1.45, wordBreak: 'break-word', marginTop: 4 }}>{error}</div>}
+        {error && <div style={{ fontSize: 12.5, color: 'var(--neg)', lineHeight: 1.45, wordBreak: 'break-word', marginTop: 4 }}>{error}</div>}
 
-          {bothSel && (
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, marginTop: 12, fontSize: 12, color: 'var(--ink-3)' }}>
-              {bothShielded
-                ? <><Icon.shield style={{ color: 'var(--accent)' }} /> <span>Shielded — amounts hidden, settled privately via ZSwap</span></>
-                : <><Icon.eye /> <span>Unshielded swap — amounts are visible on-chain</span></>}
-            </div>
-          )}
-        </div>
+        {bothSel && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, marginTop: compact ? 8 : 12, fontSize: 12, color: 'var(--ink-3)' }}>
+            {bothShielded
+              ? <><Icon.shield style={{ color: 'var(--accent)' }} /> <span>Shielded — amounts hidden, settled privately via ZSwap</span></>
+              : <><Icon.eye /> <span>Unshielded swap — amounts are visible on-chain</span></>}
+          </div>
+        )}
       </div>
 
-      <Suggestions st={st} from={from} to={to} />
+      <TokenPicker open={picking === 'from'} onClose={() => setPicking(null)} tokens={st.knownTokens} shieldedBalances={st.shieldedBalances} unshieldedBalances={st.unshieldedBalances} excludeColor={to?.token_color} title="Pay with" onPick={(t) => { setFrom(t); setQuote(null); }} />
+      <TokenPicker open={picking === 'to'} onClose={() => setPicking(null)} tokens={st.knownTokens} shieldedBalances={st.shieldedBalances} unshieldedBalances={st.unshieldedBalances} excludeColor={from?.token_color} title="Receive" onPick={(t) => { setTo(t); setQuote(null); }} />
+    </>
+  );
+}
 
-      <TokenPicker open={picking === 'from'} onClose={() => setPicking(null)} tokens={st.knownTokens} excludeColor={to?.token_color} title="Pay with" onPick={(t) => { setFrom(t); setQuote(null); }} />
-      <TokenPicker open={picking === 'to'} onClose={() => setPicking(null)} tokens={st.knownTokens} excludeColor={from?.token_color} title="Receive" onPick={(t) => { setTo(t); setQuote(null); }} />
+/** Standalone full-page Place Order screen (hero + form), kept for direct use. */
+export function Swap({ st }: { st: ZSwapApp }) {
+  return (
+    <div style={{ maxWidth: 460, margin: '0 auto', width: '100%' }}>
+      <div style={{ background: 'var(--ink)', color: '#fff', padding: '26px 26px 38px', borderRadius: 'var(--r-card) var(--r-card) 0 0', position: 'relative', overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 18, position: 'relative', zIndex: 1 }}>
+          <Mark size={20} color="#fff" /><span style={{ fontWeight: 700, fontSize: 12, letterSpacing: '.12em', opacity: 0.75, whiteSpace: 'nowrap' }}>ZERO-KNOWLEDGE SWAP</span>
+        </div>
+        <div style={{ fontSize: 32, fontWeight: 800, letterSpacing: '-.03em', lineHeight: 1.02, position: 'relative', zIndex: 1 }}>Trade without a trace.</div>
+        <div style={{ position: 'absolute', right: -36, top: -46, width: 200, height: 200, borderRadius: '50%', border: '30px solid var(--accent)', opacity: 0.5, filter: 'blur(1px)' }} />
+        <div style={{ position: 'absolute', right: 60, bottom: -70, width: 120, height: 120, borderRadius: '50%', border: '18px solid var(--accent)', opacity: 0.22 }} />
+      </div>
+      <PlaceOrderForm st={st} />
     </div>
   );
 }

--- a/templates/zswap-da/packages/frontend-new/src/services/api.ts
+++ b/templates/zswap-da/packages/frontend-new/src/services/api.ts
@@ -64,8 +64,39 @@ export const api = {
       body: JSON.stringify({ blob }),
     });
     const data = await res.json();
-    if (!res.ok) throw new Error(data.message ?? JSON.stringify(data));
+    if (!res.ok) {
+      const err = new Error(data.reason ?? data.message ?? JSON.stringify(data)) as Error & { code?: string };
+      err.code = data.error;
+      throw err;
+    }
     return data;
+  },
+
+  // ROOT_UNKNOWN is transient: the maker proves against a real chain root, but
+  // the sync node may not have ingested it into `known_roots` yet. Re-submitting
+  // the same blob succeeds once the root lands (mirrors the e2e suites). Other
+  // errors throw immediately.
+  submitSwapOfferRetrying: async (
+    blob: string,
+    opts?: { tries?: number; delayMs?: number; onWait?: (attempt: number, tries: number) => void },
+  ) => {
+    const tries = opts?.tries ?? 24;
+    const delayMs = opts?.delayMs ?? 4000;
+    for (let i = 0; ; i++) {
+      try {
+        return await api.submitSwapOffer(blob);
+      } catch (e: any) {
+        if (e?.code === 'ROOT_UNKNOWN' && i < tries) {
+          opts?.onWait?.(i + 1, tries);
+          await new Promise((r) => setTimeout(r, delayMs));
+          continue;
+        }
+        if (e?.code === 'ROOT_UNKNOWN') {
+          throw new Error('The chain has not caught up to your wallet state yet (offer root unknown). Make sure your wallet is fully synced to this network, then try again.');
+        }
+        throw e;
+      }
+    }
   },
 
   getZSwaps: async (params: Record<string, string>): Promise<ZSwapOffer[]> => {

--- a/templates/zswap-da/packages/frontend-new/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/packages/frontend-new/src/state/useZSwapApp.ts
@@ -29,6 +29,7 @@ import { parseTakerLegs } from '../services/offerParse';
 import { isOwnOffer, parseOfferSender, unshieldedAddressToHex } from '../services/offerSender';
 import { isMyOffer } from './myOffers';
 import { findTokenName, shortToken } from '../utils';
+import { log } from '../lib/log';
 import type { KnownToken, ZSwapOffer } from '../types';
 
 const NETWORK_ID = 'undeployed';
@@ -48,6 +49,9 @@ export interface Order {
   blob?: string;
   multiGive: boolean;
   multiWant: boolean;
+  /** true when this offer was created by the connected wallet (shown in the
+   *  listings as liquidity, but not takeable — you can't take your own offer). */
+  isMine: boolean;
 }
 
 /** Taker-perspective preview of an importable offer blob. */
@@ -81,6 +85,7 @@ function toOrder(offer: ZSwapOffer, knownTokens: KnownToken[]): Order | null {
     blob: offer.transaction_hex,
     multiGive: (offer.gives?.length ?? 0) > 1,
     multiWant: (offer.wants?.length ?? 0) > 1,
+    isMine: false,
   };
 }
 
@@ -137,11 +142,12 @@ export interface ZSwapApp {
   onMinted: () => void;
   // swap — create / take offers (browser-wallet ConnectedAPI path)
   canTrade: boolean;
-  createOffer: (gives: OfferLeg[], wants: OfferLeg[]) => Promise<void>;
+  createOffer: (gives: OfferLeg[], wants: OfferLeg[], opts?: { onStatus?: (s: string) => void }) => Promise<void>;
   takeOffer: (blob: string) => Promise<void>;
   // shared take-confirm dialog (driven by any screen, rendered once in App)
   pendingConfirm: ConfirmPayload | null;
   requestTake: (o: Order) => void;
+  requestTakeMany: (orders: Order[]) => void;
   closeConfirm: () => void;
   // my trades — local, on-device log of created/taken offers
   myTrades: MyTrade[];
@@ -215,20 +221,24 @@ export function useZSwapApp(): ZSwapApp {
     [wstate?.unshieldedAddress],
   );
 
-  // Map offers → order rows, EXCLUDING the connected wallet's own offers:
-  // shielded offers are anonymous on-chain, so we use (a) a local record of
-  // offers we created (isMyOffer) and (b) unshielded-owner match (isOwnOffer).
+  // Map offers → order rows. We KEEP the connected wallet's own offers (they are
+  // real open liquidity and affect the market — hiding them makes it look like
+  // your orders don't exist), but flag them `isMine` so the UI can mark them and
+  // keep them non-takeable. Ownership: shielded offers are anonymous on-chain, so
+  // we use (a) a local record of offers we created (isMyOffer) and (b) an
+  // unshielded-owner match (isOwnOffer).
   const orders = useMemo<Order[]>(() => {
     return (zapi.offers ?? [])
-      .filter((o) => {
-        if (isMyOffer(o.transaction_hex)) return false;
-        if (selfUnshieldedHex && o.transaction_hex) {
+      .map((o) => {
+        const order = toOrder(o, knownTokens);
+        if (!order) return null;
+        let mine = isMyOffer(o.transaction_hex);
+        if (!mine && selfUnshieldedHex && o.transaction_hex) {
           const info = parseOfferSender(o.transaction_hex, NETWORK_ID as any);
-          if (isOwnOffer(info, selfUnshieldedHex)) return false;
+          mine = isOwnOffer(info, selfUnshieldedHex);
         }
-        return true;
+        return { ...order, isMine: mine };
       })
-      .map((o) => toOrder(o, knownTokens))
       .filter((o): o is Order => o !== null);
   }, [zapi.offers, knownTokens, selfUnshieldedHex]);
 
@@ -245,9 +255,18 @@ export function useZSwapApp(): ZSwapApp {
 
   const refreshState = useCallback(async (c: Connected) => {
     try {
-      setWstate(await readState(c));
+      const s = await readState(c);
+      setWstate(s);
+      log.info('[wallet] state read', {
+        kind: c.kind,
+        name: c.name,
+        shieldedAddress: s.shieldedAddress,
+        unshieldedAddress: s.unshieldedAddress,
+        shieldedBalances: s.shieldedBalances,
+        unshieldedBalances: s.unshieldedBalances,
+      });
     } catch (e) {
-      console.warn('[wallet] readState failed', e);
+      log.error('[wallet] readState failed', e);
     }
   }, []);
 
@@ -320,11 +339,18 @@ export function useZSwapApp(): ZSwapApp {
   // encode + submit the blob, record it locally (so it's excluded from the
   // order book as "mine"), then refresh.
   const createOffer = useCallback(
-    async (gives: OfferLeg[], wants: OfferLeg[]) => {
+    async (gives: OfferLeg[], wants: OfferLeg[], opts?: { onStatus?: (s: string) => void }) => {
       const w = requireWallet();
       const cfg = contract.config ?? (await api.getMidnightConfig());
+      opts?.onStatus?.('Building offer in wallet…');
       const blob = await w.buildOfferBlob(cfg.networkId, gives, wants);
-      await api.submitSwapOffer(blob);
+      opts?.onStatus?.('Posting to Celestia…');
+      await api.submitSwapOfferRetrying(blob, {
+        onWait: (n, total) => {
+          opts?.onStatus?.(`Waiting for chain to sync root… (${n}/${total})`);
+          if (n === 1 || n % 5 === 0) toast('Waiting for the chain to sync your offer root…');
+        },
+      });
       addMyOffer(blob);
       const give = gives[0];
       const want = wants[0];
@@ -386,6 +412,55 @@ export function useZSwapApp(): ZSwapApp {
       });
     },
     [toast, takeOffer],
+  );
+
+  // Take one or more order-book offers in a single confirm dialog. Filters out
+  // your own offers (you can't take them) and blobs we can't settle; aggregates
+  // the pay/receive across the selection; settles each via the batcher in turn.
+  const requestTakeMany = useCallback(
+    (orders: Order[]) => {
+      // Only real bech32m offers (zswapoffer1…) can be settled. Seeded demo
+      // liquidity carries a placeholder blob and must be skipped with a clear
+      // message rather than a cryptic decode error.
+      const isReal = (b?: string) => !!b && /^zswapoffer1/i.test(b);
+      const takeable = orders.filter((o) => isReal(o.blob) && !o.isMine);
+      if (takeable.length === 0) {
+        const seeded = orders.some((o) => o.blob && !isReal(o.blob) && !o.isMine);
+        toast(
+          orders.some((o) => o.isMine) ? "That's your own offer — you can't take your own ZSwap."
+            : seeded ? "Seeded demo liquidity — these offers aren't settle-able. Use a real (zswapoffer1…) offer to test taking."
+            : 'No live offer to take here.',
+        );
+        return;
+      }
+      if (!tradeWallet?.canTransact) {
+        toast('Use the browser wallet (Lace) to take offers.');
+        return;
+      }
+      const n = takeable.length;
+      const payAmt = takeable.reduce((s, o) => s + o.amtTo, 0);
+      const recvAmt = takeable.reduce((s, o) => s + o.amtFrom, 0);
+      setPendingConfirm({
+        title: n > 1 ? `Take ${n} offers` : 'Take offer',
+        pay: { sym: takeable[0].to, amt: fmtAmt(payAmt) },
+        receive: { sym: takeable[0].from, amt: fmtAmt(recvAmt) },
+        cta: n > 1 ? `Take ${n} offers` : 'Take offer',
+        onConfirm: async () => {
+          for (const o of takeable) {
+            await takeOffer(o.blob!);
+            addTrade({
+              kind: 'take',
+              give: { sym: o.to, amt: o.amtTo },
+              get: { sym: o.from, amt: o.amtFrom },
+              status: 'completed',
+              shielded: false,
+              blob: o.blob,
+            });
+          }
+        },
+      });
+    },
+    [toast, takeOffer, tradeWallet],
   );
   const closeConfirm = useCallback(() => setPendingConfirm(null), []);
 
@@ -487,6 +562,7 @@ export function useZSwapApp(): ZSwapApp {
     takeOffer,
     pendingConfirm,
     requestTake,
+    requestTakeMany,
     closeConfirm,
     myTrades,
     clearTrade,

--- a/templates/zswap-da/packages/frontend-new/src/styles/tokens.css
+++ b/templates/zswap-da/packages/frontend-new/src/styles/tokens.css
@@ -90,6 +90,16 @@ body { background: var(--bg); color: var(--ink); font-family: var(--font-ui); -w
   border-color: transparent; box-shadow: var(--sh-btn);
 }
 .zs-btn--primary:hover { background: var(--accent-700); }
+/* secondary: outlined neutral action — quieter than the solid-blue primary,
+   and intentionally non-accent so it never reads like the shield badge. */
+.zs-btn--secondary {
+  background: var(--surface); color: var(--ink);
+  border-color: color-mix(in srgb, var(--ink) 18%, transparent); box-shadow: none;
+}
+.zs-btn--secondary:hover {
+  background: var(--surface-2);
+  border-color: color-mix(in srgb, var(--ink) 30%, transparent);
+}
 .zs-btn--ghost { background: transparent; border-color: transparent; color: var(--ink-2); }
 .zs-btn--ghost:hover { background: var(--surface-2); color: var(--ink); }
 .zs-btn--block { width: 100%; justify-content: center; padding: 17px; font-size: 17px; border-radius: var(--r-field); }
@@ -240,3 +250,7 @@ body { background: var(--bg); color: var(--ink); font-family: var(--font-ui); -w
 
 /* ---- swap page grid (panel + suggestions) */
 @media (max-width: 900px) { .zs-swap-grid { grid-template-columns: 1fr !important; } }
+
+/* ---- bottom console dock — fixed-width Place Order, My trades fills the rest */
+.zs-console-grid { display: grid; grid-template-columns: 440px minmax(0, 1fr); gap: 24px; align-items: start; }
+@media (max-width: 900px) { .zs-console-grid { grid-template-columns: 1fr; } }

--- a/templates/zswap-da/packages/frontend-new/src/ui/ConsoleDock.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/ConsoleDock.tsx
@@ -1,0 +1,79 @@
+// ConsoleDock — a static, collapsible "trading console" docked above the footer.
+// Two columns: Place Order (left, compact) and My trades (right). Collapses to a
+// single title bar so the order book above it keeps the focus. The black
+// open-source bar (Footer) sits directly below this.
+
+import { Icon } from './icons';
+import { PlaceOrderForm } from '../screens/Swap';
+import { MyTrades } from '../screens/MyTrades';
+import { log } from '../lib/log';
+import type { ZSwapApp } from '../state/useZSwapApp';
+
+function ColLabel({ children }: { children: React.ReactNode }) {
+  return <div className="zs-tag" style={{ marginBottom: 10 }}>{children}</div>;
+}
+
+export function ConsoleDock({ st, open, onToggle, dockRef, requestPayPicker, onPayPickerHandled }: {
+  st: ZSwapApp;
+  open: boolean;
+  onToggle: () => void;
+  dockRef?: React.Ref<HTMLElement>;
+  requestPayPicker?: boolean;
+  onPayPickerHandled?: () => void;
+}) {
+  const openCount = st.myTrades.filter((t) => t.status === 'open').length;
+
+  const copyLog = async () => {
+    const ok = await log.copy();
+    st.toast(ok ? 'Debug log copied to clipboard' : 'Copy failed — run zlog.dump() in the console', ok ? 'ok' : undefined);
+  };
+
+  return (
+    <section ref={dockRef} data-density="compact" style={{ position: 'relative', zIndex: 30, borderTop: '1px solid var(--line)', background: 'var(--bg-tint)', boxShadow: '0 -12px 30px -14px rgba(10,12,20,.30), 0 -2px 8px -4px rgba(10,12,20,.14)' }}>
+      {/* full-width on desktop (not capped to the 1180 app column) */}
+      <div style={{ padding: '0 24px' }}>
+        {/* console title bar */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          onClick={onToggle}
+          aria-expanded={open}
+          style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 14, padding: '13px 2px', background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--ink)' }}
+        >
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flex: '0 0 auto' }}>
+            <span style={{ width: 9, height: 9, borderRadius: '50%', background: 'var(--pos)', boxShadow: '0 0 0 3px var(--pos-soft)' }} />
+            <span className="zs-num" style={{ fontSize: 11.5, fontWeight: 700, letterSpacing: '.14em', textTransform: 'uppercase', color: 'var(--ink-2)' }}>Place order</span>
+          </span>
+          <span style={{ fontSize: 13, color: 'var(--ink-3)', fontWeight: 600 }}>My trades</span>
+          {openCount > 0 && (
+            <span className="zs-badge-shield" style={{ background: 'var(--pos-soft)', color: 'var(--pos)', border: '1px solid color-mix(in srgb, var(--pos) 25%, transparent)' }}>
+              {openCount} open
+            </span>
+          )}
+          <span style={{ flex: 1 }} />
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 13, fontWeight: 600, color: 'var(--ink-2)' }}>
+            {open ? 'Collapse' : 'Expand'}
+            <Icon.caret style={{ transform: open ? 'none' : 'rotate(180deg)', transition: 'transform .18s' }} />
+          </span>
+        </button>
+          <button onClick={copyLog} title="Copy the in-app debug log to the clipboard"
+            style={{ flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 12px', fontSize: 12.5, fontWeight: 600, color: 'var(--ink-2)', background: 'var(--surface)', border: '1px solid var(--line)', borderRadius: 'var(--r-pill)', cursor: 'pointer' }}>
+            Copy log
+          </button>
+        </div>
+
+        {open && (
+          <div className="zs-console-grid" style={{ paddingBottom: 26 }}>
+            <div style={{ minWidth: 0 }}>
+              <ColLabel>Place order</ColLabel>
+              <PlaceOrderForm st={st} compact requestPayPicker={requestPayPicker} onPayPickerHandled={onPayPickerHandled} />
+            </div>
+            <div style={{ minWidth: 0 }}>
+              <ColLabel>My trades</ColLabel>
+              <MyTrades st={st} compact />
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/templates/zswap-da/packages/frontend-new/src/ui/Footer.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/Footer.tsx
@@ -1,5 +1,6 @@
-// Footer — open-source CTA + live GitHub stars. Ported from app/footer.jsx.
-// The mock's "Go to presale →" link is removed (presale is dropped).
+// Footer — the slim black bar pinned under the console dock.
+// Open-source CTA on the left ("Launch your own DEX · fully open source"),
+// GitHub fork button + live star count on the right.
 
 import { useEffect, useState } from 'react';
 import { Mark } from './icons';
@@ -31,32 +32,22 @@ function GhStars() {
 export function Footer() {
   return (
     <footer style={{ background: 'var(--ink)', color: '#fff' }}>
-      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '44px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 32, flexWrap: 'wrap' }}>
-        <div style={{ maxWidth: 460 }}>
-          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 11.5, fontWeight: 700, letterSpacing: '.12em', textTransform: 'uppercase', color: 'rgba(255,255,255,.5)', marginBottom: 14 }}>
-            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--pos)' }} /> Fully open source
-          </div>
-          <h2 style={{ fontSize: 28, fontWeight: 800, letterSpacing: '-.03em', margin: '0 0 10px', lineHeight: 1.08 }}>Launch your own DEX.</h2>
-          <p style={{ fontSize: 14.5, color: 'rgba(255,255,255,.6)', lineHeight: 1.55, margin: 0 }}>
-            ZSwap runs on the Midnight network — fork the template and make it yours. Add features,
-            tailor it to your own token, wire in smarter matching, ship whatever you can dream up.
-          </p>
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '16px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 18, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, flex: '0 0 auto' }}>
+            <Mark size={18} color="#fff" /><span style={{ fontWeight: 800, fontSize: 14, letterSpacing: '-.02em' }}>zswap</span>
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 13.5, color: 'rgba(255,255,255,.72)' }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--pos)', flex: '0 0 auto' }} />
+            <span><b style={{ color: '#fff', fontWeight: 700 }}>Launch your own DEX</b> · fully open source</span>
+          </span>
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-            <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="zs-btn zs-btn--primary" style={{ textDecoration: 'none' }}>
-              <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.4 7.4 0 014 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" /></svg>
-              Fork the template
-            </a>
-            <GhStars />
-          </div>
-          <code style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'rgba(255,255,255,.45)' }}>git clone github.com/{REPO}</code>
-        </div>
-      </div>
-      <div style={{ borderTop: '1px solid rgba(255,255,255,.08)' }}>
-        <div style={{ maxWidth: 1180, margin: '0 auto', padding: '18px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap' }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 9 }}><Mark size={18} color="#fff" /><span style={{ fontWeight: 800, fontSize: 14, letterSpacing: '-.02em' }}>zswap</span></span>
-          <span style={{ fontSize: 12.5, color: 'rgba(255,255,255,.4)' }}>Anonymous by design · MIT licensed</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="zs-btn zs-btn--primary" style={{ textDecoration: 'none', padding: '8px 14px', fontSize: 13.5 }}>
+            <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.4 7.4 0 014 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" /></svg>
+            Fork the template
+          </a>
+          <GhStars />
         </div>
       </div>
     </footer>

--- a/templates/zswap-da/packages/frontend-new/src/ui/TokenPicker.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/TokenPicker.tsx
@@ -1,11 +1,16 @@
-// Token chooser backed by the backend's known-tokens registry (real data).
-// Privacy kind comes from the token record, not a name heuristic.
+// Token chooser. The list is the backend known-tokens registry MERGED with any
+// token colors the connected wallet actually holds (so you can trade a token the
+// indexer hasn't registered a name for). A manual-entry panel also lets you pick
+// an arbitrary token by typing its color/ID and privacy kind.
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Modal, ModalHead } from './Modal';
 import { Coin, Icon } from './icons';
 import { shortToken } from '../utils';
+import { fmtBalance } from '../state/format';
 import type { KnownToken } from '../types';
+
+const HEX_RE = /^[0-9a-fA-F]+$/;
 
 export function TokenPicker({
   open,
@@ -14,6 +19,8 @@ export function TokenPicker({
   onPick,
   excludeColor,
   title = 'Select a token',
+  shieldedBalances,
+  unshieldedBalances,
 }: {
   open: boolean;
   onClose: () => void;
@@ -21,14 +28,55 @@ export function TokenPicker({
   onPick: (t: KnownToken) => void;
   excludeColor?: string | null;
   title?: string;
+  shieldedBalances?: Record<string, string> | null;
+  unshieldedBalances?: Record<string, string> | null;
 }) {
   const [q, setQ] = useState('');
+  const [manualOpen, setManualOpen] = useState(false);
+  const [manualId, setManualId] = useState('');
+  const [manualKind, setManualKind] = useState<'shielded' | 'unshielded'>('shielded');
+
+  // Reset transient state each time the picker is dismissed.
+  useEffect(() => {
+    if (!open) { setQ(''); setManualOpen(false); setManualId(''); setManualKind('shielded'); }
+  }, [open]);
+
+  const balanceOf = (color: string): string | null =>
+    shieldedBalances?.[color] ?? unshieldedBalances?.[color] ?? null;
+
+  // Known tokens ∪ wallet-held colors (wallet-only colors get a short-id name).
+  const merged = useMemo<KnownToken[]>(() => {
+    const byColor = new Map<string, KnownToken>();
+    for (const t of tokens) byColor.set(t.token_color, t);
+    const addWallet = (map: Record<string, string> | null | undefined, kind: 'shielded' | 'unshielded') => {
+      for (const color of Object.keys(map ?? {})) {
+        if (!byColor.has(color)) byColor.set(color, { token_color: color, name: shortToken(color), kind });
+      }
+    };
+    addWallet(shieldedBalances, 'shielded');
+    addWallet(unshieldedBalances, 'unshielded');
+    // Tokens you actually hold float to the top.
+    return [...byColor.values()].sort((a, b) =>
+      (balanceOf(a.token_color) != null ? 0 : 1) - (balanceOf(b.token_color) != null ? 0 : 1));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tokens, shieldedBalances, unshieldedBalances]);
+
   const rows = useMemo(() => {
     const needle = q.trim().toLowerCase();
-    return tokens
+    return merged
       .filter((t) => t.token_color !== excludeColor)
-      .filter((t) => !needle || t.name.toLowerCase().includes(needle) || t.token_color.includes(needle));
-  }, [tokens, q, excludeColor]);
+      .filter((t) => !needle || t.name.toLowerCase().includes(needle) || t.token_color.toLowerCase().includes(needle));
+  }, [merged, q, excludeColor]);
+
+  const manualNorm = manualId.trim().toLowerCase();
+  const manualValid = manualNorm.length > 0 && HEX_RE.test(manualNorm);
+  const useManual = () => {
+    if (!manualValid) return;
+    // If the id already matches a known/held token, reuse its real record.
+    const existing = merged.find((t) => t.token_color === manualNorm);
+    onPick(existing ?? { token_color: manualNorm, name: shortToken(manualNorm), kind: manualKind });
+    onClose();
+  };
 
   return (
     <Modal open={open} onClose={onClose} width={420}>
@@ -39,21 +87,55 @@ export function TokenPicker({
           <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search name or color"
             style={{ border: 'none', background: 'transparent', outline: 'none', flex: 1, minWidth: 0, fontFamily: 'var(--font-ui)', fontSize: 14, color: 'var(--ink)' }} />
         </div>
-        <div style={{ maxHeight: 320, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+        <div style={{ maxHeight: 300, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
           {rows.length === 0 && <div style={{ padding: '18px 6px', fontSize: 13, color: 'var(--ink-3)', textAlign: 'center' }}>No tokens{q ? ` match “${q}”` : ' registered yet — mint some on the Faucet'}.</div>}
-          {rows.map((t) => (
-            <button key={t.token_color} onClick={() => { onPick(t); onClose(); }} style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '10px 10px', border: 'none', background: 'transparent', borderRadius: 12, cursor: 'pointer', textAlign: 'left' }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--surface-2)')} onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}>
-              <Coin sym={t.name} />
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontWeight: 700, fontSize: 14 }}>{t.name}</div>
-                <div className="zs-num" style={{ fontSize: 11, color: 'var(--ink-3)' }}>{shortToken(t.token_color)}</div>
-              </div>
-              {t.kind === 'shielded'
-                ? <span className="zs-badge-shield" style={{ padding: '4px 8px' }}><Icon.shield /> Shielded</span>
-                : <span className="zs-pill" style={{ padding: '4px 8px' }}><Icon.eye /> Unshielded</span>}
+          {rows.map((t) => {
+            const bal = balanceOf(t.token_color);
+            return (
+              <button key={t.token_color} onClick={() => { onPick(t); onClose(); }} style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '10px 10px', border: 'none', background: 'transparent', borderRadius: 12, cursor: 'pointer', textAlign: 'left' }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--surface-2)')} onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}>
+                <Coin sym={t.name} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.name}</div>
+                  <div className="zs-num" style={{ fontSize: 11, color: 'var(--ink-3)' }}>{shortToken(t.token_color)}</div>
+                </div>
+                {bal != null && <span className="zs-num" style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--ink-2)', flex: '0 0 auto' }}>{fmtBalance(bal)}</span>}
+                {t.kind === 'shielded'
+                  ? <span className="zs-badge-shield" style={{ padding: '4px 8px', flex: '0 0 auto' }}><Icon.shield /> Shielded</span>
+                  : <span className="zs-pill" style={{ padding: '4px 8px', flex: '0 0 auto' }}><Icon.eye /> Unshielded</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* manual token-id entry */}
+        <div style={{ borderTop: '1px solid var(--line)', marginTop: 12, paddingTop: 12 }}>
+          {!manualOpen ? (
+            <button className="zs-btn" style={{ width: '100%', justifyContent: 'center', fontSize: 13.5, padding: '11px 14px' }}
+              onClick={() => { setManualOpen(true); if (HEX_RE.test(q.trim())) setManualId(q.trim()); }}>
+              <span style={{ fontSize: 16, lineHeight: 1, fontWeight: 700 }}>+</span> Enter a token ID manually
             </button>
-          ))}
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <span className="zs-field-label">Token ID (color)</span>
+              <input autoFocus value={manualId} onChange={(e) => setManualId(e.target.value)} placeholder="0000000000000000000000000000000000000000000000000000000000000001"
+                className="zs-num" style={{ width: '100%', boxSizing: 'border-box', border: '1px solid var(--line)', background: 'var(--surface-2)', borderRadius: 'var(--r-field)', padding: '11px 13px', fontSize: 12.5, color: 'var(--ink)', outline: 'none', wordBreak: 'break-all' }} />
+              <div className="zs-seg" style={{ background: 'var(--bg-tint)', alignSelf: 'flex-start' }}>
+                {(['shielded', 'unshielded'] as const).map((k) => (
+                  <button key={k} aria-selected={manualKind === k} onClick={() => setManualKind(k)}
+                    style={manualKind === k ? { background: 'var(--surface)', color: 'var(--ink)', boxShadow: '0 1px 3px rgba(10,12,20,.08)' } : { background: 'transparent', color: 'var(--ink-2)' }}>
+                    {k === 'shielded' ? <><Icon.shield /> Shielded</> : <><Icon.eye /> Unshielded</>}
+                  </button>
+                ))}
+              </div>
+              {manualNorm && !manualValid && <div style={{ fontSize: 12, color: 'var(--neg)' }}>Token ID must be a hex string (0-9, a-f).</div>}
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button className="zs-btn" style={{ flex: '0 0 auto', padding: '10px 14px', fontSize: 13.5 }} onClick={() => setManualOpen(false)}>Cancel</button>
+                <button className="zs-btn zs-btn--primary" style={{ flex: 1, justifyContent: 'center', padding: 10, fontSize: 13.5, opacity: manualValid ? 1 : 0.5, cursor: manualValid ? 'pointer' : 'default' }} disabled={!manualValid} onClick={useManual}>Use this token</button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </Modal>

--- a/templates/zswap-da/packages/frontend-new/src/ui/icons.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/icons.tsx
@@ -58,8 +58,44 @@ export function isShielded(sym: string): boolean {
   return !!(TOKENS[sym] && TOKENS[sym].shielded);
 }
 
+// ---- deterministic coin colors -------------------------------------------
+// A token's identifier is split in half: the FIRST half seeds the background
+// hue, the SECOND half seeds the glyph (font) hue. Lightness is constrained to
+// guaranteed-safe ranges so every hue pairing reads with strong contrast: the
+// background is darkened until its luminance is low enough that the always-light
+// pastel glyph contrasts clearly against it.
+function hashStr(s: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619) >>> 0; }
+  return h >>> 0;
+}
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  s /= 100; l /= 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  return [Math.round(255 * f(0)), Math.round(255 * f(8)), Math.round(255 * f(4))];
+}
+function relLuminance([r, g, b]: [number, number, number]): number {
+  const c = (v: number) => { v /= 255; return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+  return 0.2126 * c(r) + 0.7152 * c(g) + 0.0722 * c(b);
+}
+export function coinColors(seed: string): { bg: string; fg: string } {
+  const s = seed && seed.length ? seed : '?';
+  const mid = Math.max(1, Math.ceil(s.length / 2));
+  const hBg = hashStr(s.slice(0, mid)) % 360;
+  const hFg = hashStr(s.slice(mid) || s) % 360;
+  // pick the lightest background lightness whose luminance is still dark enough
+  let bgL = 16;
+  for (const L of [46, 40, 34, 28, 22, 16]) {
+    if (relLuminance(hslToRgb(hBg, 62, L)) <= 0.085) { bgL = L; break; }
+  }
+  return { bg: `hsl(${hBg}, 62%, ${bgL}%)`, fg: `hsl(${hFg}, 85%, 90%)` };
+}
+
 export function Coin({ sym, size }: { sym: string; size?: 'lg' | 'sm' }) {
-  const t = TOKENS[sym] || { bg: '#C2C9D4', fg: '#fff', glyph: sym?.[0] || '?', shielded: false };
+  const meta = TOKENS[sym];
+  const t = meta ?? { ...coinColors(sym), glyph: (sym?.[0] || '?').toUpperCase(), shielded: false };
   const cls =
     'zs-coin' +
     (size === 'lg' ? ' zs-coin--lg' : size === 'sm' ? ' zs-coin--sm' : '') +

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -16,7 +16,8 @@ import { midnightNetworkConfig } from "@effectstream/midnight-contracts/midnight
 import { submitBlobViaBatcher } from "./batcher-client.ts";
 import { getBlankRefState, validateZswapOffer } from "@zswap-da/validator";
 import { eventBus, emitAppEvent } from "./event-bus.ts";
-import { quote, buildStats, buildDepth, buildHistory } from "./market-mock.ts";
+import { quote, buildDepth } from "./market-mock.ts";
+import { realStats, realHistory } from "./trade-data.ts";
 
 // ─── API Router ───────────────────────────────────────────────────────────────
 
@@ -114,8 +115,11 @@ export const apiRouter: StartConfigApiRouter = async function (
     return quote(fromToken, toToken, fromAmount, toAmount);
   });
 
-  // GET /api/chart/{stats,depth,history} — synthetic per-pair market data
-  // (see market-mock.ts). Params: base, quote (hex colors).
+  // GET /api/chart/{stats,history} — REAL per-pair market data derived from the
+  // indexer DB: history = consumed offers (offer_file_history), stats = last/24h/
+  // high/low/volume from those fills (mid of open offers as fallback). /depth is
+  // still the synthetic mock but unused by the frontend (it builds the book from
+  // live offers directly). Params: base, quote (hex colors).
   const readPair = (request: any): { base: string; quote: string } => {
     const q = request?.query ?? {};
     const base = String((q as any).base ?? "").toLowerCase();
@@ -125,7 +129,7 @@ export const apiRouter: StartConfigApiRouter = async function (
   };
   server.get("/api/chart/stats", async (request: any) => {
     const { base, quote: quoteToken } = readPair(request);
-    return buildStats(base, quoteToken);
+    return realStats(dbConn, base, quoteToken);
   });
   server.get("/api/chart/depth", async (request: any) => {
     const { base, quote: quoteToken } = readPair(request);
@@ -133,7 +137,7 @@ export const apiRouter: StartConfigApiRouter = async function (
   });
   server.get("/api/chart/history", async (request: any) => {
     const { base, quote: quoteToken } = readPair(request);
-    return buildHistory(base, quoteToken);
+    return realHistory(dbConn, base, quoteToken);
   });
 
   // POST /api/known-tokens — register a token name/color pair. The browser-wallet

--- a/templates/zswap-da/packages/node/trade-data.ts
+++ b/templates/zswap-da/packages/node/trade-data.ts
@@ -1,0 +1,106 @@
+// Real per-pair market data derived from the indexer DB:
+//   - trade history = CONSUMED offers (offer_file_history), each treated as a
+//     fill at its offered price (price = quote/base, size = base leg).
+//   - stats        = last / 24h-change / high / low / volume from those fills,
+//     falling back to the mid of the current open offers when there are no fills.
+//
+// Prices are quoted as quote-per-base. An offer GIVING base / WANTING quote is a
+// SELL of base (ask); GIVING quote / WANTING base is a BUY of base (bid).
+//
+// Raw SQL (via the pg client `dbConn`) keeps this independent of the pgtyped
+// codegen — these are read-only analytics queries.
+
+export interface HistoryRow { price: number; amt: number; up: boolean; at: string }
+export interface Stats {
+  base: string; quote: string; last: number; change24: number;
+  high: number; low: number; volume_base: number; volume_quote: number;
+}
+
+interface LegRow { at_ms: string; g_color: string; g_amt: string; w_color: string; w_amt: string }
+
+// One fill, normalised to quote-per-base price + base-denominated size.
+function toFill(r: LegRow, base: string): { price: number; amt: number; at: number } {
+  const gAmt = Number(r.g_amt);
+  const wAmt = Number(r.w_amt);
+  const at = Number(r.at_ms);
+  if (r.g_color === base) {
+    // sell base: give base, want quote → price = quote/base
+    return { price: gAmt > 0 ? wAmt / gAmt : 0, amt: gAmt, at };
+  }
+  // buy base: give quote, want base → price = quote/base
+  return { price: wAmt > 0 ? gAmt / wAmt : 0, amt: wAmt, at };
+}
+
+const HISTORY_SQL = `
+  SELECT (EXTRACT(EPOCH FROM h.archived_at) * 1000)::bigint AS at_ms,
+         g.token_color AS g_color, g.amount AS g_amt,
+         w.token_color AS w_color, w.amount AS w_amt
+  FROM offer_file_history h
+  JOIN offer_file_tokens_history g ON g.offer_file_id = h.id AND g.direction = 'GIVING'
+  JOIN offer_file_tokens_history w ON w.offer_file_id = h.id AND w.direction = 'WANTING'
+  WHERE h.archive_reason = 'CONSUMED'
+    AND ((g.token_color = $1 AND w.token_color = $2) OR (g.token_color = $2 AND w.token_color = $1))
+  ORDER BY h.archived_at DESC
+  LIMIT 120`;
+
+const OPEN_LEGS_SQL = `
+  SELECT g.token_color AS g_color, g.amount AS g_amt,
+         w.token_color AS w_color, w.amount AS w_amt
+  FROM offer_file o
+  JOIN offer_file_tokens g ON g.offer_file_id = o.id AND g.direction = 'GIVING'
+  JOIN offer_file_tokens w ON w.offer_file_id = o.id AND w.direction = 'WANTING'
+  WHERE ((g.token_color = $1 AND w.token_color = $2) OR (g.token_color = $2 AND w.token_color = $1))`;
+
+/** Trade history (newest first) built from consumed offers for this pair. */
+export async function realHistory(dbConn: any, base: string, quote: string): Promise<HistoryRow[]> {
+  const { rows } = await dbConn.query(HISTORY_SQL, [base, quote]);
+  const fills = (rows as LegRow[]).map((r) => toFill(r, base)).filter((f) => f.price > 0 && f.amt > 0);
+  // newest-first array; `up` compares each fill to the chronologically older one (next in the array).
+  return fills.map((f, i) => ({
+    price: f.price,
+    amt: f.amt,
+    up: i + 1 < fills.length ? f.price >= fills[i + 1].price : true,
+    at: new Date(f.at).toISOString(),
+  }));
+}
+
+/** Mid price from current open offers (best ask / best bid), 0 if none. */
+async function currentMid(dbConn: any, base: string, quote: string): Promise<number> {
+  const { rows } = await dbConn.query(OPEN_LEGS_SQL, [base, quote]);
+  const asks: number[] = []; // sell base (give base) → price quote/base
+  const bids: number[] = []; // buy base (give quote)
+  for (const r of rows as LegRow[]) {
+    const f = toFill(r, base);
+    if (f.price <= 0) continue;
+    (r.g_color === base ? asks : bids).push(f.price);
+  }
+  const bestAsk = asks.length ? Math.min(...asks) : 0;
+  const bestBid = bids.length ? Math.max(...bids) : 0;
+  if (bestAsk && bestBid) return (bestAsk + bestBid) / 2;
+  return bestAsk || bestBid || 0;
+}
+
+export async function realStats(dbConn: any, base: string, quote: string): Promise<Stats> {
+  const hist = await realHistory(dbConn, base, quote);
+  if (hist.length === 0) {
+    const mid = await currentMid(dbConn, base, quote);
+    return { base, quote, last: mid, change24: 0, high: mid, low: mid, volume_base: 0, volume_quote: 0 };
+  }
+  const now = Date.now();
+  const dayAgo = now - 86_400_000;
+  const last = hist[0].price;
+  // reference price for 24h change: most recent fill older than 24h, else the oldest fill.
+  const olderThanDay = hist.find((h) => Date.parse(h.at) < dayAgo);
+  const ref = olderThanDay ? olderThanDay.price : hist[hist.length - 1].price;
+  const change24 = ref > 0 ? ((last - ref) / ref) * 100 : 0;
+  const win = hist.filter((h) => Date.parse(h.at) >= dayAgo);
+  const window = win.length ? win : hist;
+  const prices = window.map((h) => h.price);
+  return {
+    base, quote, last, change24,
+    high: Math.max(...prices),
+    low: Math.min(...prices),
+    volume_base: window.reduce((s, h) => s + h.amt, 0),
+    volume_quote: window.reduce((s, h) => s + h.amt * h.price, 0),
+  };
+}

--- a/templates/zswap-da/packages/tests/seed-market.ts
+++ b/templates/zswap-da/packages/tests/seed-market.ts
@@ -1,0 +1,156 @@
+// seed-market.ts — populate the indexer DB with consistent market data for 2
+// pairs so the whole UI (order book, depth, 24h stats, trade history) can be
+// tested without minting/proving/settling real swaps by hand.
+//
+//   • Historic trades → offer_file_history (archive_reason='CONSUMED'): a
+//     coherent price random-walk over the last ~48h per pair. These back
+//     /api/chart/history and /api/chart/stats.
+//   • Live order book → offer_file (+ offer_file_tokens): asks above / bids
+//     below each pair's mid. These back /api/zswaps → the on-screen order book.
+//
+// All inserts are DIRECT SQL against the dev PGlite (127.0.0.1:5432). They are
+// DISPLAY-real: they render and price exactly like real offers, but the seeded
+// order-book entries carry a placeholder blob so they are NOT settle-able (use
+// packages/tests/two-wallet-swap-e2e.ts for a real takeable offer). Idempotent:
+// everything seeded lives at id >= SEED_BASE and is wiped before each run.
+//
+// Run:  bun run packages/tests/seed-market.ts        (or: bun run seed:market)
+
+import pg from "pg";
+
+const SEED_BASE = 9_000_000; // all seeded rows live at/above this id
+const HISTORY_BASE = 9_000_000;
+const BOOK_BASE = 9_500_000;
+const NIGHT = "0000000000000000000000000000000000000000000000000000000000000000";
+
+// Two pairs built from the dev mint-test-tokens colors (base traded vs native_0).
+const TOKENS = [
+  { color: NIGHT, name: "native_0", kind: "shielded" },
+  { color: "70ce552eaec9be6e009189bffbb69184b2dd008ba9bdaec6da5305fc505eb569", name: "TESTTOKENA", kind: "shielded" },
+  { color: "63b27ee9d4d94ebce3ce1bcee67f3730a87fcbfce5a8dba2c5552a0f54797bd4", name: "TESTTOKENB", kind: "shielded" },
+];
+const PAIRS = [
+  { base: TOKENS[1]!, quote: TOKENS[0]!, mid: 12.5, histTrades: 48, bookLevels: 6 }, // TESTTOKENA / native_0
+  { base: TOKENS[2]!, quote: TOKENS[0]!, mid: 0.85, histTrades: 40, bookLevels: 5 }, // TESTTOKENB / native_0
+];
+
+const HOUR = 3_600_000;
+const rnd = (a: number, b: number) => a + Math.random() * (b - a);
+const ri = (a: number, b: number) => Math.round(rnd(a, b));
+
+const client = new pg.Client({
+  host: process.env["DB_HOST"] ?? "127.0.0.1",
+  port: Number(process.env["DB_PORT"] ?? 5432),
+  user: process.env["DB_USER"] ?? "postgres",
+  password: process.env["DB_PW"] ?? "postgres",
+  database: process.env["DB_NAME"] ?? "postgres",
+});
+
+async function q(sql: string, params: unknown[] = []) {
+  return (await client.query(sql, params)).rows;
+}
+
+/** One offer leg: GIVING `giveColor`/`giveAmt`, WANTING `wantColor`/`wantAmt`. */
+function legsFor(side: "ask" | "bid", base: string, quote: string, baseAmt: number, price: number) {
+  const quoteAmt = Math.max(1, Math.round(baseAmt * price));
+  return side === "ask"
+    ? { give: [base, baseAmt], want: [quote, quoteAmt] } // sell base for quote
+    : { give: [quote, quoteAmt], want: [base, baseAmt] }; // buy base with quote
+}
+
+async function ensureTokens() {
+  for (const t of TOKENS) {
+    await q(
+      `INSERT INTO known_tokens (token_color, name, kind) VALUES ($1, $2, $3)
+       ON CONFLICT (token_color) DO UPDATE SET name = EXCLUDED.name, kind = EXCLUDED.kind`,
+      [t.color, t.name, t.kind],
+    );
+  }
+}
+
+async function wipe() {
+  await q(`DELETE FROM offer_file_tokens_history WHERE offer_file_id >= $1`, [SEED_BASE]);
+  await q(`DELETE FROM offer_file_history WHERE id >= $1`, [SEED_BASE]);
+  await q(`DELETE FROM offer_file_tokens WHERE offer_file_id >= $1`, [SEED_BASE]);
+  await q(`DELETE FROM offer_file WHERE id >= $1`, [SEED_BASE]);
+}
+
+let histId = HISTORY_BASE;
+let bookId = BOOK_BASE;
+
+async function seedHistory(p: (typeof PAIRS)[number]) {
+  const now = Date.now();
+  const span = 48 * HOUR;
+  let price = p.mid * rnd(0.92, 1.08);
+  let fills = 0;
+  for (let i = 0; i < p.histTrades; i++) {
+    // random walk that gently mean-reverts toward mid, ending near it
+    price *= 1 + rnd(-0.018, 0.018) + (p.mid - price) / p.mid * 0.05;
+    price = Math.max(p.mid * 0.6, Math.min(p.mid * 1.6, price));
+    const at = new Date(now - span + (span * (i + rnd(0, 0.6))) / p.histTrades).toISOString();
+    const side = Math.random() < 0.5 ? "ask" : "bid";
+    const baseAmt = ri(2, 40);
+    const { give, want } = legsFor(side, p.base.color, p.quote.color, baseAmt, price);
+    const id = histId++;
+    await q(
+      `INSERT INTO offer_file_history (id, celestia_height, transaction_hex, created_at, ttl_seconds, archive_reason, archived_at)
+       VALUES ($1, $2, $3, $4, 3600, 'CONSUMED', $4)`,
+      [id, 1000 + id, `seed-hist-${id}`, at],
+    );
+    await q(
+      `INSERT INTO offer_file_tokens_history (offer_file_id, token_color, amount, direction) VALUES
+       ($1,$2,$3,'GIVING'), ($1,$4,$5,'WANTING')`,
+      [id, give[0], String(give[1]), want[0], String(want[1])],
+    );
+    fills++;
+  }
+  return { fills, lastPrice: price };
+}
+
+async function seedBook(p: (typeof PAIRS)[number], mid: number) {
+  const nowIso = new Date().toISOString();
+  let n = 0;
+  const place = async (side: "ask" | "bid", price: number, baseAmt: number) => {
+    const { give, want } = legsFor(side, p.base.color, p.quote.color, baseAmt, price);
+    const id = bookId++;
+    await q(
+      `INSERT INTO offer_file (id, celestia_height, transaction_hex, created_at, ttl_seconds)
+       VALUES ($1, $2, $3, $4, 3600)`,
+      [id, 2000 + id, `seed-book-${id}`, nowIso],
+    );
+    await q(
+      `INSERT INTO offer_file_tokens (offer_file_id, token_color, amount, direction) VALUES
+       ($1,$2,$3,'GIVING'), ($1,$4,$5,'WANTING')`,
+      [id, give[0], String(give[1]), want[0], String(want[1])],
+    );
+    n++;
+  };
+  for (let k = 1; k <= p.bookLevels; k++) {
+    await place("ask", mid * (1 + 0.012 * k), ri(3, 30)); // asks above mid
+    await place("bid", mid * (1 - 0.012 * k), ri(3, 30)); // bids below mid
+  }
+  return n;
+}
+
+async function main() {
+  await client.connect();
+  console.log("[seed-market] connected to", client.host + ":" + client.port);
+  await ensureTokens();
+  await wipe();
+  for (const p of PAIRS) {
+    const { fills, lastPrice } = await seedHistory(p);
+    // anchor the live book around where the price walk ended → chart & book agree
+    const book = await seedBook(p, lastPrice);
+    console.log(
+      `[seed-market] ${p.base.name}/${p.quote.name}: ${fills} historic fills, ` +
+        `${book} live offers (mid≈${lastPrice.toFixed(3)})`,
+    );
+  }
+  console.log("[seed-market] done. Order book is live immediately; chart history/stats need the sync node to be running the updated api.ts.");
+  await client.end();
+}
+
+main().catch((e) => {
+  console.error("[seed-market] failed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Reworks the zswap-da **frontend-new** trading UI and connects the order book / trade history / price stats to **real data**, plus adds a script to seed test market data so the whole interface can be exercised without manually minting/proving swaps.

## Frontend (`packages/frontend-new`)
- **Bottom console dock** (`ui/ConsoleDock.tsx`): collapsible, full-width on desktop — fixed-width **Place Order** column + **My trades** filling the rest, with Material-style elevation. Place Order / My trades moved out of the top nav into the dock.
- **Footer** condensed to a single black bar: *Fork the template* + live GitHub star count + "Launch your own DEX · fully open source".
- **Secondary button** variant (outlined neutral) for *Connect wallet* / *Import ZSwap*; the **Select token** control now matches the network selector. Token coins get deterministic, **contrast-safe** colors derived from the token id (first half → bg hue, second half → glyph hue; verified ≥5.2:1 across all hue pairs).
- **Order book** Price / Amount / Total built from **real open offers** (`st.orders`). Own offers are shown in the listings (tagged **"Yours"**) and are non-takeable. **Take** settles the real underlying offers via the shared confirm dialog (`requestTakeMany`), with clear guards for own / seeded / non-settle-able offers.
- Pair selector header always visible; the "Markets with liquidity" picker merged into it; removed the duplicate pair search and the "Add your own · Swap now" CTAs. **Create the first order** opens the console + Pay-with picker.
- **Token picker** merges known tokens with wallet-held tokens, plus **manual token-ID entry**.
- **Create offer** robustness: retry submit on transient `ROOT_UNKNOWN`, phase-aware button status + 180s timeout. New in-app **debug log** (`lib/log.ts`) with a "Copy log" button (mirrors console errors).

## Backend (`packages/node`)
- **Real per-pair chart data**: `trade-data.ts` derives `/api/chart/history` + `/api/chart/stats` from consumed offers (`offer_file_history`) and open offers. `/api/chart/depth` stays mock but is unused (the frontend builds the book from live offers).

## Tooling
- `packages/tests/seed-market.ts` (`bun run seed:market`): seeds **2 pairs** with consistent historic fills + a live order book directly in the DB; idempotent (id ≥ 9,000,000). **Display-only** — seeded entries carry placeholder blobs and are not settle-able (use `two-wallet-swap-e2e.ts` for a real takeable offer).

## Testing
- TypeScript: `tsc -p tsconfig.app.json --noEmit` clean throughout.
- Verified live on the dev stack: seeded 2 pairs, real `/api/chart/stats` (e.g. `last: 13, change24: +1.20%`) and 48 real history rows; node changes applied via `POST :4747/restart {name:"sync"}` without resetting the chain.

## Notes
- Does not include `contract-offer-files.undeployed.json` (transient per-run deploy address).