### PR TITLE
perf(sync/celestia): concurrent worker pool + timeout-guarded blob.GetAll

### DIFF
--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/celestia/rpc.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/celestia/rpc.ts
@@ -32,6 +32,11 @@ export const ConfigSyncProtocolSchemaCelestiaBase = NameField.cloneMerge(
   }),
   optional: Type.Object({
     stepSize: Type.Number({ default: 10 }),
+    // Number of heights fetched concurrently within each window.
+    // Default 1 preserves the original serial behaviour for deployments that
+    // do not set this explicitly. Set to 8–16 for Mocha/mainnet to overlap the
+    // ~10% of blob.GetAll calls that stall on shrex share retrieval.
+    concurrency: Type.Number({ default: 1 }),
   }),
 });
 

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/CelestiaClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/CelestiaClient.ts
@@ -54,6 +54,12 @@ const CELESTIA_NODE_URL = ENV.getString(
   "http://localhost:26658",
 );
 const CELESTIA_AUTH_TOKEN = ENV.getString("CELESTIA_AUTH_TOKEN", "");
+const CELESTIA_RPC_TIMEOUT_MS = parseInt(
+  ENV.getString("CELESTIA_RPC_TIMEOUT_MS", "15000"),
+);
+const CELESTIA_RPC_RETRIES = parseInt(
+  ENV.getString("CELESTIA_RPC_RETRIES", "3"),
+);
 
 /**
  * Converts a hex-encoded Celestia namespace to a base64-encoded 29-byte array.
@@ -80,29 +86,41 @@ export class CelestiaClient {
   }
 
   private async rpc<T>(method: string, params: unknown[]): Promise<T | null> {
-    let res: Response;
-    try {
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
-      if (CELESTIA_AUTH_TOKEN) headers["Authorization"] = `Bearer ${CELESTIA_AUTH_TOKEN}`;
-      res = await fetch(this.rpcUrl, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-      });
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[Celestia] RPC fetch error [${method}]: ${msg}`);
-      return null;
-    }
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= CELESTIA_RPC_RETRIES; attempt++) {
+      let res: Response;
+      try {
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        if (CELESTIA_AUTH_TOKEN) headers["Authorization"] = `Bearer ${CELESTIA_AUTH_TOKEN}`;
+        res = await fetch(this.rpcUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+          signal: AbortSignal.timeout(CELESTIA_RPC_TIMEOUT_MS),
+        });
+      } catch (err: unknown) {
+        // Network or timeout error — retry up to CELESTIA_RPC_RETRIES times.
+        lastErr = err;
+        continue;
+      }
 
-    const json = await res.json();
-    if (json.error) {
-      const errMsg: string = json.error.message ?? String(json.error);
-      if (errMsg.includes("blob: not found")) return null;
-      console.error(`[Celestia] RPC error [${method}]:`, errMsg);
-      return null;
+      const json = await res.json();
+      if (json.error) {
+        const errMsg: string = json.error.message ?? String(json.error);
+        // Genuine empty namespace: not an error, return null so callers map to [].
+        if (errMsg.includes("blob: not found")) return null;
+        // Deterministic RPC errors won't improve on retry — throw immediately.
+        throw new Error(`[Celestia] RPC error [${method}]: ${errMsg}`);
+      }
+      return json.result as T;
     }
-    return json.result as T;
+    // All retries exhausted. Throw so the batch fails and the driver retries the
+    // whole window — never return null/[] here, which would silently drop a block.
+    throw new Error(
+      `[Celestia] ${method} failed after ${CELESTIA_RPC_RETRIES + 1} attempts: ${
+        lastErr instanceof Error ? lastErr.message : String(lastErr)
+      }`,
+    );
   }
 
   async getLatestBlockHeight(): Promise<number> {

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/fetcher.ts
@@ -51,44 +51,49 @@ export class CelestiaFetcher extends BaseDataFetcher<
       (p) => p.primitive.getAllBlockHeaders,
     );
 
+    const heights: number[] = [];
+    for (let h = data.from; h <= data.to; h++) heights.push(h);
+
     console.log(
-      `[Celestia] Fetching blocks from ${data.from} to ${data.to}.${
+      `[Celestia] Fetching blocks from ${data.from} to ${data.to} (${heights.length} blocks, concurrency=${(this.config.syncProtocol as any).concurrency ?? 1}).${
         data.isPresync ? " [presync]" : ""
       }`,
     );
 
-    let lastFetchedOutput: Output | undefined;
-    for (let height = data.from; height <= data.to; height++) {
-      let extHeader;
-      try {
-        extHeader = yield* call(() =>
-          this.client.getHeaderAtHeight(height)
-        );
-      } catch (_e) {
-        break;
+    const results: (Output | undefined)[] = new Array(heights.length);
+    let cursor = 0;
+    const concurrency: number = (this.config.syncProtocol as any).concurrency ?? 1;
+    const self = this;
+
+    // Each worker pulls the next unstarted height from `cursor` and stores the
+    // result at the corresponding index so output order is always height-ascending.
+    // The cursor increment is cooperative-race-free in effection: it runs
+    // synchronously before the first yield in each worker iteration.
+    function* worker(): Operation<void> {
+      while (true) {
+        const i = cursor++;
+        if (i >= heights.length) return;
+        const height = heights[i];
+        const extHeader = yield* call(() => self.client.getHeaderAtHeight(height));
+        const blockHash = extHeader.commit.block_id.hash;
+        const primitives = yield* self.readPrimitives(height, blockHash, self.config.primitives);
+        results[i] = { timestamp: extHeader.header.time, height, hash: blockHash, primitives };
       }
+    }
 
-      const blockHash = extHeader.commit.block_id.hash;
-
-      const primitives = yield* this.readPrimitives(
-        height,
-        blockHash,
-        this.config.primitives,
+    if (heights.length > 0) {
+      yield* all(
+        Array.from({ length: Math.min(concurrency, heights.length) }, () => worker()),
       );
+    }
 
-      const output: Output = {
-        timestamp: extHeader.header.time,
-        height,
-        hash: blockHash,
-        primitives,
-      };
+    let lastFetchedOutput: Output | undefined;
+    for (let i = 0; i < results.length; i++) {
+      const output = results[i];
+      if (!output) continue;
       lastFetchedOutput = output;
-
-      if (fetchAllBlocks || primitives.length > 0 || height === data.to) {
-        outputs.push({
-          output,
-          cleanup: () => {},
-        });
+      if (fetchAllBlocks || output.primitives.length > 0 || output.height === data.to) {
+        outputs.push({ output, cleanup: () => {} });
       }
     }
 

--- a/templates/zswap-da/packages/node/config.dev.ts
+++ b/templates/zswap-da/packages/node/config.dev.ts
@@ -16,9 +16,11 @@ import { OfferFilesContract } from "@zswap-da/contract-offer-files";
 import { getConnection } from "@effectstream/db";
 
 import {
+  CELESTIA_FETCH_CONCURRENCY,
   CELESTIA_NAMESPACE,
   CELESTIA_POLLING_INTERVAL_MS,
   CELESTIA_RPC_URL,
+  CELESTIA_STEP_SIZE,
   midnightContract,
 } from "./env.ts";
 
@@ -100,6 +102,8 @@ export const config = new ConfigBuilder()
           pollingInterval: CELESTIA_POLLING_INTERVAL_MS,
           delayMs: 12_000,
           confirmationDepth: 1,
+          stepSize: CELESTIA_STEP_SIZE,
+          concurrency: CELESTIA_FETCH_CONCURRENCY,
         }),
       )
   )

--- a/templates/zswap-da/packages/node/config.mainnet.ts
+++ b/templates/zswap-da/packages/node/config.mainnet.ts
@@ -18,11 +18,13 @@ import { getConnection } from "@effectstream/db";
 
 import {
   CELESTIA_AUTH_TOKEN,
+  CELESTIA_FETCH_CONCURRENCY,
   CELESTIA_NAMESPACE,
   CELESTIA_NETWORK,
   CELESTIA_POLLING_INTERVAL_MS,
   CELESTIA_RPC_URL,
   CELESTIA_START_HEIGHT,
+  CELESTIA_STEP_SIZE,
   midnightContract,
 } from "./env.ts";
 
@@ -158,6 +160,8 @@ export const config = new ConfigBuilder()
           pollingInterval: CELESTIA_POLLING_INTERVAL_MS,
           delayMs: 12_000,
           confirmationDepth: 1,
+          stepSize: CELESTIA_STEP_SIZE,
+          concurrency: CELESTIA_FETCH_CONCURRENCY,
         }),
       )
   )

--- a/templates/zswap-da/packages/node/env.ts
+++ b/templates/zswap-da/packages/node/env.ts
@@ -9,6 +9,12 @@ export const CELESTIA_GAS_LIMIT = parseInt(getEnv("CELESTIA_GAS_LIMIT") ?? "1000
 export const CELESTIA_AUTH_TOKEN = getEnv("CELESTIA_AUTH_TOKEN") ?? "";
 export const CELESTIA_NETWORK = getEnv("CELESTIA_NETWORK") ?? "devnet";
 export const CELESTIA_START_HEIGHT = getEnv("CELESTIA_START_HEIGHT");
+// Concurrent fetcher knobs — see packages/sync celestia/fetcher.ts.
+// stepSize controls how many blocks are batched per fetch window;
+// concurrency controls how many heights are fetched in parallel within each window.
+// Both default to values safe for Mocha-4 (~21 blocks/min with ~10% stalls).
+export const CELESTIA_STEP_SIZE = parseInt(getEnv("CELESTIA_STEP_SIZE") ?? "200");
+export const CELESTIA_FETCH_CONCURRENCY = parseInt(getEnv("CELESTIA_FETCH_CONCURRENCY") ?? "12");
 
 // Local batcher endpoint for forwarding zswap blob submissions.
 export const BATCHER_SUBMIT_URL = getEnv("BATCHER_SUBMIT_URL") ??


### PR DESCRIPTION
## Problem

Against Mocha-4 (and any Celestia light node), `~10%` of `blob.GetAll` calls stall for **tens of seconds** — shrex share retrieval intermittently hangs with no client-side timeout. Because `CelestiaFetcher.readData` fetches serially, every stall blocks the line and sustained throughput collapses to **~8–20 blocks/min < Mocha's ~21/min**. The indexer falls behind without bound.

## Changes

### 1. `packages/sync` — bounded concurrent worker pool in `readData`
Replace the serial `for` loop with **N effection workers** that pull the next height from a shared cursor (cooperative, race-free) and store results in a position-indexed array so output is always height-ascending. With `concurrency=12` and `stepSize=200` the ~10% stalls overlap instead of serialise; expected throughput ~150 blocks/min.

### 2. `packages/sync` — timeout + bounded retries in `CelestiaClient.rpc`
- `AbortSignal.timeout(CELESTIA_RPC_TIMEOUT_MS)` on every `fetch` (default **15 s**).
- Retry network/timeout errors up to `CELESTIA_RPC_RETRIES` times (default **3**).
- **Correctness invariant preserved**: `"blob: not found"` → `null` → `[]` (genuine empty namespace). Any other failure after retries → **throw** (never silent `[]`). A wedged request must never be treated as "no blobs found" — that would silently drop a block.

### 3. `packages/config` — optional `concurrency` schema field
Default `1` → serial, preserving existing behaviour for all deployments that don't opt in.

### 4. `templates/zswap-da` — wire the knobs from env
`env.ts`: `CELESTIA_STEP_SIZE` (default `200`), `CELESTIA_FETCH_CONCURRENCY` (default `12`).
Both `config.dev.ts` and `config.mainnet.ts` pass them to the `parallelCelestia` block.

## Tuning (env vars, no rebuild needed)
| Var | Default | Notes |
|---|---|---|
| `CELESTIA_STEP_SIZE` | `200` | Heights per fetch window |
| `CELESTIA_FETCH_CONCURRENCY` | `12` | Workers per window |
| `CELESTIA_RPC_TIMEOUT_MS` | `15000` | Per-request timeout |
| `CELESTIA_RPC_RETRIES` | `3` | Retries on network/timeout |

## Verify (on a live Mocha deployment)
Watch `celestia.lag_blocks` decrease over time:
```bash
curl -s http://127.0.0.1:9999/api/health/sync | jq '{celestia, ntp: {lag_seconds: .ntp.lag_seconds}}'
```
Acceptance: `celestia.lag_blocks` trends toward 0; `ntp.lag_seconds` trends toward 0.

## Notes
- Error semantics change: the old serial loop `break`-ed on a header error (silent truncation). The pool throws, so the driver retries the whole window after `pollingInterval`. This is strictly safer.
- Over-concurrency can worsen shrex contention. If throughput regresses, lower `CELESTIA_FETCH_CONCURRENCY` (try 8). The env knob allows tuning without a rebuild.
- Other parallel protocols (EVM, NEAR, Avail) have the same serial pattern; this scopes only Celestia.