### PR TITLE
feat(zswap-da): Midnight Preview + Celestia Mocha-4 production support

### DIFF
--- a/templates/zswap-da/packages/database/migrations/000-init.sql
+++ b/templates/zswap-da/packages/database/migrations/000-init.sql
@@ -1,7 +1,7 @@
 CREATE TABLE known_tokens (
     id SERIAL PRIMARY KEY,
     token_color TEXT UNIQUE NOT NULL,
-    name TEXT NOT NULL,
+    name TEXT UNIQUE NOT NULL,
     kind TEXT NOT NULL CHECK (kind IN ('shielded', 'unshielded'))
 );
 
@@ -88,7 +88,9 @@ CREATE TABLE offer_file_history (
     created_at TIMESTAMPTZ,
     -- Copy of the TTL (in seconds) that was active for the original offer.
     ttl_seconds BIGINT,
-    -- Reason why this offer was moved out of the main table.
+    -- Reason why this offer was moved out of the main table:
+    --   'CONSUMED' — input coin spent on Midnight (fill or cancel).
+    --   'TTL'      — scheduled cleanup timer fired.
     --   'CONSUMED' — one of the offer's inputs was spent on Midnight. This
     --     conflates *filled* (the offer's intended swap completed) and
     --     *canceled* (the maker spent the coin elsewhere) — the indexer
@@ -106,6 +108,10 @@ CREATE TABLE offer_file_history (
     archived_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- trade-data.ts HISTORY_SQL: WHERE archive_reason = 'CONSUMED' ORDER BY archived_at DESC LIMIT 120
+CREATE INDEX IF NOT EXISTS idx_offer_file_history_reason_archived_at
+    ON offer_file_history (archive_reason, archived_at DESC);
+
 CREATE TABLE offer_file_tokens_history (
     id SERIAL PRIMARY KEY,
     offer_file_id INTEGER NOT NULL,
@@ -114,6 +120,9 @@ CREATE TABLE offer_file_tokens_history (
     direction TEXT NOT NULL,
     archived_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+CREATE INDEX IF NOT EXISTS idx_offer_file_tokens_history_offer_file_id
+    ON offer_file_tokens_history (offer_file_id);
 
 CREATE TABLE offer_file_nullifiers_history (
     id SERIAL PRIMARY KEY,

--- a/templates/zswap-da/packages/database/migrations/002-liveness-sets.sql
+++ b/templates/zswap-da/packages/database/migrations/002-liveness-sets.sql
@@ -25,3 +25,9 @@ CREATE TABLE known_roots (
     height BIGINT NOT NULL,
     last_seen_ms BIGINT NOT NULL
 );
+
+-- PruneKnownRoots runs every ~6 s (once per Midnight block) with:
+--   DELETE WHERE last_seen_ms < :cutoff AND height < (SELECT MAX(height) ...)
+-- Default window is 14 days at 1 root/6 s = ~201 600 rows — must be indexed.
+CREATE INDEX IF NOT EXISTS idx_known_roots_last_seen_ms ON known_roots (last_seen_ms);
+CREATE INDEX IF NOT EXISTS idx_known_roots_height       ON known_roots (height);

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -17,6 +17,7 @@ import { getBlankRefState, validateZswapOffer } from "@zswap-da/validator";
 import { eventBus, emitAppEvent } from "./event-bus.ts";
 import { quote, buildDepth } from "./market-mock.ts";
 import { realStats, realHistory } from "./trade-data.ts";
+import { getSyncStatus } from "./sync-health.ts";
 
 // ─── API Router ───────────────────────────────────────────────────────────────
 
@@ -206,6 +207,14 @@ export const apiRouter: StartConfigApiRouter = async function (
       proofServerUri: midnightNetworkConfig.proofServer,
       networkId: midnightNetworkConfig.id,
     };
+  });
+
+  // GET /api/health/sync — per-protocol sync state (current block, tip, lag).
+  // Uses effectstream.effectstream_blocks for NTP and
+  // effectstream.sync_protocol_pagination for parallel chains.
+  // Chain tips are fetched from the Midnight indexer / Celestia RPC and cached 60 s.
+  server.get("/api/health/sync", async () => {
+    return getSyncStatus(dbConn);
   });
 
   // POST /api/zswap/submit — fully validate a `zswapoffer1…` blob, then forward

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -1,0 +1,136 @@
+// Per-protocol sync state for the /api/health/sync endpoint.
+//
+// NTP current block is read from effectstream.effectstream_blocks (exact).
+// Parallel chain positions come from effectstream.sync_protocol_pagination:
+//   MIN(page_number) = last merged native block (preserved as cursor by the merger)
+//   MAX(page_number) = latest prefetched native block (furthest ahead in buffer)
+// Chain tips are fetched externally and cached for 60 s to limit outbound calls.
+
+import { midnightNetworkConfig } from "@effectstream/midnight-contracts/midnight-env";
+import { CELESTIA_RPC_URL } from "./env.ts";
+
+const NTP_START_TIME_MS = 1774400742000; // Midnight Preview block-1 genesis (2026-03-25T01:05:42 UTC)
+const NTP_BLOCK_TIME_MS = 600_000;       // must match config.preview.ts blockTimeMS
+
+interface CachedTip {
+  value: number | null;
+  fetchedAt: number;
+}
+const TIP_TTL_MS = 60_000;
+const tipCache: Record<string, CachedTip> = {};
+
+async function cachedFetch(key: string, fn: () => Promise<number | null>): Promise<number | null> {
+  const hit = tipCache[key];
+  if (hit && Date.now() - hit.fetchedAt < TIP_TTL_MS) return hit.value;
+  let value: number | null = null;
+  try { value = await fn(); } catch { /* leave null */ }
+  tipCache[key] = { value, fetchedAt: Date.now() };
+  return value;
+}
+
+async function fetchMidnightTip(): Promise<number | null> {
+  return cachedFetch("midnight", async () => {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), 5000);
+    try {
+      const res = await fetch(midnightNetworkConfig.indexer, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "query { block { height } }" }),
+        signal: ac.signal,
+      });
+      const json = await res.json();
+      const h = json?.data?.block?.height;
+      return typeof h === "number" ? h : null;
+    } finally {
+      clearTimeout(t);
+    }
+  });
+}
+
+async function fetchCelestiaTip(): Promise<number | null> {
+  return cachedFetch("celestia", async () => {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), 5000);
+    try {
+      const res = await fetch(CELESTIA_RPC_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "header.NetworkHead", params: [], id: 1 }),
+        signal: ac.signal,
+      });
+      const json = await res.json();
+      const h = parseInt(json?.result?.header?.height, 10);
+      return Number.isFinite(h) ? h : null;
+    } finally {
+      clearTimeout(t);
+    }
+  });
+}
+
+function pct(current: number, tip: number | null): number | null {
+  if (tip == null || tip <= 0) return null;
+  return Math.round((current / tip) * 1000) / 10;
+}
+
+// "ok"      — within 2 NTP blocks (≤ 20 min behind), serving live data.
+// "syncing" — catching up; historical data only until lag clears.
+// "error"   — no blocks finalized yet (migrations pending or node crash).
+function deriveStatus(ntpCurrent: number, lagSeconds: number): "ok" | "syncing" | "error" {
+  if (ntpCurrent === 0) return "error";
+  if (lagSeconds > NTP_BLOCK_TIME_MS * 2 / 1000) return "syncing"; // > 2 blocks (20 min)
+  return "ok";
+}
+
+export async function getSyncStatus(dbConn: any) {
+  const [ntpRow, pageRow, midnightTip, celestiaTip] = await Promise.all([
+    dbConn.query("SELECT MAX(block_height) AS current FROM effectstream.effectstream_blocks"),
+    dbConn.query(`
+      SELECT protocol_name,
+             MIN(page_number) AS merged,
+             MAX(page_number) AS fetched
+      FROM effectstream.sync_protocol_pagination
+      GROUP BY protocol_name
+    `),
+    fetchMidnightTip(),
+    fetchCelestiaTip(),
+  ]);
+
+  const ntpCurrent = Number(ntpRow.rows[0]?.current ?? 0);
+  const ntpTip = Math.floor((Date.now() - NTP_START_TIME_MS) / NTP_BLOCK_TIME_MS);
+
+  const pages: Record<string, { merged: number; fetched: number }> = {};
+  for (const row of pageRow.rows) {
+    pages[row.protocol_name] = { merged: Number(row.merged), fetched: Number(row.fetched) };
+  }
+
+  const mn = pages["parallelMidnight"];
+  const ce = pages["parallelCelestia"];
+
+  const lagSeconds = Math.max(0, (ntpTip - ntpCurrent) * NTP_BLOCK_TIME_MS / 1000);
+
+  return {
+    ts: Date.now(),
+    status: deriveStatus(ntpCurrent, lagSeconds),
+    ntp: {
+      current: ntpCurrent,
+      tip: ntpTip,
+      pct: pct(ntpCurrent, ntpTip),
+      lag_blocks: Math.max(0, ntpTip - ntpCurrent),
+      lag_seconds: lagSeconds,
+    },
+
+    midnight: {
+      current: mn?.merged ?? null,
+      fetched: mn?.fetched ?? null,
+      tip: midnightTip,
+      pct: mn ? pct(mn.merged, midnightTip) : null,
+    },
+    celestia: {
+      current: ce?.merged ?? null,
+      fetched: ce?.fetched ?? null,
+      tip: celestiaTip,
+      pct: ce ? pct(ce.merged, celestiaTip) : null,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **Midnight Preview network** support (batcher, node, frontend) replacing the local devnet
- **Celestia Mocha-4 via QuickNode** replacing the self-hosted local Celestia sidecar — no light node needed, auth embedded in the RPC URL
- NTP epoch anchored to Midnight Preview genesis (`startTime: 1774400742000`, `blockTimeMS: 600_000`) reducing 89-day historical catch-up from ~180 days to ~4 hours
- Merged nullifier/unshielded-spend tables, TTL prune, live-set liveness checks, auto-register token colors
- `check-env.ts` — validates `.env` completeness without printing secrets
- **Removed old `packages/frontend`** — superseded by `packages/frontend-new` (real wallet, mint, swap/take via Midnight browser SDK)
- `GET /api/health/sync` — per-protocol sync state (`status: ok | syncing | error`, current block, tip, pct, lag) with chain tips cached from the Midnight indexer GraphQL and Celestia QuickNode RPC
- DB indexes fixed in-place: `known_tokens.name` UNIQUE constraint; `offer_file_history`, `offer_file_tokens_history`, `known_roots` indexes for queries that would seqscan growing tables

## Test plan

- [ ] `MIDNIGHT_NETWORK_ID=preview bun run packages/node/main.preview.ts` starts cleanly and applies all 3 app migrations at NTP block 1 (within ~90 s of startup)
- [ ] `GET /api/known-tokens` returns 3 native tokens after migrations
- [ ] `GET /api/health/sync` returns `status: syncing` during catch-up, transitions to `ok` when NTP lag ≤ 2 blocks (≤ 20 min)
- [ ] Heartbeat log shows all three protocols advancing: `mainNtp`, `parallelMidnight`, `parallelCelestia`
- [ ] Full sync completes in ~4 hours on a fresh DB
- [ ] `POST /api/zswap/submit` accepts a valid offer blob and forwards to the batcher
- [ ] `packages/frontend-new` builds with `VITE_API_BASE`, `VITE_BATCHER_URL`, `VITE_MIDNIGHT_NETWORK_ID=preview` and serves the DEX UI