### PR TITLE
feat(zswap-da): blockL2 improvements, 409 on duplicate token, local-migration.sql

### DIFF
--- a/templates/zswap-da/packages/database/migration-order.ts
+++ b/templates/zswap-da/packages/database/migration-order.ts
@@ -2,6 +2,7 @@ import type { DBMigrations } from "@effectstream/runtime";
 import databaseSql from "./migrations/000-init.sql" with { type: "text" };
 import spentSetsSql from "./migrations/001-spent-sets.sql" with { type: "text" };
 import livenessSetsSql from "./migrations/002-liveness-sets.sql" with { type: "text" };
+import localMigrationSql from "./migrations/local-migration.sql" with { type: "text" };
 export const migrationTable: DBMigrations[] = [
   {
     name: "000-init.sql",
@@ -14,5 +15,9 @@ export const migrationTable: DBMigrations[] = [
   {
     name: "002-liveness-sets.sql",
     sql: livenessSetsSql,
+  },
+  {
+    name: "local-migration.sql",
+    sql: localMigrationSql,
   },
 ];

--- a/templates/zswap-da/packages/database/migrations/local-migration.sql
+++ b/templates/zswap-da/packages/database/migrations/local-migration.sql
@@ -1,0 +1,2 @@
+-- local-migration.sql
+-- Applied after all default migrations. Add project-specific schema changes here.

--- a/templates/zswap-da/packages/frontend-new/src/ui/SyncBanner.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/SyncBanner.tsx
@@ -6,6 +6,8 @@ interface HealthSync {
   ntp: { pct: number; lag_seconds: number };
 }
 
+const ISSUES_URL = 'https://github.com/effectstream/effectstream/issues';
+
 export function SyncBanner() {
   const [health, setHealth] = useState<HealthSync | null>(null);
 
@@ -36,33 +38,61 @@ export function SyncBanner() {
     return () => { dead = true; clearTimeout(timer); };
   }, []);
 
-  if (!health || health.status === 'ok') return null;
+  // Syncing / error bar
+  if (health && health.status !== 'ok') {
+    const isError = health.status === 'error';
+    const lagH    = Math.round((health.ntp?.lag_seconds ?? 0) / 3600);
+    const pct     = Math.min(health.ntp?.pct ?? 0, 99.9);
+    return (
+      <div style={{
+        background: isError ? 'rgba(139,32,32,0.18)' : 'rgba(140,110,0,0.15)',
+        borderBottom: `1px solid ${isError ? 'rgba(220,80,80,0.35)' : 'rgba(210,165,40,0.35)'}`,
+        padding: '9px 24px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        fontSize: 13,
+        color: isError ? '#E88080' : '#D4A830',
+        fontFamily: 'var(--font-ui)',
+      }}>
+        <span style={{ width: 7, height: 7, borderRadius: '50%', background: isError ? '#E06060' : '#D4A830', flex: '0 0 auto' }} />
+        {isError
+          ? 'Indexer error — no blocks finalized. The service may be starting up or recovering.'
+          : <span>
+              <strong>Syncing</strong> — {pct.toFixed(1)}% complete
+              {lagH > 1 ? `, ~${lagH}h remaining` : ''}.
+              {' '}Live offers will appear once the node catches up.
+            </span>
+        }
+      </div>
+    );
+  }
 
-  const isError = health.status === 'error';
-  const lagH    = Math.round((health.ntp?.lag_seconds ?? 0) / 3600);
-  const pct     = Math.min(health.ntp?.pct ?? 0, 99.9);
-
+  // Preview banner — shown when OK (or before first check resolves)
   return (
     <div style={{
-      background: isError ? 'rgba(139,32,32,0.18)' : 'rgba(140,110,0,0.15)',
-      borderBottom: `1px solid ${isError ? 'rgba(220,80,80,0.35)' : 'rgba(210,165,40,0.35)'}`,
-      padding: '9px 24px',
+      background: 'var(--bg-tint)',
+      borderBottom: '1px solid var(--line)',
+      padding: '8px 24px',
       display: 'flex',
       alignItems: 'center',
-      gap: 10,
-      fontSize: 13,
-      color: isError ? '#E88080' : '#D4A830',
+      justifyContent: 'center',
+      gap: 6,
+      fontSize: 12.5,
+      color: 'var(--ink-3)',
       fontFamily: 'var(--font-ui)',
     }}>
-      <span style={{ width: 7, height: 7, borderRadius: '50%', background: isError ? '#E06060' : '#D4A830', flex: '0 0 auto' }} />
-      {isError
-        ? 'Indexer error — no blocks finalized. The service may be starting up or recovering.'
-        : <span>
-            <strong>Syncing</strong> — {pct.toFixed(1)}% complete
-            {lagH > 1 ? `, ~${lagH}h remaining` : ''}.
-            {' '}Live offers will appear once the node catches up.
-          </span>
-      }
+      This is an early preview of the ZSwap DEX Orderbook.
+      {' '}Report issues{' '}
+      <a
+        href={ISSUES_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: 'var(--accent)', textDecoration: 'underline', textUnderlineOffset: 3 }}
+      >
+        here
+      </a>
+      .
     </div>
   );
 }

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -158,16 +158,18 @@ export const apiRouter: StartConfigApiRouter = async function (
         },
       },
     },
-    async (request: any) => {
+    async (request: any, reply: any) => {
       const color = String(request.body.color).toLowerCase().replace(/^0x/, "");
       const name = String(request.body.name).trim().toUpperCase().slice(0, 16);
       const kind = String(request.body.kind);
       if (!/^[0-9a-f]{64}$/.test(color)) {
-        throw new Error("Invalid token color (expected 64 hex chars)");
+        return reply.code(400).send({ error: "Invalid token color (expected 64 hex chars)" });
       }
-      if (!name) throw new Error("Invalid token name");
+      if (!name) {
+        return reply.code(400).send({ error: "Invalid token name" });
+      }
       if (kind !== "shielded" && kind !== "unshielded") {
-        throw new Error('Invalid kind (expected "shielded" or "unshielded")');
+        return reply.code(400).send({ error: 'Invalid kind (expected "shielded" or "unshielded")' });
       }
 
       const nameCheck = await dbConn.query(
@@ -175,14 +177,14 @@ export const apiRouter: StartConfigApiRouter = async function (
         [name],
       );
       if (nameCheck.rows.length > 0) {
-        throw new Error(`Token name "${name}" is already taken`);
+        return reply.code(409).send({ error: `Token name "${name}" is already taken` });
       }
       const colorCheck = await dbConn.query(
         `SELECT name FROM known_tokens WHERE token_color = $1 LIMIT 1`,
         [color],
       );
       if (colorCheck.rows.length > 0) {
-        throw new Error(`Token color already registered as "${colorCheck.rows[0].name}"`);
+        return reply.code(409).send({ error: `Token color already registered as "${colorCheck.rows[0].name}"` });
       }
 
       await insertKnownToken.run({ token_color: color, name, kind }, dbConn);

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -135,12 +135,14 @@ export async function getSyncStatus(dbConn: any) {
     ts: Date.now(),
     now: new Date().toISOString(),
     status: deriveStatus(ntpCurrent, lagSeconds),
-    block: latestBlock
+    blockL2: latestBlock
       ? {
           height: latestBlock.block_height,
           timestamp: latestBlock.ms_timestamp,
           block_hash: toHex(latestBlock.effectstream_block_hash),
           main_chain_block_hash: toHex(latestBlock.main_chain_block_hash),
+          block_time: NTP_BLOCK_TIME_MS,
+          lag: Math.max(0, ntpTip - ntpCurrent),
         }
       : null,
     ntp: {


### PR DESCRIPTION
## Summary

- **`blockL2`**: renamed from `block` in `/api/health/sync`; added `block_time` (ms per NTP block) and `lag` (blocks behind tip)
- **`POST /api/known-tokens`**: returns `409 Conflict` instead of throwing a 500 when name or color is already registered
- **`local-migration.sql`**: empty migration file applied after all default migrations — add project-specific schema changes here

## Test plan

- [ ] `/api/health/sync` response uses `blockL2` key with `block_time: 600000` and correct `lag`
- [ ] `POST /api/known-tokens` with a duplicate name returns `409` with `{ "error": "..." }`
- [ ] Node starts cleanly with the new `local-migration.sql` (no-op on a fresh DB)