### PR TITLE
feat(zswap-da): health endpoint improvements + sync banner

### DIFF
--- a/templates/zswap-da/packages/frontend-new/src/ui/SyncBanner.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/SyncBanner.tsx
@@ -40,7 +40,7 @@ export function SyncBanner() {
 
   const isError = health.status === 'error';
   const lagH    = Math.round((health.ntp?.lag_seconds ?? 0) / 3600);
-  const pct     = health.ntp?.pct ?? 0;
+  const pct     = Math.min(health.ntp?.pct ?? 0, 99.9);
 
   return (
     <div style={{

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -209,26 +209,6 @@ export const apiRouter: StartConfigApiRouter = async function (
     };
   });
 
-  // GET /api/block/latest — latest finalized L2 (NTP) block from the framework DB.
-  server.get("/api/block/latest", async () => {
-    const result = await dbConn.query(
-      `SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
-       FROM effectstream.effectstream_blocks
-       ORDER BY block_height DESC
-       LIMIT 1`,
-    );
-    const row = result.rows[0] ?? null;
-    if (!row) return null;
-    const toHex = (v: unknown) =>
-      v != null ? Buffer.from(v as Buffer).toString("hex") : null;
-    return {
-      block_height: row.block_height,
-      timestamp: row.ms_timestamp,
-      block_hash: toHex(row.effectstream_block_hash),
-      main_chain_block_hash: toHex(row.main_chain_block_hash),
-    };
-  });
-
   // GET /api/health/sync — per-protocol sync state (current block, tip, lag).
   // Uses effectstream.effectstream_blocks for NTP and
   // effectstream.sync_protocol_pagination for parallel chains.

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -209,6 +209,26 @@ export const apiRouter: StartConfigApiRouter = async function (
     };
   });
 
+  // GET /api/block/latest — latest finalized L2 (NTP) block from the framework DB.
+  server.get("/api/block/latest", async () => {
+    const result = await dbConn.query(
+      `SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
+       FROM effectstream.effectstream_blocks
+       ORDER BY block_height DESC
+       LIMIT 1`,
+    );
+    const row = result.rows[0] ?? null;
+    if (!row) return null;
+    const toHex = (v: unknown) =>
+      v != null ? Buffer.from(v as Buffer).toString("hex") : null;
+    return {
+      block_height: row.block_height,
+      timestamp: row.ms_timestamp,
+      block_hash: toHex(row.effectstream_block_hash),
+      main_chain_block_hash: toHex(row.main_chain_block_hash),
+    };
+  });
+
   // GET /api/health/sync — per-protocol sync state (current block, tip, lag).
   // Uses effectstream.effectstream_blocks for NTP and
   // effectstream.sync_protocol_pagination for parallel chains.

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -83,7 +83,7 @@ function deriveStatus(ntpCurrent: number, lagSeconds: number): "ok" | "syncing" 
 }
 
 export async function getSyncStatus(dbConn: any) {
-  const [ntpRow, pageRow, blockRow, midnightTip, celestiaTip] = await Promise.all([
+  const [ntpRow, pageRow, blockRow, nullifierRow, rootRow, unshieldedRow, lastOfferRow, midnightTip, celestiaTip] = await Promise.all([
     dbConn.query("SELECT MAX(block_height) AS current FROM effectstream.effectstream_blocks"),
     dbConn.query(`
       SELECT protocol_name,
@@ -96,6 +96,15 @@ export async function getSyncStatus(dbConn: any) {
       SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
       FROM effectstream.effectstream_blocks
       ORDER BY block_height DESC
+      LIMIT 1
+    `),
+    dbConn.query("SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM nullifiers"),
+    dbConn.query("SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM known_roots"),
+    dbConn.query("SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM created_unshielded"),
+    dbConn.query(`
+      SELECT id, celestia_height, created_at
+      FROM offer_file
+      ORDER BY id DESC
       LIMIT 1
     `),
     fetchMidnightTip(),
@@ -118,6 +127,7 @@ export async function getSyncStatus(dbConn: any) {
   const toHex = (v: unknown) =>
     v != null ? Buffer.from(v as Buffer).toString("hex") : null;
   const latestBlock = blockRow.rows[0] ?? null;
+  const lastOffer   = lastOfferRow.rows[0] ?? null;
 
   return {
     ts: Date.now(),
@@ -149,6 +159,27 @@ export async function getSyncStatus(dbConn: any) {
       fetched: ce?.fetched ?? null,
       tip: celestiaTip,
       pct: ce ? pct(ce.merged, celestiaTip) : null,
+    },
+    sets: {
+      nullifiers: {
+        total: nullifierRow.rows[0]?.total ?? 0,
+        latest_height: nullifierRow.rows[0]?.latest_height ?? null,
+      },
+      known_roots: {
+        total: rootRow.rows[0]?.total ?? 0,
+        latest_height: rootRow.rows[0]?.latest_height ?? null,
+      },
+      unshielded_utxos: {
+        total: unshieldedRow.rows[0]?.total ?? 0,
+        latest_height: unshieldedRow.rows[0]?.latest_height ?? null,
+      },
+      last_zswap: lastOffer
+        ? {
+            id: lastOffer.id,
+            celestia_height: lastOffer.celestia_height,
+            created_at: lastOffer.created_at,
+          }
+        : null,
     },
   };
 }

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -131,6 +131,7 @@ export async function getSyncStatus(dbConn: any) {
 
   return {
     ts: Date.now(),
+    now: new Date().toISOString(),
     status: deriveStatus(ntpCurrent, lagSeconds),
     block: latestBlock
       ? {

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -70,7 +70,9 @@ async function fetchCelestiaTip(): Promise<number | null> {
 
 function pct(current: number, tip: number | null): number | null {
   if (tip == null || tip <= 0) return null;
-  return Math.round((current / tip) * 1000) / 10;
+  const p = Math.round((current / tip) * 1000) / 10;
+  // Never show 100 when there are still blocks to process.
+  return current < tip ? Math.min(p, 99.9) : p;
 }
 
 // "ok"      — within 2 NTP blocks (≤ 20 min behind), serving live data.
@@ -153,12 +155,14 @@ export async function getSyncStatus(dbConn: any) {
       current: mn?.merged ?? null,
       fetched: mn?.fetched ?? null,
       tip: midnightTip,
+      lag_blocks: mn && midnightTip != null ? Math.max(0, midnightTip - mn.merged) : null,
       pct: mn ? pct(mn.merged, midnightTip) : null,
     },
     celestia: {
       current: ce?.merged ?? null,
       fetched: ce?.fetched ?? null,
       tip: celestiaTip,
+      lag_blocks: ce && celestiaTip != null ? Math.max(0, celestiaTip - ce.merged) : null,
       pct: ce ? pct(ce.merged, celestiaTip) : null,
     },
     sets: {

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -83,7 +83,7 @@ function deriveStatus(ntpCurrent: number, lagSeconds: number): "ok" | "syncing" 
 }
 
 export async function getSyncStatus(dbConn: any) {
-  const [ntpRow, pageRow, midnightTip, celestiaTip] = await Promise.all([
+  const [ntpRow, pageRow, blockRow, midnightTip, celestiaTip] = await Promise.all([
     dbConn.query("SELECT MAX(block_height) AS current FROM effectstream.effectstream_blocks"),
     dbConn.query(`
       SELECT protocol_name,
@@ -91,6 +91,12 @@ export async function getSyncStatus(dbConn: any) {
              MAX(page_number) AS fetched
       FROM effectstream.sync_protocol_pagination
       GROUP BY protocol_name
+    `),
+    dbConn.query(`
+      SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
+      FROM effectstream.effectstream_blocks
+      ORDER BY block_height DESC
+      LIMIT 1
     `),
     fetchMidnightTip(),
     fetchCelestiaTip(),
@@ -109,9 +115,21 @@ export async function getSyncStatus(dbConn: any) {
 
   const lagSeconds = Math.max(0, (ntpTip - ntpCurrent) * NTP_BLOCK_TIME_MS / 1000);
 
+  const toHex = (v: unknown) =>
+    v != null ? Buffer.from(v as Buffer).toString("hex") : null;
+  const latestBlock = blockRow.rows[0] ?? null;
+
   return {
     ts: Date.now(),
     status: deriveStatus(ntpCurrent, lagSeconds),
+    block: latestBlock
+      ? {
+          height: latestBlock.block_height,
+          timestamp: latestBlock.ms_timestamp,
+          block_hash: toHex(latestBlock.effectstream_block_hash),
+          main_chain_block_hash: toHex(latestBlock.main_chain_block_hash),
+        }
+      : null,
     ntp: {
       current: ntpCurrent,
       tip: ntpTip,


### PR DESCRIPTION
## Summary

- **Sync banner** (`SyncBanner`): appears below header when `/api/health/sync` returns `status !== "ok"`. Checks once on mount, retries every 60 s only while still syncing/errored. Auto-hides when node catches up. Pct capped at 99.9% while still syncing.
- **Network badge**: replaced interactive `NetworkMenu` dropdown with a static badge — network is fixed by `VITE_MIDNIGHT_NETWORK_ID`, correctly displays `"Preview"` instead of `"Undeployed"`.
- **`/api/health/sync` additions**:
  - `now` — ISO timestamp for easy comparison with other timestamps in the response
  - `block` — latest finalized L2 block (`height`, `timestamp`, `block_hash`, `main_chain_block_hash`)
  - `sets` — live counts + latest heights for `nullifiers`, `known_roots`, `unshielded_utxos`, and `last_zswap`
  - `lag_blocks` added to `midnight` and `celestia` sections
  - `pct` capped at 99.9 server-side when `current < tip` (prevents misleading `100` while still lagging)

## Test plan

- [ ] Header badge shows `"Preview"` with `VITE_MIDNIGHT_NETWORK_ID=preview`
- [ ] Amber syncing banner visible while node is catching up; disappears on `status: "ok"`
- [ ] `/api/health/sync` includes `now`, `block`, and `sets` fields
- [ ] `midnight.pct` and `celestia.pct` never show `100` when `lag_blocks > 0`