### PR TITLE
feat(zswap-da): pair_stats, My Trades status, typed SQL queries, /api/pairs

### DIFF
--- a/templates/zswap-da/packages/database/migration-order.ts
+++ b/templates/zswap-da/packages/database/migration-order.ts
@@ -3,6 +3,7 @@ import databaseSql from "./migrations/000-init.sql" with { type: "text" };
 import spentSetsSql from "./migrations/001-spent-sets.sql" with { type: "text" };
 import livenessSetsSql from "./migrations/002-liveness-sets.sql" with { type: "text" };
 import tokenPricesSql from "./migrations/003-token-prices.sql" with { type: "text" };
+import pairStatsSql from "./migrations/004-pair-stats.sql" with { type: "text" };
 import localMigrationSql from "./migrations/local-migration.sql" with { type: "text" };
 export const migrationTable: DBMigrations[] = [
   {
@@ -20,6 +21,10 @@ export const migrationTable: DBMigrations[] = [
   {
     name: "003-token-prices.sql",
     sql: tokenPricesSql,
+  },
+  {
+    name: "004-pair-stats.sql",
+    sql: pairStatsSql,
   },
   {
     name: "local-migration.sql",

--- a/templates/zswap-da/packages/database/migrations/004-pair-stats.sql
+++ b/templates/zswap-da/packages/database/migrations/004-pair-stats.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS pair_stats (
+    pair_key       TEXT PRIMARY KEY,   -- LEAST(a,b)||'|'||GREATEST(a,b)
+    base_color     TEXT NOT NULL,
+    quote_color    TEXT NOT NULL,
+    trade_count    INTEGER NOT NULL DEFAULT 0,
+    last_price     NUMERIC,
+    last_traded_at TIMESTAMPTZ
+);

--- a/templates/zswap-da/packages/database/mod.ts
+++ b/templates/zswap-da/packages/database/mod.ts
@@ -1,2 +1,3 @@
 export * from "./sql/queries.queries.ts";
+export * from "./sql/queries.app.ts";
 export { migrationTable } from "./migration-order.ts";

--- a/templates/zswap-da/packages/database/sql/queries.app.ts
+++ b/templates/zswap-da/packages/database/sql/queries.app.ts
@@ -1,0 +1,321 @@
+// Typed query wrappers for queries defined in queries.sql.
+// These use dbConn.query() directly and mirror the PreparedQuery.run() interface
+// so call sites are identical. Run `bun run pgtyped:update` when a live DB is
+// available to regenerate queries.queries.ts with proper PreparedQuery objects,
+// then move these exports there and delete this file.
+
+import type { DateOrString, NumberOrString } from "./queries.queries.ts";
+
+// Convert :param! style SQL to $N positional params and execute.
+// Repeated occurrences of the same param reuse the same $N index.
+async function runQ<P extends object, R>(
+  sql: string,
+  params: P,
+  dbConn: any,
+): Promise<R[]> {
+  const seen = new Map<string, number>();
+  let n = 0;
+  const pgSql = sql.replace(/:(\w+)!/g, (_: string, name: string) => {
+    if (!seen.has(name)) seen.set(name, ++n);
+    return `$${seen.get(name)}`;
+  });
+  const values = [...seen.keys()].map((k) => (params as any)[k]);
+  return (await dbConn.query(pgSql, values)).rows as R[];
+}
+
+async function runNoParams<R>(sql: string, dbConn: any): Promise<R[]> {
+  return (await dbConn.query(sql)).rows as R[];
+}
+
+// ── Sync health — effectstream framework schema ────────────────────────────
+
+export interface IGetNtpCurrentBlockResult {
+  current: NumberOrString | null;
+}
+export const getNtpCurrentBlock = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetNtpCurrentBlockResult>(
+      "SELECT MAX(block_height) AS current FROM effectstream.effectstream_blocks",
+      dbConn,
+    ),
+};
+
+export interface IGetSyncProtocolPaginationResult {
+  protocol_name: string;
+  merged: NumberOrString | null;
+  fetched: NumberOrString | null;
+}
+export const getSyncProtocolPagination = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetSyncProtocolPaginationResult>(
+      `SELECT protocol_name,
+              MIN(page_number) AS merged,
+              MAX(page_number) AS fetched
+       FROM effectstream.sync_protocol_pagination
+       GROUP BY protocol_name`,
+      dbConn,
+    ),
+};
+
+export interface IGetLatestEffectstreamBlockResult {
+  block_height: NumberOrString;
+  ms_timestamp: NumberOrString | null;
+  effectstream_block_hash: Buffer | null;
+  main_chain_block_hash: Buffer | null;
+}
+export const getLatestEffectstreamBlock = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetLatestEffectstreamBlockResult>(
+      `SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
+       FROM effectstream.effectstream_blocks
+       ORDER BY block_height DESC
+       LIMIT 1`,
+      dbConn,
+    ),
+};
+
+export interface IGetNullifierStatsResult {
+  total: number;
+  latest_height: NumberOrString | null;
+}
+export const getNullifierStats = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetNullifierStatsResult>(
+      "SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM nullifiers",
+      dbConn,
+    ),
+};
+
+export interface IGetKnownRootStatsResult {
+  total: number;
+  latest_height: NumberOrString | null;
+}
+export const getKnownRootStats = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetKnownRootStatsResult>(
+      "SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM known_roots",
+      dbConn,
+    ),
+};
+
+export interface IGetUnshieldedStatsResult {
+  total: number;
+  latest_height: NumberOrString | null;
+}
+export const getUnshieldedStats = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetUnshieldedStatsResult>(
+      "SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM created_unshielded",
+      dbConn,
+    ),
+};
+
+export interface IGetLastOfferResult {
+  id: number;
+  celestia_height: NumberOrString;
+  created_at: DateOrString | null;
+}
+export const getLastOffer = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetLastOfferResult>(
+      `SELECT id, celestia_height, created_at
+       FROM offer_file
+       ORDER BY id DESC
+       LIMIT 1`,
+      dbConn,
+    ),
+};
+
+// ── Trade history ──────────────────────────────────────────────────────────
+
+export interface IGetTradeHistoryParams {
+  base: string;
+  quote: string;
+}
+export interface IGetTradeHistoryResult {
+  at_ms: string;
+  g_color: string;
+  g_amt: string;
+  w_color: string;
+  w_amt: string;
+}
+export const getTradeHistory = {
+  run: (params: IGetTradeHistoryParams, dbConn: any) =>
+    runQ<IGetTradeHistoryParams, IGetTradeHistoryResult>(
+      `SELECT (EXTRACT(EPOCH FROM h.archived_at) * 1000)::bigint AS at_ms,
+              g.token_color AS g_color, g.amount AS g_amt,
+              w.token_color AS w_color, w.amount AS w_amt
+       FROM offer_file_history h
+       JOIN offer_file_tokens_history g ON g.offer_file_id = h.id AND g.direction = 'GIVING'
+       JOIN offer_file_tokens_history w ON w.offer_file_id = h.id AND w.direction = 'WANTING'
+       WHERE h.archive_reason = 'CONSUMED'
+         AND ((g.token_color = :base! AND w.token_color = :quote!)
+           OR (g.token_color = :quote! AND w.token_color = :base!))
+       ORDER BY h.archived_at DESC
+       LIMIT 120`,
+      params,
+      dbConn,
+    ),
+};
+
+export interface IGetOpenLegsParams {
+  base: string;
+  quote: string;
+}
+export interface IGetOpenLegsResult {
+  g_color: string;
+  g_amt: string;
+  w_color: string;
+  w_amt: string;
+}
+export const getOpenLegs = {
+  run: (params: IGetOpenLegsParams, dbConn: any) =>
+    runQ<IGetOpenLegsParams, IGetOpenLegsResult>(
+      `SELECT g.token_color AS g_color, g.amount AS g_amt,
+              w.token_color AS w_color, w.amount AS w_amt
+       FROM offer_file o
+       JOIN offer_file_tokens g ON g.offer_file_id = o.id AND g.direction = 'GIVING'
+       JOIN offer_file_tokens w ON w.offer_file_id = o.id AND w.direction = 'WANTING'
+       WHERE ((g.token_color = :base! AND w.token_color = :quote!)
+           OR (g.token_color = :quote! AND w.token_color = :base!))`,
+      params,
+      dbConn,
+    ),
+};
+
+// ── Token prices ───────────────────────────────────────────────────────────
+
+export interface IGetTokenPriceParams { token_color: string }
+export interface IGetTokenPriceResult { price_usd: string }
+export const getTokenPrice = {
+  run: (params: IGetTokenPriceParams, dbConn: any) =>
+    runQ<IGetTokenPriceParams, IGetTokenPriceResult>(
+      "SELECT price_usd FROM token_prices WHERE token_color = :token_color!",
+      params,
+      dbConn,
+    ),
+};
+
+export interface IUpsertTokenPriceParams { token_color: string; price_usd: number }
+export type IUpsertTokenPriceResult = void;
+export const upsertTokenPrice = {
+  run: (params: IUpsertTokenPriceParams, dbConn: any) =>
+    runQ<IUpsertTokenPriceParams, IUpsertTokenPriceResult>(
+      `INSERT INTO token_prices (token_color, price_usd)
+       VALUES (:token_color!, :price_usd!)
+       ON CONFLICT (token_color) DO NOTHING`,
+      params,
+      dbConn,
+    ),
+};
+
+// ── Known tokens (duplicate-check queries) ─────────────────────────────────
+
+export interface ICheckTokenNameExistsParams { name: string }
+export interface ICheckTokenNameExistsResult { present: number }
+export const checkTokenNameExists = {
+  run: (params: ICheckTokenNameExistsParams, dbConn: any) =>
+    runQ<ICheckTokenNameExistsParams, ICheckTokenNameExistsResult>(
+      "SELECT 1 AS present FROM known_tokens WHERE name = :name! LIMIT 1",
+      params,
+      dbConn,
+    ),
+};
+
+export interface IGetTokenByColorParams { token_color: string }
+export interface IGetTokenByColorResult { name: string }
+export const getTokenByColor = {
+  run: (params: IGetTokenByColorParams, dbConn: any) =>
+    runQ<IGetTokenByColorParams, IGetTokenByColorResult>(
+      "SELECT name FROM known_tokens WHERE token_color = :token_color! LIMIT 1",
+      params,
+      dbConn,
+    ),
+};
+
+// ── Pair stats ─────────────────────────────────────────────────────────────
+
+export interface IUpsertPairStatsByOfferIdParams { offer_id: number }
+export type IUpsertPairStatsByOfferIdResult = void;
+export const upsertPairStatsByOfferId = {
+  run: (params: IUpsertPairStatsByOfferIdParams, dbConn: any) =>
+    runQ<IUpsertPairStatsByOfferIdParams, IUpsertPairStatsByOfferIdResult>(
+      `INSERT INTO pair_stats (pair_key, base_color, quote_color, trade_count, last_price, last_traded_at)
+       SELECT
+           LEAST(g.token_color, w.token_color) || '|' || GREATEST(g.token_color, w.token_color),
+           LEAST(g.token_color, w.token_color),
+           GREATEST(g.token_color, w.token_color),
+           1,
+           w.amount::numeric / NULLIF(g.amount::numeric, 0),
+           NOW()
+       FROM offer_file_tokens_history g
+       JOIN offer_file_tokens_history w ON w.offer_file_id = g.offer_file_id AND w.direction = 'WANTING'
+       WHERE g.direction = 'GIVING' AND g.offer_file_id = :offer_id!
+       ON CONFLICT (pair_key) DO UPDATE SET
+           trade_count    = pair_stats.trade_count + 1,
+           last_price     = EXCLUDED.last_price,
+           last_traded_at = EXCLUDED.last_traded_at`,
+      params,
+      dbConn,
+    ),
+};
+
+export interface IGetPairsResult {
+  pair_key: string;
+  base_color: string;
+  quote_color: string;
+  trade_count: number;
+  last_price: string | null;
+  last_traded_at: DateOrString | null;
+  open_count: number;
+}
+export const getPairs = {
+  run: (_: void, dbConn: any) =>
+    runNoParams<IGetPairsResult>(
+      `SELECT
+           COALESCE(ps.pair_key, live.pair_key) AS pair_key,
+           COALESCE(ps.base_color, split_part(live.pair_key, '|', 1)) AS base_color,
+           COALESCE(ps.quote_color, split_part(live.pair_key, '|', 2)) AS quote_color,
+           COALESCE(ps.trade_count, 0) AS trade_count,
+           ps.last_price,
+           ps.last_traded_at,
+           COALESCE(live.open_count, 0) AS open_count
+       FROM pair_stats ps
+       FULL OUTER JOIN (
+           SELECT
+               LEAST(g.token_color, w.token_color) || '|' || GREATEST(g.token_color, w.token_color) AS pair_key,
+               COUNT(*)::int AS open_count
+           FROM offer_file_tokens g
+           JOIN offer_file_tokens w ON w.offer_file_id = g.offer_file_id AND w.direction = 'WANTING'
+           WHERE g.direction = 'GIVING'
+           GROUP BY 1
+       ) live ON live.pair_key = ps.pair_key
+       ORDER BY open_count DESC, last_traded_at DESC NULLS LAST`,
+      dbConn,
+    ),
+};
+
+// ── ZSwap status (My Trades reconciliation) ────────────────────────────────
+
+export interface IGetZswapStatusByBlobParams { blob: string }
+export interface IGetZswapStatusByBlobResult {
+  transaction_hex: string;
+  status: string;
+  archive_reason: string | null;
+}
+export const getZswapStatusByBlob = {
+  run: (params: IGetZswapStatusByBlobParams, dbConn: any) =>
+    runQ<IGetZswapStatusByBlobParams, IGetZswapStatusByBlobResult>(
+      `SELECT transaction_hex, 'open' AS status, NULL::text AS archive_reason
+       FROM offer_file
+       WHERE transaction_hex = :blob!
+       UNION ALL
+       SELECT transaction_hex,
+           CASE archive_reason WHEN 'CONSUMED' THEN 'completed' ELSE 'expired' END AS status,
+           archive_reason
+       FROM offer_file_history
+       WHERE transaction_hex = :blob!`,
+      params,
+      dbConn,
+    ),
+};

--- a/templates/zswap-da/packages/database/sql/queries.sql
+++ b/templates/zswap-da/packages/database/sql/queries.sql
@@ -399,3 +399,119 @@ WHERE root = :root!;
 DELETE FROM known_roots
 WHERE last_seen_ms < :cutoff_ms!
   AND height < (SELECT MAX(height) FROM known_roots);
+
+/* @name GetNtpCurrentBlock */
+SELECT MAX(block_height) AS current FROM effectstream.effectstream_blocks;
+
+/* @name GetSyncProtocolPagination */
+SELECT protocol_name,
+       MIN(page_number) AS merged,
+       MAX(page_number) AS fetched
+FROM effectstream.sync_protocol_pagination
+GROUP BY protocol_name;
+
+/* @name GetLatestEffectstreamBlock */
+SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
+FROM effectstream.effectstream_blocks
+ORDER BY block_height DESC
+LIMIT 1;
+
+/* @name GetNullifierStats */
+SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM nullifiers;
+
+/* @name GetKnownRootStats */
+SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM known_roots;
+
+/* @name GetUnshieldedStats */
+SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM created_unshielded;
+
+/* @name GetLastOffer */
+SELECT id, celestia_height, created_at
+FROM offer_file
+ORDER BY id DESC
+LIMIT 1;
+
+/* @name GetTradeHistory */
+SELECT (EXTRACT(EPOCH FROM h.archived_at) * 1000)::bigint AS at_ms,
+       g.token_color AS g_color, g.amount AS g_amt,
+       w.token_color AS w_color, w.amount AS w_amt
+FROM offer_file_history h
+JOIN offer_file_tokens_history g ON g.offer_file_id = h.id AND g.direction = 'GIVING'
+JOIN offer_file_tokens_history w ON w.offer_file_id = h.id AND w.direction = 'WANTING'
+WHERE h.archive_reason = 'CONSUMED'
+  AND ((g.token_color = :base! AND w.token_color = :quote!)
+    OR (g.token_color = :quote! AND w.token_color = :base!))
+ORDER BY h.archived_at DESC
+LIMIT 120;
+
+/* @name GetOpenLegs */
+SELECT g.token_color AS g_color, g.amount AS g_amt,
+       w.token_color AS w_color, w.amount AS w_amt
+FROM offer_file o
+JOIN offer_file_tokens g ON g.offer_file_id = o.id AND g.direction = 'GIVING'
+JOIN offer_file_tokens w ON w.offer_file_id = o.id AND w.direction = 'WANTING'
+WHERE ((g.token_color = :base! AND w.token_color = :quote!)
+    OR (g.token_color = :quote! AND w.token_color = :base!));
+
+/* @name GetTokenPrice */
+SELECT price_usd FROM token_prices WHERE token_color = :token_color!;
+
+/* @name UpsertTokenPrice */
+INSERT INTO token_prices (token_color, price_usd)
+VALUES (:token_color!, :price_usd!)
+ON CONFLICT (token_color) DO NOTHING;
+
+/* @name CheckTokenNameExists */
+SELECT 1 AS present FROM known_tokens WHERE name = :name! LIMIT 1;
+
+/* @name GetTokenByColor */
+SELECT name FROM known_tokens WHERE token_color = :token_color! LIMIT 1;
+
+/* @name UpsertPairStatsByOfferId */
+INSERT INTO pair_stats (pair_key, base_color, quote_color, trade_count, last_price, last_traded_at)
+SELECT
+    LEAST(g.token_color, w.token_color) || '|' || GREATEST(g.token_color, w.token_color),
+    LEAST(g.token_color, w.token_color),
+    GREATEST(g.token_color, w.token_color),
+    1,
+    w.amount::numeric / NULLIF(g.amount::numeric, 0),
+    NOW()
+FROM offer_file_tokens_history g
+JOIN offer_file_tokens_history w ON w.offer_file_id = g.offer_file_id AND w.direction = 'WANTING'
+WHERE g.direction = 'GIVING' AND g.offer_file_id = :offer_id!
+ON CONFLICT (pair_key) DO UPDATE SET
+    trade_count    = pair_stats.trade_count + 1,
+    last_price     = EXCLUDED.last_price,
+    last_traded_at = EXCLUDED.last_traded_at;
+
+/* @name GetPairs */
+SELECT
+    COALESCE(ps.pair_key, live.pair_key) AS pair_key,
+    COALESCE(ps.base_color, split_part(live.pair_key, '|', 1)) AS base_color,
+    COALESCE(ps.quote_color, split_part(live.pair_key, '|', 2)) AS quote_color,
+    COALESCE(ps.trade_count, 0) AS trade_count,
+    ps.last_price,
+    ps.last_traded_at,
+    COALESCE(live.open_count, 0) AS open_count
+FROM pair_stats ps
+FULL OUTER JOIN (
+    SELECT
+        LEAST(g.token_color, w.token_color) || '|' || GREATEST(g.token_color, w.token_color) AS pair_key,
+        COUNT(*)::int AS open_count
+    FROM offer_file_tokens g
+    JOIN offer_file_tokens w ON w.offer_file_id = g.offer_file_id AND w.direction = 'WANTING'
+    WHERE g.direction = 'GIVING'
+    GROUP BY 1
+) live ON live.pair_key = ps.pair_key
+ORDER BY open_count DESC, last_traded_at DESC NULLS LAST;
+
+/* @name GetZswapStatusByBlob */
+SELECT transaction_hex, 'open' AS status, NULL::text AS archive_reason
+FROM offer_file
+WHERE transaction_hex = :blob!
+UNION ALL
+SELECT transaction_hex,
+    CASE archive_reason WHEN 'CONSUMED' THEN 'completed' ELSE 'expired' END AS status,
+    archive_reason
+FROM offer_file_history
+WHERE transaction_hex = :blob!;

--- a/templates/zswap-da/packages/frontend-new/src/screens/Market.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/screens/Market.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Coin, Icon, isShielded } from '../ui/icons';
-import { api, type ChartHistoryRow, type ChartStats } from '../services/api';
+import { api, type ChartHistoryRow, type ChartStats, type PairInfo } from '../services/api';
 import { shortToken } from '../utils';
 import type { Order, ZSwapApp } from '../state/useZSwapApp';
 
@@ -88,25 +88,64 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
     return () => document.removeEventListener('pointerdown', off);
   }, []);
 
-  // Pairs with liquidity from real open orders; opposite directions merge.
-  // `mine` marks pairs that include one of your own offers.
+  // Pairs from /api/pairs (pair_stats projection + live open count). Includes
+  // pairs with no current open orders as long as they have trade history.
+  // Refreshed every 30 s so the list stays reasonably current.
+  const [apiPairs, setApiPairs] = useState<PairInfo[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => api.fetchPairs().then((ps) => { if (!cancelled) setApiPairs(ps); });
+    load();
+    const id = setInterval(load, 30_000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
+
+  // Name-resolve the color pairs from /api/pairs and merge with live orders to
+  // mark "mine". Falls back to the live order set for pairs not yet in pair_stats.
   const liquidPairs = useMemo(() => {
+    const nameOf = (color: string) =>
+      st.knownTokens.find((t) => t.token_color === color)?.name ?? shortToken(color);
+
+    // Build a mine-set from live orders.
+    const minePairs = new Set<string>();
+    for (const o of st.orders) {
+      if (o.isMine) {
+        const key = [o.fromColor, o.toColor].sort().join('|');
+        minePairs.add(key);
+      }
+    }
+
+    // API pairs (authoritative — includes historical pairs with 0 open orders).
+    const seen = new Set<string>();
+    const out: { base: string; quote: string; count: number; mine: boolean; dimmed: boolean }[] = [];
+    for (const p of apiPairs) {
+      seen.add(p.pair_key);
+      const base = nameOf(p.base_color);
+      const quote = nameOf(p.quote_color);
+      const mine = minePairs.has(p.pair_key);
+      out.push({ base, quote, count: p.open_count, mine, dimmed: p.open_count === 0 });
+    }
+
+    // Live pairs not yet in pair_stats (brand-new pairs before any fills).
     const orders = st.orders || [];
-    const m: Record<string, { count: number; dirs: Record<string, number>; mine: boolean }> = {};
+    const liveMap: Record<string, { count: number; dirs: Record<string, number>; mine: boolean }> = {};
     orders.forEach((o) => {
-      const key = [o.from, o.to].sort().join('/');
-      if (!m[key]) m[key] = { count: 0, dirs: {}, mine: false };
-      m[key].count++;
-      if (o.isMine) m[key].mine = true;
-      const dk = o.from + '/' + o.to;
-      m[key].dirs[dk] = (m[key].dirs[dk] || 0) + 1;
+      const key = [o.fromColor, o.toColor].sort().join('|');
+      if (seen.has(key)) return;
+      if (!liveMap[key]) liveMap[key] = { count: 0, dirs: {}, mine: false };
+      liveMap[key].count++;
+      if (o.isMine) liveMap[key].mine = true;
+      const dk = o.fromColor + '/' + o.toColor;
+      liveMap[key].dirs[dk] = (liveMap[key].dirs[dk] || 0) + 1;
     });
-    return Object.values(m).map((p) => {
+    for (const [, p] of Object.entries(liveMap)) {
       const [top] = Object.entries(p.dirs).sort((a, b) => b[1] - a[1]);
-      const [b0, q0] = top[0].split('/');
-      return { base: b0, quote: q0, count: p.count, mine: p.mine };
-    }).sort((a, b) => b.count - a.count).slice(0, 24);
-  }, [st.orders]);
+      const [b0Color, q0Color] = top[0].split('/');
+      out.push({ base: nameOf(b0Color), quote: nameOf(q0Color), count: p.count, mine: p.mine, dimmed: false });
+    }
+
+    return out.sort((a, b) => b.count - a.count || (a.dimmed ? 1 : 0) - (b.dimmed ? 1 : 0)).slice(0, 24);
+  }, [apiPairs, st.orders, st.knownTokens]);
 
   const q = pairQuery.trim().toLowerCase();
   const shownPairs = q ? liquidPairs.filter((p) => (p.base + ' ' + p.quote).toLowerCase().includes(q)) : liquidPairs;
@@ -263,14 +302,14 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
                   {pairQuery && <button onClick={() => setPairQuery('')} style={{ border: 'none', background: 'transparent', color: 'var(--ink-3)', cursor: 'pointer', padding: 0, fontSize: 14, flex: '0 0 auto' }}>✕</button>}
                 </div>
                 <div style={{ overflowY: 'auto' }}>
-                  <div className="zs-tag" style={{ padding: '6px 10px 8px', display: 'flex', alignItems: 'center', gap: 6 }}><Icon.spark style={{ color: 'var(--accent)' }} /> Pairs with liquidity</div>
-                  {shownPairs.length === 0 && <div style={{ padding: '6px 10px 12px', fontSize: 12.5, color: 'var(--ink-3)' }}>{q ? `No pairs match “${pairQuery}”.` : 'No open liquidity right now.'}</div>}
+                  <div className=”zs-tag” style={{ padding: '6px 10px 8px', display: 'flex', alignItems: 'center', gap: 6 }}><Icon.spark style={{ color: 'var(--accent)' }} /> Known pairs</div>
+                  {shownPairs.length === 0 && <div style={{ padding: '6px 10px 12px', fontSize: 12.5, color: 'var(--ink-3)' }}>{q ? `No pairs match “${pairQuery}”.` : 'No pairs yet.'}</div>}
                   {shownPairs.map((p, i) => (
-                    <button key={i} onClick={() => { setPair({ base: p.base, quote: p.quote }); setPickOpen(false); }} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 10, padding: '9px 10px', border: 'none', background: pair && pair.base === p.base && pair.quote === p.quote ? 'var(--surface-2)' : 'transparent', borderRadius: 10, cursor: 'pointer', textAlign: 'left' }}>
-                      <div style={{ display: 'flex', alignItems: 'center', flex: '0 0 auto' }}><Coin sym={p.base} size="sm" /><span style={{ margin: '0 3px', color: 'var(--ink-3)', fontSize: 11, position: 'relative', zIndex: 2 }}>→</span><Coin sym={p.quote} size="sm" /></div>
+                    <button key={i} onClick={() => { setPair({ base: p.base, quote: p.quote }); setPickOpen(false); }} style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 10, padding: '9px 10px', border: 'none', background: pair && pair.base === p.base && pair.quote === p.quote ? 'var(--surface-2)' : 'transparent', borderRadius: 10, cursor: 'pointer', textAlign: 'left', opacity: p.dimmed ? 0.6 : 1 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', flex: '0 0 auto' }}><Coin sym={p.base} size=”sm” /><span style={{ margin: '0 3px', color: 'var(--ink-3)', fontSize: 11, position: 'relative', zIndex: 2 }}>→</span><Coin sym={p.quote} size=”sm” /></div>
                       <span style={{ flex: 1, fontWeight: 700, fontSize: 13.5 }}>{p.base}<span style={{ color: 'var(--ink-3)', fontWeight: 500 }}> / {p.quote}</span></span>
-                      {p.mine && <span className="zs-pill" style={{ padding: '2px 7px', fontSize: 10, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)', flex: '0 0 auto' }}>Yours</span>}
-                      <span className="zs-num" style={{ fontSize: 11.5, color: 'var(--ink-3)', flex: '0 0 auto' }}>{p.count} open</span>
+                      {p.mine && <span className=”zs-pill” style={{ padding: '2px 7px', fontSize: 10, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)', flex: '0 0 auto' }}>Yours</span>}
+                      <span className=”zs-num” style={{ fontSize: 11.5, color: 'var(--ink-3)', flex: '0 0 auto' }}>{p.count} open</span>
                     </button>
                   ))}
                 </div>
@@ -305,29 +344,29 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
         <div style={{ borderTop: '1px solid var(--line)', paddingTop: 18 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
             <Icon.spark style={{ color: 'var(--accent)' }} />
-            <span style={{ fontWeight: 800, fontSize: 17, letterSpacing: '-.02em' }}>Markets with liquidity</span>
+            <span style={{ fontWeight: 800, fontSize: 17, letterSpacing: '-.02em' }}>Known pairs</span>
           </div>
-          <p style={{ fontSize: 13.5, color: 'var(--ink-2)', margin: '0 0 16px' }}>Pick a pair to open its order book and trade history — use “Select a pair” above to search. These have open ZSwaps right now.</p>
+          <p style={{ fontSize: 13.5, color: 'var(--ink-2)', margin: '0 0 16px' }}>Pick a pair to open its order book and trade history. Pairs with no current orders still show historical trades.</p>
 
           {shownPairs.length === 0 ? (
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', gap: 12, padding: '30px 0' }}>
               <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink-2)' }}>{q ? `No pairs match “${pairQuery}”` : 'No open liquidity right now'}</div>
-              <button className="zs-btn zs-btn--primary" onClick={() => onStartOrder?.()}>Create the first order <Icon.arrow /></button>
+              <button className=”zs-btn zs-btn--primary” onClick={() => onStartOrder?.()}>Create the first order <Icon.arrow /></button>
             </div>
           ) : (
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 12 }}>
               {shownPairs.map((p, i) => {
                 const sh = isShielded(p.base) && isShielded(p.quote);
                 return (
-                  <button key={i} onClick={() => setPair({ base: p.base, quote: p.quote })} style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 16, borderRadius: 'var(--r-field)', border: '1px solid var(--line)', background: 'var(--surface)', cursor: 'pointer', textAlign: 'left' }}>
+                  <button key={i} onClick={() => setPair({ base: p.base, quote: p.quote })} style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 16, borderRadius: 'var(--r-field)', border: '1px solid var(--line)', background: 'var(--surface)', cursor: 'pointer', textAlign: 'left', opacity: p.dimmed ? 0.55 : 1 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                       <span style={{ display: 'inline-flex', alignItems: 'center' }}><Coin sym={p.base} /><span style={{ margin: '0 4px', color: 'var(--ink-3)', position: 'relative', zIndex: 2 }}>→</span><Coin sym={p.quote} /></span>
                       <span style={{ fontWeight: 700, fontSize: 14.5 }}>{p.base}<span style={{ color: 'var(--ink-3)', fontWeight: 500 }}> / {p.quote}</span></span>
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-                      <span className="zs-tag">Open ZSwaps</span>
+                      <span className=”zs-tag”>{p.count > 0 ? 'Open ZSwaps' : 'No open orders'}</span>
                       <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                        {p.mine && <span className="zs-pill" style={{ padding: '3px 8px', fontSize: 10.5, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)' }}>Yours</span>}
+                        {p.mine && <span className=”zs-pill” style={{ padding: '3px 8px', fontSize: 10.5, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)' }}>Yours</span>}
                         <span className={sh ? 'zs-badge-shield' : 'zs-pill'} style={{ padding: '4px 9px', fontSize: 11 }}>{p.count} open</span>
                       </span>
                     </div>

--- a/templates/zswap-da/packages/frontend-new/src/screens/MyTrades.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/screens/MyTrades.tsx
@@ -27,11 +27,13 @@ function offerName(t: MyTrade) {
 
 function StatusBadge({ status }: { status: MyTrade['status'] }) {
   const map: Record<string, { c: string; bg: string; label: string }> = {
-    open: { c: 'var(--pos)', bg: 'var(--pos-soft)', label: 'Open' },
-    completed: { c: 'var(--accent)', bg: 'var(--accent-soft)', label: 'Completed' },
-    cancelled: { c: 'var(--ink-3)', bg: 'var(--surface-3)', label: 'Cancelled' },
+    not_public: { c: 'var(--ink-3)', bg: 'var(--surface-2)', label: 'Not public' },
+    open:       { c: 'var(--pos)', bg: 'var(--pos-soft)', label: 'Open' },
+    completed:  { c: 'var(--accent)', bg: 'var(--accent-soft)', label: 'Completed' },
+    expired:    { c: 'var(--warn)', bg: 'var(--warn-soft)', label: 'Expired' },
+    cancelled:  { c: 'var(--ink-3)', bg: 'var(--surface-3)', label: 'Cancelled' },
   };
-  const s = map[status] || map.open;
+  const s = map[status] ?? map.not_public;
   return <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, fontWeight: 700, color: s.c, background: s.bg, borderRadius: 'var(--r-pill)', padding: '4px 10px', whiteSpace: 'nowrap' }}><Icon.dot /> {s.label}</span>;
 }
 
@@ -47,7 +49,7 @@ function Cell({ amt, sym, accent }: { amt: number; sym: string; accent?: boolean
 
 export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
   const trades = st.myTrades;
-  const [filter, setFilter] = useState<'all' | 'open' | 'completed'>('all');
+  const [filter, setFilter] = useState<'all' | 'open' | 'completed' | 'expired'>('all');
   const [viewing, setViewing] = useState<MyTrade | null>(null);
   const [importOpen, setImportOpen] = useState(false);
   const [dump, setDump] = useState('');
@@ -57,10 +59,13 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
 
   const counts = {
     all: trades.length,
-    open: trades.filter((t) => t.status === 'open').length,
+    open: trades.filter((t) => t.status === 'open' || t.status === 'not_public').length,
     completed: trades.filter((t) => t.status === 'completed').length,
+    expired: trades.filter((t) => t.status === 'expired').length,
   };
-  const rows = filter === 'all' ? trades : trades.filter((t) => t.status === filter);
+  const rows = filter === 'all' ? trades
+    : filter === 'open' ? trades.filter((t) => t.status === 'open' || t.status === 'not_public')
+    : trades.filter((t) => t.status === filter);
 
   const doImport = async () => {
     setImporting(true);
@@ -78,7 +83,7 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
 
   const filterSeg = (
     <div className="zs-seg" style={{ background: 'var(--bg-tint)' }}>
-      {([['all', 'All'], ['open', 'Open'], ['completed', 'Completed']] as const).map(([id, lbl]) => (
+      {([['all', 'All'], ['open', 'Open'], ['completed', 'Completed'], ['expired', 'Expired']] as const).map(([id, lbl]) => (
         <button key={id} className="zs-nav-tab" aria-selected={filter === id} onClick={() => setFilter(id)}
           style={filter === id ? { background: 'var(--surface)', color: 'var(--ink)', boxShadow: '0 1px 3px rgba(10,12,20,.08)' } : { background: 'transparent', color: 'var(--ink-2)' }}>
           {lbl} <span className="zs-num" style={{ color: 'var(--ink-3)', fontWeight: 600 }}>{counts[id]}</span>

--- a/templates/zswap-da/packages/frontend-new/src/services/api.ts
+++ b/templates/zswap-da/packages/frontend-new/src/services/api.ts
@@ -21,6 +21,17 @@ export interface ChartDepth { mid: number; asks: ChartDepthRow[]; bids: ChartDep
 export interface ChartStats { base: string; quote: string; last: number; change24: number; high: number; low: number; volume_base: number; volume_quote: number }
 export interface ChartHistoryRow { price: number; amt: number; up: boolean; at: string }
 
+/** One row from /api/pairs — pair_stats write-side projection merged with live open count. */
+export interface PairInfo {
+  pair_key: string;
+  base_color: string;
+  quote_color: string;
+  trade_count: number;
+  last_price: string | null;
+  last_traded_at: string | null;
+  open_count: number;
+}
+
 const MIDNIGHT_ADDRESS_TYPE = 5;
 
 export async function submitToBatcher(
@@ -164,5 +175,38 @@ export const api = {
     const data = await res.json();
     if (!res.ok) throw new Error(data.message ?? JSON.stringify(data));
     return data;
+  },
+
+  /** Fetch all known pairs from the write-side projection (pair_stats). */
+  fetchPairs: async (): Promise<PairInfo[]> => {
+    try {
+      const res = await fetch(`${API_BASE}/api/pairs`);
+      if (!res.ok) return [];
+      return res.json();
+    } catch {
+      return [];
+    }
+  },
+
+  /**
+   * Lookup the server-side status for a list of offer blobs.
+   * Returns a map of blob → 'open' | 'completed' | 'expired' | 'not_found'.
+   * Used for startup-only My Trades reconciliation.
+   */
+  fetchTradeStatuses: async (blobs: string[]): Promise<Record<string, string>> => {
+    if (blobs.length === 0) return {};
+    const results = await Promise.all(
+      blobs.map(async (blob): Promise<[string, string]> => {
+        try {
+          const res = await fetch(`${API_BASE}/api/zswap/status?blob=${encodeURIComponent(blob)}`);
+          if (!res.ok) return [blob, 'unknown'];
+          const data = await res.json();
+          return [blob, data.status ?? 'unknown'];
+        } catch {
+          return [blob, 'unknown'];
+        }
+      }),
+    );
+    return Object.fromEntries(results);
   },
 };

--- a/templates/zswap-da/packages/frontend-new/src/state/myTrades.ts
+++ b/templates/zswap-da/packages/frontend-new/src/state/myTrades.ts
@@ -10,7 +10,12 @@ export interface MyTrade {
   give: TradeLeg;
   get: TradeLeg;
   at: number;
-  status: 'open' | 'completed' | 'cancelled';
+  // not_public: submitted to Celestia but not yet visible in the live order book
+  // open:       visible in the live order book
+  // completed:  offer was consumed (settled or cancelled on-chain)
+  // expired:    offer TTL elapsed before being consumed
+  // cancelled:  user cleared or the import/take flow never completed
+  status: 'not_public' | 'open' | 'completed' | 'expired' | 'cancelled';
   shielded: boolean;
   blob?: string;
 }

--- a/templates/zswap-da/packages/frontend-new/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/packages/frontend-new/src/state/useZSwapApp.ts
@@ -365,7 +365,7 @@ export function useZSwapApp(): ZSwapApp {
         kind: 'create',
         give: { sym: findTokenName(give.color, knownTokens) ?? shortToken(give.color), amt: Number(give.amount) },
         get: { sym: findTokenName(want.color, knownTokens) ?? shortToken(want.color), amt: Number(want.amount) },
-        status: 'open',
+        status: 'not_public',
         shielded: give.kind === 'shielded' && want.kind === 'shielded',
         blob,
       });
@@ -508,19 +508,46 @@ export function useZSwapApp(): ZSwapApp {
   const clearTrade = useCallback((id: string) => removeTrade(id), []);
   const clearAllTrades = useCallback(() => clearTrades(), []);
 
-  // Reconcile created-offer status: once a created offer has been observed live
-  // in the book and later disappears (consumed or expired), mark it completed.
+  // Live order-book reconciliation: watch the blob set in each poll cycle.
+  //   not_public → open    when the blob first appears in the live book
+  //   open       → completed  when a previously-seen blob disappears from the book
   const seenBlobs = useRef<Set<string>>(new Set());
   useEffect(() => {
     const offers = zapi.offers ?? [];
     const live = new Set(offers.map((o) => o.transaction_hex).filter(Boolean) as string[]);
-    live.forEach((b) => seenBlobs.current.add(b));
     for (const t of listTrades()) {
-      if (t.kind === 'create' && t.status === 'open' && t.blob && seenBlobs.current.has(t.blob) && !live.has(t.blob)) {
+      if (t.kind !== 'create' || !t.blob) continue;
+      if (t.status === 'not_public' && live.has(t.blob)) {
+        seenBlobs.current.add(t.blob);
+        updateTradeStatus(t.id, 'open');
+      } else if (t.status === 'open' && seenBlobs.current.has(t.blob) && !live.has(t.blob)) {
         updateTradeStatus(t.id, 'completed');
+      } else {
+        // Track any live blob regardless of status so we detect future removal.
+        if (live.has(t.blob)) seenBlobs.current.add(t.blob);
       }
     }
   }, [zapi.offers]);
+
+  // Startup-only reconciliation: on first mount, ask the server for the
+  // definitive status of every non-terminal created trade.
+  useEffect(() => {
+    const blobs = listTrades()
+      .filter((t) => t.kind === 'create' && t.blob && t.status !== 'cancelled')
+      .map((t) => t.blob!);
+    if (blobs.length === 0) return;
+    api.fetchTradeStatuses(blobs).then((statusMap) => {
+      for (const t of listTrades()) {
+        if (t.kind !== 'create' || !t.blob) continue;
+        const srv = statusMap[t.blob];
+        if (!srv || srv === 'unknown') continue;
+        if (srv === 'completed' && t.status !== 'completed') updateTradeStatus(t.id, 'completed');
+        else if (srv === 'expired' && t.status !== 'expired') updateTradeStatus(t.id, 'expired');
+        else if (srv === 'open' && t.status === 'not_public') updateTradeStatus(t.id, 'open');
+      }
+    }).catch(() => { /* startup reconcile is best-effort */ });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const wallet = useMemo<WalletInfo | null>(() => {
     if (!connected) return null;

--- a/templates/zswap-da/packages/node/api.ts
+++ b/templates/zswap-da/packages/node/api.ts
@@ -8,13 +8,20 @@ import {
   isNullifierSpent,
   isUnshieldedCreated,
   isKnownRoot,
+  getTokenPrice,
+  upsertTokenPrice,
+  checkTokenNameExists,
+  getTokenByColor,
+  getPairs,
+  getZswapStatusByBlob,
+  upsertPairStatsByOfferId,
 } from "@zswap-da/database";
 
 import { MIDNIGHT_NETWORK_ID, OFFER_MAX_BYTES, midnightContract } from "./env.ts";
 import { midnightNetworkConfig } from "@effectstream/midnight-contracts/midnight-env";
 import { submitBlobViaBatcher } from "./batcher-client.ts";
 import { getBlankRefState, validateZswapOffer } from "@zswap-da/validator";
-import { eventBus, emitAppEvent } from "./event-bus.ts";
+import { eventBus, emitAppEvent, type AppEvent } from "./event-bus.ts";
 import { quoteWithPrices, priceOf } from "./market-mock.ts";
 import { realStats, realHistory } from "./trade-data.ts";
 import { getSyncStatus } from "./sync-health.ts";
@@ -25,6 +32,20 @@ export const apiRouter: StartConfigApiRouter = async function (
   server: any,
   dbConn: any,
 ): Promise<void> {
+  // Update pair_stats after each CONSUMED archive. The state machine fires
+  // offer_consumed after the archive transaction commits; this listener keeps
+  // pair_stats in sync without needing access to dbConn inside the generator.
+  const onAppEvent = async (event: AppEvent) => {
+    if (event.type === "offer_consumed") {
+      try {
+        await upsertPairStatsByOfferId.run({ offer_id: event.offerId }, dbConn);
+      } catch (e) {
+        console.error("[PAIR_STATS] Failed to update pair stats for offer", event.offerId, e);
+      }
+    }
+  };
+  eventBus.on("app_event", onAppEvent);
+
   // GET /api/zswaps — list ZSWAPs ordered by newest first, with optional filtering & pagination
   server.get("/api/zswaps", async (request: any) => {
     const query = request?.query ?? {};
@@ -103,17 +124,10 @@ export const apiRouter: StartConfigApiRouter = async function (
   // Params: from_token, to_token (hex colors), from_amount (base units),
   // optional to_amount (a user-set receive amount → discount/sponsored vs it).
   async function resolvePrice(token: string): Promise<number> {
-    const row = await dbConn.query(
-      "SELECT price_usd FROM token_prices WHERE token_color = $1",
-      [token],
-    );
-    if (row.rows.length > 0) return Number(row.rows[0].price_usd);
+    const rows = await getTokenPrice.run({ token_color: token }, dbConn);
+    if (rows.length > 0) return Number(rows[0].price_usd);
     const fallback = priceOf(token);
-    await dbConn.query(
-      `INSERT INTO token_prices (token_color, price_usd) VALUES ($1, $2)
-       ON CONFLICT (token_color) DO NOTHING`,
-      [token, fallback],
-    );
+    await upsertTokenPrice.run({ token_color: token, price_usd: fallback }, dbConn);
     return fallback;
   }
 
@@ -184,19 +198,13 @@ export const apiRouter: StartConfigApiRouter = async function (
         return reply.code(400).send({ error: 'Invalid kind (expected "shielded" or "unshielded")' });
       }
 
-      const nameCheck = await dbConn.query(
-        `SELECT 1 FROM known_tokens WHERE name = $1 LIMIT 1`,
-        [name],
-      );
-      if (nameCheck.rows.length > 0) {
+      const nameCheck = await checkTokenNameExists.run({ name }, dbConn);
+      if (nameCheck.length > 0) {
         return reply.code(409).send({ error: `Token name "${name}" is already taken` });
       }
-      const colorCheck = await dbConn.query(
-        `SELECT name FROM known_tokens WHERE token_color = $1 LIMIT 1`,
-        [color],
-      );
-      if (colorCheck.rows.length > 0) {
-        return reply.code(409).send({ error: `Token color already registered as "${colorCheck.rows[0].name}"` });
+      const colorCheck = await getTokenByColor.run({ token_color: color }, dbConn);
+      if (colorCheck.length > 0) {
+        return reply.code(409).send({ error: `Token color already registered as "${colorCheck[0].name}"` });
       }
 
       await insertKnownToken.run({ token_color: color, name, kind }, dbConn);
@@ -229,6 +237,24 @@ export const apiRouter: StartConfigApiRouter = async function (
   // Chain tips are fetched from the Midnight indexer / Celestia RPC and cached 60 s.
   server.get("/api/health/sync", async () => {
     return getSyncStatus(dbConn);
+  });
+
+  // GET /api/pairs — all known trading pairs from pair_stats (historical) merged
+  // with live open-offer counts. Fast: pair_stats is a write-side projection
+  // updated on each CONSUMED archive; the live subquery hits a small indexed table.
+  server.get("/api/pairs", async () => {
+    return getPairs.run(undefined, dbConn);
+  });
+
+  // GET /api/zswap/status?blob=<hex> — single-blob status lookup for My Trades
+  // startup reconciliation. Returns { blob, status } where status is one of
+  // 'open' | 'completed' | 'expired' | 'not_found'.
+  server.get("/api/zswap/status", async (request: any, reply: any) => {
+    const blob = String((request.query as any)?.blob ?? "").trim();
+    if (!blob) return reply.code(400).send({ error: "blob query param required" });
+    const rows = await getZswapStatusByBlob.run({ blob }, dbConn);
+    if (rows.length === 0) return { blob, status: "not_found" };
+    return { blob: rows[0].transaction_hex, status: rows[0].status };
   });
 
   // POST /api/zswap/submit — fully validate a `zswapoffer1…` blob, then forward

--- a/templates/zswap-da/packages/node/sync-health.ts
+++ b/templates/zswap-da/packages/node/sync-health.ts
@@ -8,6 +8,15 @@
 
 import { midnightNetworkConfig } from "@effectstream/midnight-contracts/midnight-env";
 import { BLOCK_TIME_MS, CELESTIA_RPC_URL, NTP_START_TIME } from "./env.ts";
+import {
+  getNtpCurrentBlock,
+  getSyncProtocolPagination,
+  getLatestEffectstreamBlock,
+  getNullifierStats,
+  getKnownRootStats,
+  getUnshieldedStats,
+  getLastOffer,
+} from "@zswap-da/database";
 
 interface CachedTip {
   value: number | null;
@@ -82,39 +91,23 @@ function deriveStatus(ntpCurrent: number, lagSeconds: number): "ok" | "syncing" 
 }
 
 export async function getSyncStatus(dbConn: any) {
-  const [ntpRow, pageRow, blockRow, nullifierRow, rootRow, unshieldedRow, lastOfferRow, midnightTip, celestiaTip] = await Promise.all([
-    dbConn.query("SELECT MAX(block_height) AS current FROM effectstream.effectstream_blocks"),
-    dbConn.query(`
-      SELECT protocol_name,
-             MIN(page_number) AS merged,
-             MAX(page_number) AS fetched
-      FROM effectstream.sync_protocol_pagination
-      GROUP BY protocol_name
-    `),
-    dbConn.query(`
-      SELECT block_height, ms_timestamp, effectstream_block_hash, main_chain_block_hash
-      FROM effectstream.effectstream_blocks
-      ORDER BY block_height DESC
-      LIMIT 1
-    `),
-    dbConn.query("SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM nullifiers"),
-    dbConn.query("SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM known_roots"),
-    dbConn.query("SELECT COUNT(*)::int AS total, MAX(height) AS latest_height FROM created_unshielded"),
-    dbConn.query(`
-      SELECT id, celestia_height, created_at
-      FROM offer_file
-      ORDER BY id DESC
-      LIMIT 1
-    `),
+  const [ntpRows, pageRows, blockRows, nullifierRows, rootRows, unshieldedRows, lastOfferRows, midnightTip, celestiaTip] = await Promise.all([
+    getNtpCurrentBlock.run(undefined, dbConn),
+    getSyncProtocolPagination.run(undefined, dbConn),
+    getLatestEffectstreamBlock.run(undefined, dbConn),
+    getNullifierStats.run(undefined, dbConn),
+    getKnownRootStats.run(undefined, dbConn),
+    getUnshieldedStats.run(undefined, dbConn),
+    getLastOffer.run(undefined, dbConn),
     fetchMidnightTip(),
     fetchCelestiaTip(),
   ]);
 
-  const ntpCurrent = Number(ntpRow.rows[0]?.current ?? 0);
+  const ntpCurrent = Number(ntpRows[0]?.current ?? 0);
   const ntpTip = Math.floor((Date.now() - NTP_START_TIME) / BLOCK_TIME_MS);
 
   const pages: Record<string, { merged: number; fetched: number }> = {};
-  for (const row of pageRow.rows) {
+  for (const row of pageRows) {
     pages[row.protocol_name] = { merged: Number(row.merged), fetched: Number(row.fetched) };
   }
 
@@ -125,8 +118,8 @@ export async function getSyncStatus(dbConn: any) {
 
   const toHex = (v: unknown) =>
     v != null ? Buffer.from(v as Buffer).toString("hex") : null;
-  const latestBlock = blockRow.rows[0] ?? null;
-  const lastOffer   = lastOfferRow.rows[0] ?? null;
+  const latestBlock = blockRows[0] ?? null;
+  const lastOffer   = lastOfferRows[0] ?? null;
 
   return {
     ts: Date.now(),
@@ -149,7 +142,6 @@ export async function getSyncStatus(dbConn: any) {
       lag_blocks: Math.max(0, ntpTip - ntpCurrent),
       lag_seconds: lagSeconds,
     },
-
     midnight: {
       current: mn?.merged ?? null,
       fetched: mn?.fetched ?? null,
@@ -166,16 +158,16 @@ export async function getSyncStatus(dbConn: any) {
     },
     sets: {
       nullifiers: {
-        total: nullifierRow.rows[0]?.total ?? 0,
-        latest_height: nullifierRow.rows[0]?.latest_height ?? null,
+        total: nullifierRows[0]?.total ?? 0,
+        latest_height: nullifierRows[0]?.latest_height ?? null,
       },
       known_roots: {
-        total: rootRow.rows[0]?.total ?? 0,
-        latest_height: rootRow.rows[0]?.latest_height ?? null,
+        total: rootRows[0]?.total ?? 0,
+        latest_height: rootRows[0]?.latest_height ?? null,
       },
       unshielded_utxos: {
-        total: unshieldedRow.rows[0]?.total ?? 0,
-        latest_height: unshieldedRow.rows[0]?.latest_height ?? null,
+        total: unshieldedRows[0]?.total ?? 0,
+        latest_height: unshieldedRows[0]?.latest_height ?? null,
       },
       last_zswap: lastOffer
         ? {

--- a/templates/zswap-da/packages/node/trade-data.ts
+++ b/templates/zswap-da/packages/node/trade-data.ts
@@ -6,9 +6,8 @@
 //
 // Prices are quoted as quote-per-base. An offer GIVING base / WANTING quote is a
 // SELL of base (ask); GIVING quote / WANTING base is a BUY of base (bid).
-//
-// Raw SQL (via the pg client `dbConn`) keeps this independent of the pgtyped
-// codegen — these are read-only analytics queries.
+
+import { getTradeHistory, getOpenLegs } from "@zswap-da/database";
 
 export interface HistoryRow { price: number; amt: number; up: boolean; at: string }
 export interface Stats {
@@ -16,46 +15,25 @@ export interface Stats {
   high: number; low: number; volume_base: number; volume_quote: number;
 }
 
-interface LegRow { at_ms: string; g_color: string; g_amt: string; w_color: string; w_amt: string }
+interface LegRow { g_color: string; g_amt: string; w_color: string; w_amt: string }
 
 // One fill, normalised to quote-per-base price + base-denominated size.
-function toFill(r: LegRow, base: string): { price: number; amt: number; at: number } {
+function toFill(r: LegRow, base: string): { price: number; amt: number } {
   const gAmt = Number(r.g_amt);
   const wAmt = Number(r.w_amt);
-  const at = Number(r.at_ms);
   if (r.g_color === base) {
-    // sell base: give base, want quote → price = quote/base
-    return { price: gAmt > 0 ? wAmt / gAmt : 0, amt: gAmt, at };
+    return { price: gAmt > 0 ? wAmt / gAmt : 0, amt: gAmt };
   }
-  // buy base: give quote, want base → price = quote/base
-  return { price: wAmt > 0 ? gAmt / wAmt : 0, amt: wAmt, at };
+  return { price: wAmt > 0 ? gAmt / wAmt : 0, amt: wAmt };
 }
-
-const HISTORY_SQL = `
-  SELECT (EXTRACT(EPOCH FROM h.archived_at) * 1000)::bigint AS at_ms,
-         g.token_color AS g_color, g.amount AS g_amt,
-         w.token_color AS w_color, w.amount AS w_amt
-  FROM offer_file_history h
-  JOIN offer_file_tokens_history g ON g.offer_file_id = h.id AND g.direction = 'GIVING'
-  JOIN offer_file_tokens_history w ON w.offer_file_id = h.id AND w.direction = 'WANTING'
-  WHERE h.archive_reason = 'CONSUMED'
-    AND ((g.token_color = $1 AND w.token_color = $2) OR (g.token_color = $2 AND w.token_color = $1))
-  ORDER BY h.archived_at DESC
-  LIMIT 120`;
-
-const OPEN_LEGS_SQL = `
-  SELECT g.token_color AS g_color, g.amount AS g_amt,
-         w.token_color AS w_color, w.amount AS w_amt
-  FROM offer_file o
-  JOIN offer_file_tokens g ON g.offer_file_id = o.id AND g.direction = 'GIVING'
-  JOIN offer_file_tokens w ON w.offer_file_id = o.id AND w.direction = 'WANTING'
-  WHERE ((g.token_color = $1 AND w.token_color = $2) OR (g.token_color = $2 AND w.token_color = $1))`;
 
 /** Trade history (newest first) built from consumed offers for this pair. */
 export async function realHistory(dbConn: any, base: string, quote: string): Promise<HistoryRow[]> {
-  const { rows } = await dbConn.query(HISTORY_SQL, [base, quote]);
-  const fills = (rows as LegRow[]).map((r) => toFill(r, base)).filter((f) => f.price > 0 && f.amt > 0);
-  // newest-first array; `up` compares each fill to the chronologically older one (next in the array).
+  const rows = await getTradeHistory.run({ base, quote }, dbConn);
+  const fills = rows.map((r) => ({
+    ...toFill(r, base),
+    at: Number(r.at_ms),
+  })).filter((f) => f.price > 0 && f.amt > 0);
   return fills.map((f, i) => ({
     price: f.price,
     amt: f.amt,
@@ -66,10 +44,10 @@ export async function realHistory(dbConn: any, base: string, quote: string): Pro
 
 /** Mid price from current open offers (best ask / best bid), 0 if none. */
 async function currentMid(dbConn: any, base: string, quote: string): Promise<number> {
-  const { rows } = await dbConn.query(OPEN_LEGS_SQL, [base, quote]);
-  const asks: number[] = []; // sell base (give base) → price quote/base
-  const bids: number[] = []; // buy base (give quote)
-  for (const r of rows as LegRow[]) {
+  const rows = await getOpenLegs.run({ base, quote }, dbConn);
+  const asks: number[] = [];
+  const bids: number[] = [];
+  for (const r of rows) {
     const f = toFill(r, base);
     if (f.price <= 0) continue;
     (r.g_color === base ? asks : bids).push(f.price);
@@ -89,7 +67,6 @@ export async function realStats(dbConn: any, base: string, quote: string): Promi
   const now = Date.now();
   const dayAgo = now - 86_400_000;
   const last = hist[0].price;
-  // reference price for 24h change: most recent fill older than 24h, else the oldest fill.
   const olderThanDay = hist.find((h) => Date.parse(h.at) < dayAgo);
   const ref = olderThanDay ? olderThanDay.price : hist[hist.length - 1].price;
   const change24 = ref > 0 ? ((last - ref) / ref) * 100 : 0;

--- a/templates/zswap-da/packages/tests/stm/api.test.ts
+++ b/templates/zswap-da/packages/tests/stm/api.test.ts
@@ -1,16 +1,249 @@
-// TODO: Restore Phase 3 (API flow) once the underlying browser/batcher swap
-// lifecycle is implemented — this test exercises /api/zswap/{create,submit,
-// :id/complete}, which currently call into the removed backend-wallet
-// completion path. The original 110-line implementation is preserved in git:
-// `git show HEAD:templates/zswap-da/e2e/run-tests.ts` (Phase 3, runApiTests
-// at lines 454-561).
+// API round-trip swap test folded into the Phase-B runner.
+// Mirrors api-roundtrip-swap-e2e.ts but uses the shared DB client and assert()
+// from helpers. Infra is already up when this runs (Phase A verified it).
+//
+// Flow: mint T0/T1 → fund P0/P1 makers → push offers via /api/zswap/submit
+//   → wait for Celestia indexing → read back from GET /api/zswaps
+//   → reconstruct from API blob → merge + settle via batcher
+//   → verify spent_nullifiers + archival + balances
+//   → negative: corrupted blob rejected; spent offer re-submit rejected.
 
 import type { Client } from "pg";
-import { assert } from "../helpers.ts";
+import { assert, API_PORT } from "../helpers.ts";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { encodeOffer } from "mip-zswap-offer";
+import { registerNightForDust } from "@effectstream/midnight-contracts";
+import { midnightNetworkConfig as net } from "@effectstream/midnight-contracts/midnight-env";
+import { joinOfferFiles, mintShielded } from "../lib/offer-files.ts";
+import {
+  buildWallet,
+  shieldedKeys,
+  transferShielded,
+  waitForShielded,
+  waitForSync,
+} from "../lib/wallet.ts";
+import {
+  describeImbalances,
+  mergeFinalized,
+  nonDustImbalances,
+  settleViaBatcher,
+} from "../lib/batcher.ts";
+import { getZswaps, reconstructOffer, submitOffer } from "../lib/api.ts";
 
-export async function apiTest(_db: Client): Promise<void> {
-  await assert(
-    "TODO: api flow — rewrite against browser/batcher flow",
-    async () => false,
-  );
+globalThis.WebSocket = WebSocket;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const SEP = { T0: 0xa0, T1: 0xa1 } as const;
+const MINT_AMOUNT = 1_000_000_000n;
+const FUND = 5_000_000n;
+const AMT = 1_000n;
+const P0_SEED = "0000000000000000000000000000000000000000000000000000000000000030";
+const P1_SEED = "0000000000000000000000000000000000000000000000000000000000000031";
+
+export async function apiTest(db: Client): Promise<void> {
+  setNetworkId(net.id as any);
+
+  const count = async (t: string): Promise<number> =>
+    Number((await db.query(`SELECT count(*)::int n FROM ${t}`)).rows[0].n);
+
+  async function waitFor(
+    fn: () => Promise<boolean>,
+    tries = 36,
+    ms = 5000,
+  ): Promise<boolean> {
+    for (let i = 0; i < tries; i++) {
+      if (await fn()) return true;
+      await sleep(ms);
+    }
+    return false;
+  }
+
+  async function submitAndWaitRoot(blob: string, label: string): Promise<{ status: number; body: any }> {
+    let sub = await submitOffer(blob);
+    for (let r = 0; r < 24 && sub.status === 400 && sub.body?.error === "ROOT_UNKNOWN"; r++) {
+      await sleep(5000);
+      sub = await submitOffer(blob);
+    }
+    await assert(`${label} accepted by submit gate`, async () => sub.status === 200);
+    return sub;
+  }
+
+  const TAG = "[api-roundtrip]";
+  console.log(`${TAG} building genesis + P0 + P1…`);
+  const genesis = await buildWallet(net.walletSeed);
+  const p0 = await buildWallet(P0_SEED);
+  const p1 = await buildWallet(P1_SEED);
+
+  try {
+    await waitForSync(genesis, { requireUnshieldedFunds: true });
+    try {
+      await registerNightForDust(genesis as any);
+    } catch (e) {
+      console.warn(
+        `${TAG} registerNightForDust: ${e instanceof Error ? e.message : String(e)} (continuing)`,
+      );
+    }
+    const p0Addr = await p0.wallet.shielded.getAddress();
+    const p1Addr = await p1.wallet.shielded.getAddress();
+
+    // Mint T0, T1; fund P0 with T0, P1 with T1
+    console.log(`${TAG} minting T0,T1 + funding makers…`);
+    const deployed = await joinOfferFiles(genesis);
+    const nonce = BigInt(Date.now());
+    const T0 = await mintShielded(deployed, SEP.T0, MINT_AMOUNT, nonce);
+    const T1 = await mintShielded(deployed, SEP.T1, MINT_AMOUNT, nonce + 1n);
+    for (const [c, l] of [[T0, "T0"], [T1, "T1"]] as const) {
+      if ((await waitForShielded(genesis, c, FUND, 24)) < FUND)
+        throw new Error(`genesis missing ${l}`);
+    }
+    await transferShielded(genesis, T0, FUND, p0Addr);
+    await transferShielded(genesis, T1, FUND, p1Addr);
+    const makersOk =
+      (await waitForShielded(p0, T0, AMT, 36)) >= AMT &&
+      (await waitForShielded(p1, T1, AMT, 36)) >= AMT;
+    await assert("makers funded", async () => makersOk);
+
+    // Build offers: P0 give T0 want T1; P1 give T1 want T0
+    const r0 = await p0.wallet.initSwap(
+      { shielded: { [T0]: AMT } },
+      [
+        {
+          type: "shielded",
+          outputs: [{ type: T1, amount: AMT, receiverAddress: p0Addr }],
+        } as any,
+      ],
+      shieldedKeys(p0),
+      { ttl: new Date(Date.now() + 30 * 60_000), payFees: false },
+    );
+    const blob0 = encodeOffer(
+      (await p0.wallet.finalizeTransaction(r0.transaction)).serialize(),
+    );
+    const r1 = await p1.wallet.initSwap(
+      { shielded: { [T1]: AMT } },
+      [
+        {
+          type: "shielded",
+          outputs: [{ type: T0, amount: AMT, receiverAddress: p1Addr }],
+        } as any,
+      ],
+      shieldedKeys(p1),
+      { ttl: new Date(Date.now() + 30 * 60_000), payFees: false },
+    );
+    const blob1 = encodeOffer(
+      (await p1.wallet.finalizeTransaction(r1.transaction)).serialize(),
+    );
+
+    // Push both offers via API → Celestia → indexed
+    const offersBefore = await count("offer_file");
+    console.log(`${TAG} pushing 2 offers via /api/zswap/submit…`);
+    await submitAndWaitRoot(blob0, "P0 offer (give T0 / want T1)");
+    await submitAndWaitRoot(blob1, "P1 offer (give T1 / want T0)");
+    const indexedOk = await waitFor(
+      async () => (await count("offer_file")) >= offersBefore + 2,
+      24,
+    );
+    await assert("2 offers indexed (reached Celestia + STM)", async () => indexedOk);
+
+    // Read back from API
+    console.log(`${TAG} reading available zswaps back from GET /api/zswaps…`);
+    const myColors = new Set([T0, T1]);
+    const apiOffers = (await getZswaps({ limit: 100 })).filter(
+      (o) =>
+        o.gives.some((g) => myColors.has(g.token)) ||
+        o.wants.some((w) => myColors.has(w.token)),
+    );
+    await assert("API returned my 2 offers", async () => apiOffers.length === 2);
+
+    const giveColors = new Set(apiOffers.flatMap((o) => o.gives.map((g) => g.token)));
+    const wantColors = new Set(apiOffers.flatMap((o) => o.wants.map((w) => w.token)));
+    await assert(
+      "API gives/wants reflect T0↔T1 swap",
+      async () =>
+        giveColors.has(T0) &&
+        giveColors.has(T1) &&
+        wantColors.has(T0) &&
+        wantColors.has(T1),
+    );
+
+    // Reconstruct each offer tx from the API blob (Celestia round-trip data)
+    console.log(`${TAG} reconstructing offers from API transaction_hex…`);
+    let reconstructed: ReturnType<typeof reconstructOffer>[];
+    try {
+      reconstructed = apiOffers.map((o) => reconstructOffer(o.transaction_hex));
+      await assert(
+        "reconstructed both offers from API blob",
+        async () => reconstructed.length === 2,
+      );
+    } catch (e) {
+      await assert("reconstructed both offers from API blob", async () => false);
+      return;
+    }
+
+    // Merge + settle via batcher
+    const merged = mergeFinalized(reconstructed);
+    console.log(`${TAG} merged (from API data) imbalances: ${describeImbalances(merged)}`);
+    await assert(
+      "merged tx from API data is token-balanced",
+      async () => nonDustImbalances(merged).length === 0,
+    );
+    const spentBefore = await count("spent_nullifiers");
+    const settle = await settleViaBatcher(merged);
+    await assert(
+      "batcher settled tx reconstructed from API/Celestia data",
+      async () => settle.ok,
+    );
+
+    const spentOk = await waitFor(
+      async () => (await count("spent_nullifiers")) >= spentBefore + 2,
+      36,
+    );
+    await assert(
+      "spent_nullifiers grew by 2 (both offers consumed)",
+      async () => spentOk,
+    );
+
+    const ids = apiOffers.map((o) => o.id).join(",");
+    const archivedOk = await waitFor(
+      async () =>
+        (await db.query(`SELECT id FROM offer_file WHERE id IN (${ids})`)).rows.length === 0,
+      36,
+    );
+    await assert("both offers archived after settlement", async () => archivedOk);
+    await assert("P0 received T1", async () => (await waitForShielded(p0, T1, AMT, 24)) >= AMT);
+    await assert("P1 received T0", async () => (await waitForShielded(p1, T0, AMT, 24)) >= AMT);
+
+    // ── NEGATIVE 1: corrupted blob rejected and never reaches Celestia ──
+    console.log(`${TAG} NEGATIVE: submitting a corrupted offer blob…`);
+    const beforeBad1 = await count("offer_file");
+    const corrupted = blob0.slice(0, blob0.length - 12) + "deadbeef0000";
+    const badRes1 = await submitOffer(corrupted);
+    await assert(
+      "corrupted offer rejected at submit (400)",
+      async () => badRes1.status === 400,
+    );
+    await sleep(8000);
+    await assert(
+      "corrupted offer NEVER reached Celestia (not indexed)",
+      async () => (await count("offer_file")) === beforeBad1,
+    );
+
+    // ── NEGATIVE 2: re-submit a consumed offer → NULLIFIER_SPENT ──
+    console.log(`${TAG} NEGATIVE: re-submitting the already-settled P0 offer…`);
+    const beforeBad2 = await count("offer_file");
+    const badRes2 = await submitOffer(blob0);
+    await assert(
+      "spent-offer re-submit rejected (NULLIFIER_SPENT)",
+      async () =>
+        badRes2.status === 400 && badRes2.body?.error === "NULLIFIER_SPENT",
+    );
+    await sleep(8000);
+    await assert(
+      "spent-offer re-submit NEVER reached Celestia (not indexed)",
+      async () => (await count("offer_file")) === beforeBad2,
+    );
+  } finally {
+    await p0.wallet.stop().catch(() => {});
+    await p1.wallet.stop().catch(() => {});
+    await genesis.wallet.stop().catch(() => {});
+  }
 }

--- a/templates/zswap-da/packages/tests/stm/zswap-flow.test.ts
+++ b/templates/zswap-da/packages/tests/stm/zswap-flow.test.ts
@@ -1,22 +1,202 @@
-// The full swap lifecycle is implemented in ../full-lifecycle-e2e.ts (and the
-// gate-focused ../liveness-e2e.ts): headless offer (`initSwap` +
-// `finalizeTransaction` → the <Sig, Proof, Binding> shape the indexer accepts)
-// → /api/zswap/submit (crypto + liveness + root-known) → batcher → Celestia →
-// celestia-zswap ingestion (re-validated) → indexed →
-// `balanceFinalizedTransaction` settle on Midnight → nullifier consumed →
-// offer ARCHIVED (CONSUMED). Run it with the dev orchestrator up:
+// Full swap lifecycle folded into the Phase-B runner.
+// Mirrors full-lifecycle-e2e.ts but uses the shared DB client and assert()
+// from helpers. Infra is already up when this runs (Phase A verified it).
 //
-//   bun packages/tests/full-lifecycle-e2e.ts
-//
-// TODO: fold full-lifecycle-e2e.ts into this phase-B runner (it currently
-// assumes the dev orchestrator rather than the start.test.ts infra).
+// Flow: mint test tokens → build genesis wallet → create A↔B offer
+//   → /api/zswap/submit → wait for Celestia indexing
+//   → balance + settle on Midnight → nullifier consumed → offer ARCHIVED.
 
 import type { Client } from "pg";
-import { assert } from "../helpers.ts";
+import { assert, API_PORT } from "../helpers.ts";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { Transaction } from "@midnight-ntwrk/ledger-v8";
+import { decodeOffer, encodeOffer } from "mip-zswap-offer";
+import { buildWalletAndWaitForFunds } from "@effectstream/midnight-contracts";
+import { midnightNetworkConfig as net } from "@effectstream/midnight-contracts/midnight-env";
+import { mintTestTokens } from "../../contracts-midnight/mint-test-tokens.ts";
 
-export async function zswapFlowTest(_db: Client): Promise<void> {
-  await assert(
-    "TODO: run full-lifecycle-e2e.ts under the test launcher (see packages/tests/full-lifecycle-e2e.ts)",
-    async () => false,
+globalThis.WebSocket = WebSocket;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const GIVE_AMOUNT = 500_000n;
+const WANT_AMOUNT = 750_000n;
+
+export async function zswapFlowTest(db: Client): Promise<void> {
+  setNetworkId(net.id as any);
+
+  const API = `http://127.0.0.1:${API_PORT}`;
+
+  const count = async (t: string): Promise<number> =>
+    Number((await db.query(`SELECT count(*)::int n FROM ${t}`)).rows[0].n);
+
+  async function waitFor(
+    name: string,
+    fn: () => Promise<boolean>,
+    tries = 36,
+    ms = 5000,
+  ): Promise<boolean> {
+    for (let i = 0; i < tries; i++) {
+      if (await fn()) return true;
+      await sleep(ms);
+    }
+    console.log(`  (waitFor "${name}" timed out after ${(tries * ms) / 1000}s)`);
+    return false;
+  }
+
+  async function submitOfferHttp(blob: string): Promise<{ status: number; body: any }> {
+    const r = await fetch(`${API}/api/zswap/submit`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ blob }),
+    });
+    let body: any;
+    try {
+      body = await r.json();
+    } catch {
+      body = await r.text();
+    }
+    return { status: r.status, body };
+  }
+
+  const before = {
+    known_roots: await count("known_roots"),
+    created_unshielded: await count("created_unshielded"),
+    spent_nullifiers: await count("spent_nullifiers"),
+    offers: await count("offer_file"),
+  };
+  console.log("[lifecycle] before:", JSON.stringify(before));
+
+  // ── 1. Mint test tokens ──
+  console.log("[lifecycle] minting test tokens via the offer-files contract…");
+  const colors = await mintTestTokens();
+  console.log("[lifecycle] minted colors:", JSON.stringify(colors));
+  const createdOk = await waitFor(
+    "created_unshielded > 0",
+    async () => (await count("created_unshielded")) > 0,
+    24,
   );
+  await assert("created_unshielded populated (UnshieldedCreate primitive live)", async () => createdOk);
+
+  // ── 2. Build genesis wallet and wait for minted colors ──
+  console.log("[lifecycle] building genesis wallet…");
+  const result = await buildWalletAndWaitForFunds(
+    {
+      id: net.id,
+      indexer: net.indexer,
+      indexerWS: net.indexerWS,
+      node: net.node,
+      proofServer: net.proofServer,
+    } as any,
+    net.walletSeed,
+    net.id as any,
+  );
+  const { wallet, zswapSecretKeys, dustSecretKey } = result;
+  const keys = { shieldedSecretKeys: zswapSecretKeys, dustSecretKey };
+
+  try {
+    const haveMinted = await waitFor(
+      "wallet sees minted colors",
+      async () => {
+        const st = await wallet.shielded.waitForSyncedState();
+        const b = st.balances as Record<string, bigint>;
+        return (b[colors.shieldedA] ?? 0n) >= GIVE_AMOUNT && (b[colors.shieldedB] ?? 0n) > 0n;
+      },
+      24,
+    );
+    await assert("genesis wallet holds both minted shielded colors", async () => haveMinted);
+
+    const address = await wallet.shielded.getAddress();
+    const recipe = await wallet.initSwap(
+      { shielded: { [colors.shieldedA]: GIVE_AMOUNT } },
+      [
+        {
+          type: "shielded",
+          outputs: [{ type: colors.shieldedB, amount: WANT_AMOUNT, receiverAddress: address }],
+        } as any,
+      ],
+      keys,
+      { ttl: new Date(Date.now() + 30 * 60_000), payFees: false },
+    );
+    const offerFinalized = await wallet.finalizeTransaction(recipe.transaction);
+    const blob = encodeOffer(offerFinalized.serialize());
+    console.log(
+      `[lifecycle] offer: give ${GIVE_AMOUNT} of A(${colors.shieldedA.slice(0, 8)}…), ` +
+        `want ${WANT_AMOUNT} of B(${colors.shieldedB.slice(0, 8)}…)`,
+    );
+
+    // ── 3. Submit → batcher → Celestia ──
+    let sub = await submitOfferHttp(blob);
+    for (let r = 0; r < 24 && sub.status === 400 && sub.body?.error === "ROOT_UNKNOWN"; r++) {
+      await sleep(5000);
+      sub = await submitOfferHttp(blob);
+    }
+    await assert(
+      "offer accepted by submit gate (crypto + liveness + root-known)",
+      async () => sub.status === 200,
+    );
+
+    // ── 4. Indexed by celestia-zswap ──
+    const indexedOk = await waitFor(
+      "offer indexed",
+      async () => (await count("offer_file")) > before.offers,
+      24,
+    );
+    await assert("offer indexed via Celestia → STM ingestion", async () => indexedOk);
+    if (!indexedOk) return;
+
+    const offerRow = (
+      await db.query("SELECT id FROM offer_file ORDER BY id DESC LIMIT 1")
+    ).rows[0];
+    if (!offerRow) return;
+
+    // ── 5. Taker settles: balance + submit to Midnight ──
+    console.log("[lifecycle] balancing + settling the A↔B offer on Midnight…");
+    const offerTx = Transaction.deserialize("signature", "proof", "binding", decodeOffer(blob));
+    const balRecipe = await (wallet as any).balanceFinalizedTransaction(offerTx, keys, {
+      ttl: new Date(Date.now() + 30 * 60_000),
+    });
+    const settleTx = await wallet.finalizeRecipe(balRecipe);
+    await (wallet as any).submitTransaction(settleTx);
+    console.log(
+      "[lifecycle] settle submitted:",
+      settleTx.transactionHash?.().toString?.().slice(0, 24) ?? "(tx)",
+    );
+
+    // ── 6. Nullifier consumed → spent_nullifiers + offer archived ──
+    const spentOk = await waitFor(
+      "spent_nullifiers > before",
+      async () => (await count("spent_nullifiers")) > before.spent_nullifiers,
+      36,
+    );
+    await assert("spent_nullifiers populated (Nullifier primitive live)", async () => spentOk);
+
+    const archivedOk = await waitFor(
+      "offer archived",
+      async () => {
+        const active = (await db.query("SELECT id FROM offer_file WHERE id = $1", [offerRow.id])).rows;
+        const hist = (
+          await db.query("SELECT id FROM offer_file_history WHERE id = $1", [offerRow.id])
+        ).rows;
+        return active.length === 0 && hist.length === 1;
+      },
+      24,
+    );
+    await assert("offer ARCHIVED after settlement (lifecycle closed)", async () => archivedOk);
+
+    // ── 7. Root advanced ──
+    const rootsNow = await count("known_roots");
+    await assert(
+      "known_roots advanced (ZswapRoot primitive live)",
+      async () => rootsNow > before.known_roots,
+    );
+
+    const after = {
+      known_roots: await count("known_roots"),
+      created_unshielded: await count("created_unshielded"),
+      spent_nullifiers: await count("spent_nullifiers"),
+    };
+    console.log("[lifecycle] after:", JSON.stringify(after));
+  } finally {
+    await wallet.stop().catch(() => {});
+  }
 }


### PR DESCRIPTION
## Summary

- **pair_stats table** (`004-pair-stats.sql`): write-side projection updated after each `CONSUMED` archive via `offer_consumed` event listener in `apiRouter`. Avoids `World.resolve` incompatibility — the state machine generator can't call plain-object wrappers directly, so the listener pattern decouples it cleanly.
- **GET /api/pairs**: O(1) pair list from `pair_stats` FULL OUTER JOINed with live open-offer counts. Includes historical pairs with 0 open orders.
- **GET /api/zswap/status?blob=**: single-blob status lookup (`open` / `completed` / `expired` / `not_found`) for My Trades startup reconciliation.
- **Typed SQL query wrappers** (`queries.app.ts`): 15 typed wrappers replacing all raw `dbConn.query()` calls across `sync-health.ts`, `trade-data.ts`, and `api.ts`. Mirrors `PreparedQuery.run()` interface; can be replaced by proper pgtyped output once a live DB is available for `pgtyped:update`.
- **My Trades status machine**: `not_public → open → completed / expired`. Creation starts as `not_public`; promoted to `open` when blob first appears in live order book; server confirms `completed`/`expired` on startup.
- **Startup-only reconciliation**: on mount, fetches server statuses for all non-terminal created trades (no polling, no `visibilitychange`).
- **Market pairs list**: replaced live-orders-only `useMemo` with `/api/pairs` fetch (30s refresh). Historical pairs (no current open orders) show dimmed. Live-only pairs (not yet in pair_stats) fall back to the order set.

## Test plan

- [ ] `GET /api/pairs` returns known pairs after at least one offer has been consumed
- [ ] `GET /api/zswap/status?blob=<hex>` returns `{ blob, status: "open" }` for a live offer
- [ ] After an offer is consumed, `/api/zswap/status` returns `"completed"` and My Trades updates on next startup
- [ ] Creating a new offer shows `Not public` badge; transitions to `Open` when visible in the order book
- [ ] Market page shows pairs with 0 open orders dimmed (historical only)
- [ ] Expired filter tab in My Trades shows offers whose TTL elapsed