### PR TITLE
feat(zswap-da): Celestia concurrent fetch + API docs + api-examples + TokenChip

### DIFF
--- a/templates/zswap-da/API.md
+++ b/templates/zswap-da/API.md
@@ -2,16 +2,69 @@
 
 ZSwap-DA is a dual-chain indexer and offer relay for shielded DEX swaps. It watches two chains simultaneously — **Midnight** (shielded settlement) and **Celestia** (decentralised data availability) — and presents a single REST API for reading live swap offers and writing new ones.
 
-This document is for application developers building on top of the service. It covers the node API (port **9999**) and the batcher API (port **3334**).
+This document targets application developers who want to interact with the endpoints directly, submit ZSwap offers to Celestia, or drive settlement transactions on Midnight programmatically.
+
+---
+
+## Environments
+
+Three configurations ship out of the box. All endpoints and env-var names are identical across environments; only the values differ.
+
+| | **Undeployed (local dev)** | **Preview** | **Mainnet** |
+|---|---|---|---|
+| `MIDNIGHT_NETWORK_ID` | `undeployed` | `preview` | `mainnet` |
+| `CELESTIA_NETWORK` | `devnet` | `mocha` | `mainnet` |
+| `CELESTIA_RPC_URL` | `http://127.0.0.1:26658` | QuickNode Mocha-4 URL | QuickNode / self-hosted |
+| `CELESTIA_POLLING_INTERVAL_MS` | `6000` | `3000` | `30000` |
+| `CELESTIA_START_HEIGHT` | `1` | `10620000` ¹ | set to your deployment block |
+| `MIDNIGHT_START_BLOCK` | `1` | `1` | set to your deployment block |
+| `OFFER_TTL_SECONDS` | `2592000` (30 d) | `3600` ² | `3600` ² |
+| Node API port | `9999` | `9999` | `9999` |
+| Batcher port | `3334` | `3334` | `3334` |
+| Config file | `config.dev.ts` | `config.preview.ts` | `config.mainnet.ts` |
+
+¹ Mocha-4 block equivalent to Midnight Preview genesis (2026-03-25T01:05:42 UTC).  
+² Preview and Mainnet use a ~1-hour Merkle-root window. Offers proving against an expired root cannot settle; matching `OFFER_TTL_SECONDS` to the root window prevents the indexer from serving un-fillable offers.
+
+### Environment variables (complete reference)
+
+```bash
+# ── Celestia ────────────────────────────────────────────────────────────────
+CELESTIA_NETWORK=devnet|mocha|mainnet    # selects polling-interval default
+CELESTIA_RPC_URL=http://...              # light-node JSON-RPC endpoint
+CELESTIA_NAMESPACE=000000000000deadbeef # 10-byte hex namespace (no 0x prefix)
+CELESTIA_AUTH_TOKEN=                    # bearer token; leave empty for QuickNode (auth is in the URL)
+CELESTIA_START_HEIGHT=1                 # skip blocks before your deployment
+CELESTIA_POLLING_INTERVAL_MS=6000       # how often to poll for new blocks
+CELESTIA_STEP_SIZE=200                  # blocks per fetch window
+CELESTIA_FETCH_CONCURRENCY=12           # parallel RPC calls per window
+
+# ── Midnight ─────────────────────────────────────────────────────────────────
+MIDNIGHT_NETWORK_ID=undeployed|preview|mainnet
+MIDNIGHT_CONTRACT_ADDRESS=mn1...        # required on preview/mainnet
+MIDNIGHT_START_BLOCK=1
+MIDNIGHT_DELAY_MS=30000                 # indexer poll delay
+
+# ── NTP timing ────────────────────────────────────────────────────────────────
+NTP_START_TIME=1774400742000            # epoch anchor (ms); default = Preview block 1
+BLOCK_TIME_MS=600000                    # 10 min/block keeps catch-up short
+NTP_STEP_SIZE=1000
+
+# ── Node ──────────────────────────────────────────────────────────────────────
+EFFECTSTREAM_API_PORT=9999
+BATCHER_SUBMIT_URL=http://127.0.0.1:3334
+OFFER_TTL_SECONDS=2592000               # offer lifetime (seconds)
+OFFER_MAX_BYTES=1048576                 # max decoded offer size (DoS guard)
+ROOT_WINDOW_SECONDS=1209600             # known-roots retention window (14 days default)
+SEEN_NULLIFIER_TTL_SECONDS=2592000      # prune unmatched nullifier rows after N seconds
+```
 
 ---
 
 ## How it works (indexer overview)
 
-ZSwap-DA runs two parallel indexers stitched together by a wall-clock NTP block:
-
 ```
-Celestia DA (Mocha-4)          Midnight (Preview)
+Celestia DA                    Midnight
      │                               │
      │  every blob in namespace      │  every block: nullifiers,
      │  → decoded as zswapoffer1…    │  unshielded UTXOs, Merkle roots
@@ -23,20 +76,18 @@ Celestia DA (Mocha-4)          Midnight (Preview)
          │  nullifiers  (spent coins)  │
          │  known_roots (root window)  │
          └────────────┬────────────────┘
-                      │  REST API
+                      │  REST API  :9999
                       ▼
                your application
 ```
 
 **Offer lifecycle:**
 
-1. A maker encodes a `zswapoffer1…` blob (ZSwap binary format) and POSTs it to `/api/zswap/submit`.
+1. A maker encodes a `zswapoffer1…` blob and POSTs it to `/api/zswap/submit`.
 2. The node validates it, then forwards it to the batcher which publishes it as a Celestia blob.
-3. The Celestia indexer sees the blob and re-validates it deterministically. On success the offer lands in `offer_file`.
-4. When any input coin of the offer is spent on Midnight (nullifier seen or unshielded UTXO consumed), the offer is moved to `offer_file_history` with `archive_reason = 'CONSUMED'`.
-5. If no consumption is observed before the offer's TTL expires, a scheduled cleanup moves it to history with `archive_reason = 'TTL'`.
-
-Makers do not need wallets or direct chain access to read data — the node API is fully public.
+3. The Celestia indexer picks up the blob and re-validates it deterministically. On success the offer lands in `offer_file`.
+4. When any input coin is spent on Midnight (nullifier seen or unshielded UTXO consumed), the offer moves to `offer_file_history` with `archive_reason = 'CONSUMED'`.
+5. If no consumption is observed before the TTL, a scheduled cleanup archives it with `archive_reason = 'TTL'`.
 
 ---
 
@@ -46,11 +97,29 @@ Base URL: `http://<host>:9999`
 
 ---
 
-### Sync health
+### Health
+
+#### `GET /health`
+
+Framework-level liveness probe. Returns `200 OK` as soon as the HTTP server is up, regardless of sync state.
+
+```bash
+curl http://host:9999/health
+```
+
+```json
+{ "status": "ok" }
+```
+
+---
 
 #### `GET /api/health/sync`
 
-Shows the current sync progress of each chain indexer. Use this to know whether the node is serving live data or still catching up with history.
+Per-protocol sync progress. Use this to confirm the node is serving live data before submitting offers.
+
+```bash
+curl http://host:9999/api/health/sync
+```
 
 **Response**
 
@@ -82,18 +151,12 @@ Shows the current sync progress of each chain indexer. Use this to know whether 
 
 | Field | Description |
 |---|---|
-| `status` | `"ok"` — within 2 NTP blocks of real time (≤ 20 min lag); `"syncing"` — catching up with history; `"error"` — no blocks finalized yet |
-| `ntp.current` | Last finalized internal (NTP) block |
-| `ntp.tip` | Current wall-clock NTP block |
-| `ntp.lag_seconds` | How many seconds of history remain to process |
-| `midnight.current` | Last Midnight block merged into a finalized NTP block |
-| `midnight.fetched` | Latest Midnight block prefetched into the buffer |
-| `midnight.tip` | Live Midnight chain tip (fetched from the indexer, cached 60 s; `null` if unreachable) |
-| `celestia.current` | Last Celestia block merged |
-| `celestia.fetched` | Latest Celestia block in the prefetch buffer |
-| `celestia.tip` | Live Celestia chain tip (fetched from QuickNode, cached 60 s; `null` if unreachable) |
+| `status` | `"ok"` — within 2 NTP blocks of real time (≤ 20 min lag); `"syncing"` — catching up; `"error"` — no blocks finalized yet |
+| `ntp.lag_seconds` | Seconds of history remaining to process |
+| `midnight.tip` | Live Midnight chain tip (cached 60 s; `null` if unreachable) |
+| `celestia.tip` | Live Celestia chain tip (cached 60 s; `null` if unreachable) |
 
-During the initial sync `lag_seconds` can be several million seconds (89 days of Midnight history). Full sync takes approximately 4 hours on a fresh database.
+On a fresh database the initial sync of 89 days of Midnight history takes approximately 4 hours.
 
 ---
 
@@ -101,14 +164,14 @@ During the initial sync `lag_seconds` can be several million seconds (89 days of
 
 #### `GET /api/zswaps`
 
-Returns the current live offer book — offers that have been published to Celestia, validated, and not yet consumed or expired.
+Returns the current live offer book — offers published to Celestia, validated, and not yet consumed or expired.
 
 **Query parameters**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `token` | hex string | — | Filter to offers that include this token color (64 hex chars). Returns both GIVING and WANTING sides. |
-| `direction` | `GIVING` \| `WANTING` | any | Filter by which side the token appears on. Only meaningful when `token` is also set. |
+| `token` | hex string | — | Filter to offers that include this token color (64 hex chars, no `0x`). Matches both giving and wanting sides. |
+| `direction` | `GIVING` \| `WANTING` | any | Filter by side. Only meaningful when `token` is also set. |
 | `limit` | integer | 100 | Max results (capped at 100). |
 | `offset` | integer | 0 | Pagination offset. |
 
@@ -122,13 +185,13 @@ Returns the current live offer book — offers that have been published to Celes
     "transaction_hex": "zswapoffer1...",
     "metadata_created_at": "2026-06-01T12:00:00.000Z",
     "metadata_expires_at": null,
-    "ttl_seconds": 2592000,
+    "ttl_seconds": 3600,
     "created_at": "2026-06-01T12:00:05.123Z",
     "gives": [
-      { "token": "0000...0001", "amount": "1000000" }
+      { "token": "0000000000000000000000000000000000000000000000000000000000000000", "amount": "1000000" }
     ],
     "wants": [
-      { "token": "0000...0002", "amount": "500000" }
+      { "token": "70ce552eaec9be6e009189bffbb69184b2dd008ba9bdaec6da5305fc505eb569", "amount": "500000" }
     ]
   }
 ]
@@ -136,52 +199,118 @@ Returns the current live offer book — offers that have been published to Celes
 
 | Field | Description |
 |---|---|
-| `id` | Internal offer ID |
-| `celestia_height` | Celestia block where this offer was published |
-| `transaction_hex` | The raw `zswapoffer1…` blob (pass directly to the Midnight contract for settlement) |
-| `gives` | Tokens the maker is offering (array of `{ token, amount }`) |
+| `transaction_hex` | The raw `zswapoffer1…` blob. Pass directly to the Midnight contract for settlement. |
+| `gives` | Tokens the maker is offering |
 | `wants` | Tokens the maker is requesting |
 | `ttl_seconds` | Offer lifetime in seconds from `metadata_created_at` |
 
-**Example — find all offers giving token A:**
+```bash
+# All open offers giving NIGHT:
+curl "http://host:9999/api/zswaps?token=0000000000000000000000000000000000000000000000000000000000000000&direction=GIVING"
+```
+
+---
+
+#### `GET /api/zswap/status`
+
+Single-blob status lookup. Use this to reconcile a "My Trades" list on startup without fetching the full offer book.
+
+**Query parameter:** `blob` — the `zswapoffer1…` string.
 
 ```bash
-curl "http://host:9999/api/zswaps?token=<64-hex-color>&direction=GIVING"
+curl "http://host:9999/api/zswap/status?blob=zswapoffer1..."
+```
+
+**Response**
+
+```json
+{ "blob": "zswapoffer1...", "status": "open" }
+```
+
+`status` is one of `"open"` | `"completed"` | `"expired"` | `"not_found"`.
+
+---
+
+#### `GET /api/pairs`
+
+All known trading pairs, combining historical fill data from `pair_stats` with live open-offer counts. Use this to populate a pair picker or market list.
+
+```bash
+curl http://host:9999/api/pairs
+```
+
+```json
+[
+  {
+    "base":       "70ce552eaec9be6e009189bffbb69184b2dd008ba9bdaec6da5305fc505eb569",
+    "quote":      "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_name":  "TESTTOKENA",
+    "quote_name": "NIGHT",
+    "open_count": 6,
+    "last_price": 12.5
+  }
+]
 ```
 
 ---
 
 #### `GET /api/known-tokens`
 
-Returns all token colors the indexer has seen, including the three pre-seeded native tokens.
+> **⚠️ Demo endpoint — do not use as a source of truth.**
+> This registry is a temporary convenience feature for this demo. The official Midnight token-metadata standard is not yet live. Names and kinds stored here are manually curated and unverified. Do not rely on this endpoint for authoritative token information.
+
+All registered token colors.
+
+```bash
+curl http://host:9999/api/known-tokens
+```
 
 ```json
 [
-  { "id": 1, "token_color": "0000...0000", "name": "native_0", "kind": "shielded" },
-  { "id": 2, "token_color": "0000...0001", "name": "native_1", "kind": "shielded" },
-  { "id": 3, "token_color": "0000...0002", "name": "native_2", "kind": "shielded" }
+  { "id": 1, "token_color": "0000000000000000000000000000000000000000000000000000000000000000", "name": "NIGHT", "kind": "unshielded" }
 ]
 ```
 
-New token colors are registered automatically when a valid offer containing them is indexed.
+New token colors are auto-registered when a valid offer containing them is indexed.
 
 ---
 
 #### `POST /api/known-tokens`
 
-Manually register a token name. Useful when the browser wallet mints a new token client-side and you want to give it a human-readable name before any offers appear.
+> **⚠️ Demo endpoint — do not use as a source of truth.**
+> Registering a name here does not make it canonical. Any operator can write any name against any color. Wait for the official token-metadata standard before building user-facing trust on top of this endpoint.
+
+Register a human-readable name for a token color before any offers appear (e.g. immediately after a browser-wallet mint).
+
+```bash
+curl -X POST http://host:9999/api/known-tokens \
+  -H "Content-Type: application/json" \
+  -d '{"color":"70ce552eaec9be6e009189bffbb69184b2dd008ba9bdaec6da5305fc505eb569","name":"TESTTOKENA","kind":"shielded"}'
+```
 
 **Body**
 
 ```json
 {
-  "color": "<64-hex-color>",
-  "name": "MYTOKEN",
+  "color": "70ce552eaec9be6e009189bffbb69184b2dd008ba9bdaec6da5305fc505eb569",
+  "name": "TESTTOKENA",
   "kind": "shielded"
 }
 ```
 
 `name` must be unique (max 16 chars, stored uppercased). `kind` is `"shielded"` or `"unshielded"`.
+
+**Success `200`**
+
+```json
+{ "success": true, "color": "70ce...", "name": "TESTTOKENA", "kind": "shielded" }
+```
+
+**Conflict `409`** — name or color already registered:
+
+```json
+{ "error": "Token name \"TESTTOKENA\" is already taken" }
+```
 
 ---
 
@@ -189,12 +318,12 @@ Manually register a token name. Useful when the browser wallet mints a new token
 
 #### `POST /api/zswap/submit`
 
-Validate and forward a `zswapoffer1…` blob to Celestia DA via the batcher. This is the recommended submission path — it validates the offer structure and coin liveness before paying any Celestia fee.
+Validate and forward a `zswapoffer1…` blob to Celestia DA via the batcher. This is the recommended submission path — structure and coin liveness are verified before any Celestia fee is incurred.
 
-**Body**
-
-```json
-{ "blob": "zswapoffer1..." }
+```bash
+curl -X POST http://host:9999/api/zswap/submit \
+  -H "Content-Type: application/json" \
+  -d '{"blob":"zswapoffer1..."}'
 ```
 
 **Success `200`**
@@ -206,7 +335,7 @@ Validate and forward a `zswapoffer1…` blob to Celestia DA via the batcher. Thi
 **Error `400`**
 
 ```json
-{ "error": "NULLIFIER_SPENT", "reason": "nullifier already spent: abc123..." }
+{ "error": "ROOT_UNKNOWN", "reason": "input merkle root not a known recent chain root: abc123..." }
 ```
 
 | Error code | Meaning |
@@ -214,10 +343,10 @@ Validate and forward a `zswapoffer1…` blob to Celestia DA via the batcher. Thi
 | `INVALID_FORMAT` | Blob is not a valid `zswapoffer1…` encoding |
 | `INVALID_PROOF` | Cryptographic proof verification failed |
 | `NULLIFIER_SPENT` | A shielded input coin is already spent on Midnight |
-| `UTXO_NOT_LIVE` | An unshielded input UTXO has been spent or was never created |
-| `ROOT_UNKNOWN` | The shielded input proves against a Merkle root the chain never held (or that has aged out of the 14-day window) |
+| `UTXO_NOT_LIVE` | An unshielded UTXO was spent or was never created on-chain |
+| `ROOT_UNKNOWN` | The shielded input proves against a Merkle root outside the `ROOT_WINDOW_SECONDS` retention window |
 
-Validation is deterministic and requires no live chain connection. The node consults its local copy of the spent-nullifier set, the live unshielded UTXO set, and the Merkle-root window.
+Validation consults the node's local state only — no live RPC calls are made. `ROOT_UNKNOWN` can fire while the node is still syncing (the root simply hasn't arrived yet). Retry once `/api/health/sync` reports `"status":"ok"`.
 
 ---
 
@@ -225,44 +354,46 @@ Validation is deterministic and requires no live chain connection. The node cons
 
 #### `GET /api/quote`
 
-Returns a synthetic price quote for a token swap. Useful for estimating rates in the UI without constructing a real offer.
+Price quote for a token swap, backed by the `token_prices` table. On first request the deterministic fallback price is written; subsequent calls are consistent. Operators can override rows directly in the DB.
 
-**Query parameters:** `from_token`, `to_token` (64-hex colors), `from_amount` (base units), optional `to_amount`.
+**Query parameters:** `from_token`, `to_token` (64-hex, no `0x`), `from_amount` (base units), optional `to_amount`.
 
 ```bash
-curl "http://host:9999/api/quote?from_token=<A>&to_token=<B>&from_amount=1000000"
+curl "http://host:9999/api/quote?from_token=0000...0000&to_token=70ce...b569&from_amount=1000000"
 ```
 
 ---
 
 #### `GET /api/chart/stats?base=<A>&quote=<B>`
 
-Returns 24-hour market statistics for a token pair derived from consumed (filled) offers.
+24-hour statistics for a pair derived from consumed (filled) offers. Falls back to the mid of current open offers when no fills exist yet.
+
+```bash
+curl "http://host:9999/api/chart/stats?base=70ce...b569&quote=0000...0000"
+```
 
 ```json
 {
-  "base": "0000...0001",
-  "quote": "0000...0002",
-  "last": 0.5,
+  "base": "70ce...",
+  "quote": "0000...",
+  "last": 12.5,
   "change24": 2.3,
-  "high": 0.55,
-  "low": 0.48,
+  "high": 13.1,
+  "low": 12.0,
   "volume_base": 10000000,
-  "volume_quote": 5000000
+  "volume_quote": 800000
 }
 ```
-
-Falls back to the mid of current open offers when there are no fills yet.
 
 ---
 
 #### `GET /api/chart/history?base=<A>&quote=<B>`
 
-Returns the last 120 fills (consumed offers) for a pair, newest first.
+Last 120 fills (consumed offers) for a pair, newest first.
 
 ```json
 [
-  { "price": 0.5, "amt": 1000000, "up": true, "at": "2026-06-01T12:00:00.000Z" }
+  { "price": 12.5, "amt": 1000000, "up": true, "at": "2026-06-01T12:00:00.000Z" }
 ]
 ```
 
@@ -272,7 +403,7 @@ Returns the last 120 fills (consumed offers) for a pair, newest first.
 
 #### `GET /api/events`
 
-Server-Sent Events stream for real-time offer lifecycle notifications. Connect once and receive push updates without polling.
+Server-Sent Events stream for real-time offer lifecycle notifications. A comment-only keepalive (`: heartbeat`) is sent every 30 seconds.
 
 ```bash
 curl -N http://host:9999/api/events
@@ -294,34 +425,37 @@ data: {"type":"offer_rejected","code":"ROOT_UNKNOWN","reason":"...","celestiaHei
 data: {"type":"token_minted","name":"MYTOKEN","color":"...","kind":"shielded","timestamp":...}
 ```
 
-The stream also sends a comment-only keepalive (`: heartbeat`) every 30 seconds to prevent proxy timeouts.
-
 ---
 
 ### Midnight configuration
 
 #### `GET /api/midnight/config`
 
-Returns the public Midnight configuration the browser contract client needs. Never includes secrets.
+Public Midnight configuration the browser contract client needs. Never includes secrets.
+
+```bash
+curl http://host:9999/api/midnight/config
+```
 
 ```json
 {
   "contractAddress": "mn1abc...",
-  "indexerUri": "https://indexer.midnight.network:8088/graphql",
-  "indexerWsUri": "wss://indexer.midnight.network:8088/graphql",
-  "proofServerUri": "https://proof.midnight.network",
-  "networkId": "preview"
+  "indexerUri":      "https://indexer.midnight.network:8088/graphql",
+  "indexerWsUri":    "wss://indexer.midnight.network:8088/graphql",
+  "proofServerUri":  "https://proof.midnight.network",
+  "networkId":       "preview"
 }
 ```
+
+Returns `500` if `MIDNIGHT_CONTRACT_ADDRESS` is not set.
 
 ---
 
 ## Batcher API — port 3334
 
-The batcher accepts encoded offer blobs, validates them, and publishes them as Celestia blobs. In normal usage you go through `/api/zswap/submit` on the node (which calls the batcher internally). Direct batcher access is for advanced integrations.
+The batcher accepts `zswapoffer1…` blobs, validates them, and publishes them as Celestia blobs. In normal usage you go through `/api/zswap/submit` on the node (which calls the batcher internally). Direct batcher access is for advanced integrations.
 
-Base URL: `http://<host>:3334`
-
+Base URL: `http://<host>:3334`  
 Swagger UI: `http://<host>:3334/documentation`
 
 ---
@@ -336,7 +470,7 @@ Swagger UI: `http://<host>:3334/documentation`
 
 #### `GET /status`
 
-Returns batcher initialization state, pending input counts, and queue targets.
+Batcher initialization state, pending input counts, and queue targets.
 
 ---
 
@@ -346,7 +480,13 @@ Returns batcher initialization state, pending input counts, and queue targets.
 {
   "totalPendingInputs": 3,
   "targets": [
-    { "target": "midnight-balancer", "pendingInputs": 3, "isReady": true, "criteriaType": "...", "timeSinceLastProcess": 120 }
+    {
+      "target": "midnight-balancer",
+      "pendingInputs": 3,
+      "isReady": true,
+      "criteriaType": "size",
+      "timeSinceLastProcess": 120
+    }
   ]
 }
 ```
@@ -355,7 +495,7 @@ Returns batcher initialization state, pending input counts, and queue targets.
 
 #### `POST /send-input`
 
-Submit a blob directly to the batcher queue. The batcher validates the offer (structure + cryptographic proofs) before accepting it. Liveness checks (spent coins) are not repeated here — they are enforced at the node's STM ingestion step.
+Submit a blob directly to the batcher queue. Structure and cryptographic proofs are validated before acceptance. Liveness checks (spent coins, root-known) are not repeated here — they are enforced at the node's STM ingestion step.
 
 **Body**
 
@@ -397,28 +537,59 @@ Submit a blob directly to the batcher queue. The batcher validates the offer (st
 
 ## Token colors
 
-Token colors are 32-byte (64 hex character) identifiers used throughout the Midnight shielded ledger. They appear without a `0x` prefix in all API fields.
+Token colors are 32-byte (64 hex character) identifiers used throughout the Midnight shielded ledger. They appear **without** a `0x` prefix in all API fields. Amounts are always integers in the token's base unit.
 
-The three pre-seeded native tokens:
+The one pre-seeded native token:
 
-| Name | Color |
-|---|---|
-| `native_0` | `0000000000000000000000000000000000000000000000000000000000000000` |
-| `native_1` | `0000000000000000000000000000000000000000000000000000000000000001` |
-| `native_2` | `0000000000000000000000000000000000000000000000000000000000000002` |
+| Name | Color | Kind | Notes |
+|---|---|---|---|
+| `NIGHT` | `0000000000000000000000000000000000000000000000000000000000000000` | `unshielded` | Native Midnight token. `nativeToken()` in the SDK returns `TokenType::Unshielded(NIGHT)`. 1 NIGHT = 10⁶ Stars (atomic units). |
 
-Amounts are always integers in the token's base unit (no decimals in the API layer).
+Shielded and unshielded NIGHT share the same color (`0x0000…0000`) and differ only by the enum tag (`Unshielded=0`, `Shielded=1`). The API does not distinguish them by color — both appear as the all-zeros color in offer legs.
 
 ---
 
 ## Encoding offers (`zswapoffer1…`)
 
-Offer blobs are produced by the Midnight browser SDK (`@midnight-ntwrk/...`). The encoding bundles the ZSwap transaction structure plus the cryptographic proofs required for settlement. The validator package (`@zswap-da/validator`) exposes `encodeOffer` and `validateZswapOffer` — use these rather than constructing the binary format by hand.
+Offer blobs are produced by the Midnight browser SDK. The encoding bundles the ZSwap transaction structure plus the cryptographic proofs required for settlement. Use `encodeOffer` / `validateZswapOffer` from `@zswap-da/validator` rather than constructing the binary format by hand.
 
 The decoded offer contains:
-- **nullifiers** — hashes of the shielded input coins being spent
-- **unshieldedSpends** — `(owner, intentHash, outputNo)` triples for unshielded inputs
-- **inputRoots** — Merkle tree roots against which the input proofs are made
-- **gives / wants** — the token legs of the swap
+
+| Field | Description |
+|---|---|
+| `nullifiers` | Hashes of shielded input coins being spent |
+| `unshieldedSpends` | `(owner, intentHash, outputNo)` triples for unshielded inputs |
+| `inputRoots` | Merkle roots against which the input proofs are made |
+| `gives` / `wants` | The token legs of the swap |
 
 All of these are checked by `/api/zswap/submit` before any Celestia fee is incurred.
+
+### Manual submission (curl)
+
+```bash
+BLOB="zswapoffer1..."
+
+# Recommended: submit through the node (validates + forwards to batcher)
+curl -s -X POST http://host:9999/api/zswap/submit \
+  -H "Content-Type: application/json" \
+  -d "{\"blob\":\"$BLOB\"}" | jq .
+
+# Advanced: submit directly to the batcher (skips liveness re-check)
+curl -s -X POST http://host:3334/send-input \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "input": "'"$BLOB"'",
+      "target": "midnight-balancer",
+      "address": "mn1...",
+      "addressType": 0
+    },
+    "confirmationLevel": "wait-receipt"
+  }' | jq .
+
+# Confirm the offer landed in the indexer
+curl -s "http://host:9999/api/zswaps?limit=5" | jq '.[0]'
+
+# Stream lifecycle events while waiting for settlement
+curl -N http://host:9999/api/events
+```

--- a/templates/zswap-da/api-examples/01-health.ts
+++ b/templates/zswap-da/api-examples/01-health.ts
@@ -1,0 +1,25 @@
+// 01-health.ts — Check liveness and sync progress.
+// bun run api-examples/01-health.ts
+
+import { config, get, print, header } from "./config.ts";
+
+header("Health");
+console.log(`Node: ${config.nodeUrl}  Network: ${config.networkId}`);
+
+const liveness = await fetch(`${config.nodeUrl}/health`);
+print("/health", { status: liveness.status, ok: liveness.ok });
+
+const sync = await get("/api/health/sync");
+print("/api/health/sync", sync);
+
+const s = sync as any;
+if (s.status === "ok") {
+  console.log("\n✅  Node is fully synced and serving live data.");
+} else if (s.status === "syncing") {
+  const lag = s.ntp?.lag_seconds ?? 0;
+  const hrs = (lag / 3600).toFixed(1);
+  console.log(`\n⏳  Still syncing — ${hrs}h of history remaining (NTP ${s.ntp?.pct?.toFixed(1)}%).`);
+  console.log("   ROOT_UNKNOWN errors on submit will resolve once sync completes.");
+} else {
+  console.log("\n⚠️  Sync status:", s.status);
+}

--- a/templates/zswap-da/api-examples/02-tokens.ts
+++ b/templates/zswap-da/api-examples/02-tokens.ts
@@ -1,0 +1,38 @@
+// 02-tokens.ts — List registered tokens; optionally register a new one.
+// bun run api-examples/02-tokens.ts
+// REGISTER=1 bun run api-examples/02-tokens.ts   # also POSTs a test token
+//
+// ⚠️  DEMO ONLY — /api/known-tokens is a temporary convenience endpoint for
+// this demo. The official Midnight token-metadata standard is not yet live.
+// Names and kinds stored here are manually curated and MUST NOT be trusted as
+// authoritative token information.
+
+import { get, post, print, header } from "./config.ts";
+
+header("Known Tokens");
+console.log("⚠️  WARNING: known-tokens is a demo endpoint. Token metadata is not authoritative — the Midnight token-metadata standard is not yet live.\n");
+
+const tokens = await get("/api/known-tokens");
+print("GET /api/known-tokens", tokens);
+
+const list = tokens as Array<{ token_color: string; name: string; kind: string }>;
+console.log(`\n${list.length} token(s) registered.`);
+for (const t of list) {
+  console.log(`  ${t.name.padEnd(16)} ${t.kind.padEnd(11)} ${t.token_color}`);
+}
+
+if (process.env.REGISTER === "1") {
+  // Register a synthetic test token.  Change color/name to your own.
+  const payload = {
+    color: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    name: "EXAMPLE",
+    kind: "shielded",
+  };
+  console.log("\nRegistering test token…");
+  try {
+    const result = await post("/api/known-tokens", payload);
+    print("POST /api/known-tokens", result);
+  } catch (e: any) {
+    console.log("Registration failed (likely already exists):", e.message);
+  }
+}

--- a/templates/zswap-da/api-examples/03-offers.ts
+++ b/templates/zswap-da/api-examples/03-offers.ts
@@ -1,0 +1,33 @@
+// 03-offers.ts — Read the live offer book; optionally filter by token/direction.
+// bun run api-examples/03-offers.ts
+// TOKEN=0000...0000 DIRECTION=GIVING bun run api-examples/03-offers.ts
+
+import { config, get, print, header } from "./config.ts";
+
+header("Live Offer Book");
+
+const params = new URLSearchParams({ limit: "10" });
+if (process.env.TOKEN)     params.set("token",     process.env.TOKEN);
+if (process.env.DIRECTION) params.set("direction", process.env.DIRECTION);
+
+const offers = await get<any[]>(`/api/zswaps?${params}`);
+print(`GET /api/zswaps?${params}`, offers);
+
+if (offers.length === 0) {
+  console.log("\nNo open offers found.");
+} else {
+  console.log(`\n${offers.length} open offer(s):\n`);
+  for (const o of offers) {
+    const gives = o.gives.map((g: any) => `${g.amount} ${g.token.slice(0, 8)}…`).join(", ");
+    const wants = o.wants.map((w: any) => `${w.amount} ${w.token.slice(0, 8)}…`).join(", ");
+    console.log(`  [${o.id}] gives: ${gives}  →  wants: ${wants}  (Celestia #${o.celestia_height})`);
+  }
+
+  // Check status of the first offer (blobs can be large — skip if > 4 KB)
+  const first = offers[0];
+  if (first && first.transaction_hex.length < 4096) {
+    console.log(`\nStatus check for offer ${first.id}:`);
+    const status = await get<any>(`/api/zswap/status?blob=${encodeURIComponent(first.transaction_hex)}`);
+    print("GET /api/zswap/status", status);
+  }
+}

--- a/templates/zswap-da/api-examples/04-pairs.ts
+++ b/templates/zswap-da/api-examples/04-pairs.ts
@@ -1,0 +1,22 @@
+// 04-pairs.ts — List all known trading pairs with live open counts.
+// bun run api-examples/04-pairs.ts
+
+import { get, print, header } from "./config.ts";
+
+header("Trading Pairs");
+
+const pairs = await get<any[]>("/api/pairs");
+print("GET /api/pairs", pairs);
+
+if (pairs.length === 0) {
+  console.log("\nNo pairs yet — open offers will create pairs automatically.");
+} else {
+  console.log(`\n${pairs.length} pair(s):\n`);
+  for (const p of pairs) {
+    const base  = p.base_name  ?? (p.base_color  as string).slice(0, 8) + "…";
+    const quote = p.quote_name ?? (p.quote_color as string).slice(0, 8) + "…";
+    console.log(
+      `  ${(base + "/" + quote).padEnd(24)}  open: ${String(p.open_count ?? 0).padStart(4)}  last: ${p.last_price ?? "—"}`
+    );
+  }
+}

--- a/templates/zswap-da/api-examples/05-market.ts
+++ b/templates/zswap-da/api-examples/05-market.ts
@@ -1,0 +1,45 @@
+// 05-market.ts — Quote, 24h stats, and trade history for a pair.
+// bun run api-examples/05-market.ts
+//
+// Env overrides:
+//   FROM=<64-hex>  TO=<64-hex>  AMOUNT=1000000
+//   BASE=<64-hex>  QUOTE=<64-hex>
+
+import { get, print, header } from "./config.ts";
+
+const NIGHT = "0000000000000000000000000000000000000000000000000000000000000000";
+// Fall back to NIGHT/NIGHT so the script runs even with no pairs seeded.
+const FROM  = process.env.FROM  ?? NIGHT;
+const TO    = process.env.TO    ?? "70ce552eaec9be6e009189bffbb69184b2dd008ba9bdaec6da5305fc505eb569";
+const AMOUNT = process.env.AMOUNT ?? "1000000";
+const BASE  = process.env.BASE  ?? TO;
+const QUOTE = process.env.QUOTE ?? NIGHT;
+
+header("Market Data");
+
+// Quote
+const quoteParams = new URLSearchParams({ from_token: FROM, to_token: TO, from_amount: AMOUNT });
+try {
+  const quote = await get(`/api/quote?${quoteParams}`);
+  print(`GET /api/quote  (${AMOUNT} of ${FROM.slice(0,8)}… → ${TO.slice(0,8)}…)`, quote);
+} catch (e: any) {
+  console.log("Quote unavailable:", e.message);
+}
+
+// 24h stats
+const pairParams = new URLSearchParams({ base: BASE, quote: QUOTE });
+try {
+  const stats = await get(`/api/chart/stats?${pairParams}`);
+  print("GET /api/chart/stats", stats);
+} catch (e: any) {
+  console.log("Stats unavailable:", e.message);
+}
+
+// Trade history
+try {
+  const history = await get<any[]>(`/api/chart/history?${pairParams}`);
+  print(`GET /api/chart/history (${(history as any[]).length} fills)`, history.slice(0, 5));
+  if (history.length > 5) console.log(`  … and ${history.length - 5} more`);
+} catch (e: any) {
+  console.log("History unavailable:", e.message);
+}

--- a/templates/zswap-da/api-examples/06-midnight-config.ts
+++ b/templates/zswap-da/api-examples/06-midnight-config.ts
@@ -1,0 +1,18 @@
+// 06-midnight-config.ts — Fetch the public Midnight contract config from the node.
+// Gives you the contract address, indexer URI, and proof server URI.
+// bun run api-examples/06-midnight-config.ts
+
+import { get, print, header } from "./config.ts";
+
+header("Midnight Config");
+
+const cfg = await get("/api/midnight/config");
+print("GET /api/midnight/config", cfg);
+
+const c = cfg as any;
+console.log("\nQuick-copy values:");
+console.log(`  contractAddress : ${c.contractAddress}`);
+console.log(`  indexerUri      : ${c.indexerUri}`);
+console.log(`  indexerWsUri    : ${c.indexerWsUri}`);
+console.log(`  proofServerUri  : ${c.proofServerUri}`);
+console.log(`  networkId       : ${c.networkId}`);

--- a/templates/zswap-da/api-examples/07-events.ts
+++ b/templates/zswap-da/api-examples/07-events.ts
@@ -1,0 +1,60 @@
+// 07-events.ts — Stream real-time offer lifecycle events via SSE.
+// Runs until Ctrl+C. Not included in run-all.ts (it never exits).
+// bun run api-examples/07-events.ts
+
+import { config, header } from "./config.ts";
+
+header("SSE Event Stream");
+console.log(`Connecting to ${config.nodeUrl}/api/events  (Ctrl+C to stop)\n`);
+
+const res = await fetch(`${config.nodeUrl}/api/events`);
+if (!res.ok || !res.body) {
+  console.error(`Failed to connect: ${res.status}`);
+  process.exit(1);
+}
+
+const reader = res.body.getReader();
+const decoder = new TextDecoder();
+let buffer = "";
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  buffer += decoder.decode(value, { stream: true });
+
+  const lines = buffer.split("\n");
+  buffer = lines.pop() ?? "";
+
+  for (const line of lines) {
+    if (line.startsWith("data: ")) {
+      try {
+        const event = JSON.parse(line.slice(6));
+        const ts = new Date(event.timestamp).toISOString().slice(11, 23);
+        const type = event.type?.padEnd(18) ?? "unknown";
+        let detail = "";
+        switch (event.type) {
+          case "offer_indexed":
+            detail = `id=${event.offerId}  celestia=#${event.celestiaHeight}`;
+            break;
+          case "offer_consumed":
+            detail = `id=${event.offerId}  nullifier=${String(event.nullifier).slice(0, 16)}…`;
+            break;
+          case "offer_expired":
+            detail = `id=${event.offerId}`;
+            break;
+          case "offer_rejected":
+            detail = `code=${event.code}  celestia=#${event.celestiaHeight}`;
+            break;
+          case "token_minted":
+            detail = `${event.name}  color=${String(event.color).slice(0, 16)}…`;
+            break;
+          default:
+            detail = JSON.stringify(event);
+        }
+        console.log(`[${ts}] ${type}  ${detail}`);
+      } catch {
+        // heartbeat comment line or malformed — skip
+      }
+    }
+  }
+}

--- a/templates/zswap-da/api-examples/08-wallet.ts
+++ b/templates/zswap-da/api-examples/08-wallet.ts
@@ -1,0 +1,71 @@
+// 08-wallet.ts — Build a Midnight wallet and print its address + balances.
+// Requires: WALLET_SEED env var (hex, 64 chars) OR falls back to the dev
+// genesis seed (only has funds on undeployed / local dev).
+//
+// On Preview/Mainnet you need a funded wallet seed:
+//   MIDNIGHT_NETWORK_ID=preview bun mnemonic-to-seed.ts  # converts a 24-word phrase
+//   export WALLET_SEED=<printed hex>
+//   bun run api-examples/08-wallet.ts
+
+import { config, header } from "./config.ts";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { buildWalletAndWaitForFunds } from "@effectstream/midnight-contracts";
+import { get } from "./config.ts";
+
+globalThis.WebSocket = WebSocket;
+
+header("Wallet");
+
+// Midnight config is served by the node — no need to hard-code it.
+const midnightCfg = await get<{
+  contractAddress: string;
+  indexerUri: string;
+  indexerWsUri: string;
+  proofServerUri: string;
+  networkId: string;
+}>("/api/midnight/config");
+
+setNetworkId(midnightCfg.networkId as any);
+
+const networkUrls = {
+  id:          midnightCfg.networkId as any,
+  indexer:     midnightCfg.indexerUri,
+  indexerWS:   midnightCfg.indexerWsUri,
+  node:        midnightCfg.indexerUri,          // Midnight node behind indexer
+  proofServer: midnightCfg.proofServerUri,
+};
+
+console.log(`Building wallet for seed ${config.walletSeed.slice(0, 8)}… on ${midnightCfg.networkId}`);
+console.log("(This syncs the wallet state from the indexer — may take a minute.)\n");
+
+const { wallet, dustAddress, zswapSecretKeys, dustSecretKey } =
+  await buildWalletAndWaitForFunds(networkUrls, config.walletSeed, midnightCfg.networkId as any);
+
+const state = await wallet.shielded.waitForSyncedState();
+const address = state.address.coinPublicKeyString();
+
+console.log("─── Wallet ──────────────────────────────────────────────────────");
+console.log(`  Shielded address : ${address}`);
+console.log(`  Dust address     : ${dustAddress}`);
+
+const balances: Record<string, bigint> = state.balances as any;
+const STARS_PER_NIGHT = 1_000_000n;
+
+if (Object.keys(balances).length === 0) {
+  console.log("  Shielded balances: (none)");
+} else {
+  console.log("  Shielded balances:");
+  for (const [color, amount] of Object.entries(balances)) {
+    const night = color === "0000000000000000000000000000000000000000000000000000000000000000"
+      ? `  (${(BigInt(amount as any) / STARS_PER_NIGHT).toString()} NIGHT)`
+      : "";
+    console.log(`    ${color.slice(0, 16)}…  ${amount}${night}`);
+  }
+}
+
+console.log("\nKeys available for offer construction:");
+console.log(`  zswapSecretKeys : ${zswapSecretKeys?.length ?? 0} key(s)`);
+console.log(`  dustSecretKey   : ${dustSecretKey ? "yes" : "no"}`);
+
+await wallet.stop().catch(() => {});
+console.log("\n✅  Wallet synced and stopped cleanly.");

--- a/templates/zswap-da/api-examples/09-mint.ts
+++ b/templates/zswap-da/api-examples/09-mint.ts
@@ -1,0 +1,179 @@
+// 09-mint.ts — Mint test tokens into the wallet via the on-chain OfferFiles contract.
+//
+// What this does:
+//   1. Fetches /api/midnight/config (contract address, indexer, proof server).
+//   2. Builds the maker wallet (WALLET_SEED) and connects to the deployed contract.
+//   3. Calls mint_shielded twice (two distinct token colors, stable domain separators)
+//      and mint_unshielded once.
+//   4. Registers each color with /api/known-tokens for human-readable display.
+//   5. Writes the minted colors to /tmp/zswap-minted-tokens.json so 10-submit-offer
+//      and 11-settle-offer can consume them automatically.
+//
+// Domain separators are fixed → same token colors on every run; re-minting adds
+// balance to the same coins rather than creating new identities. Nonces use Date.now()
+// so each mint call creates a fresh coin commitment (required — duplicates are rejected).
+//
+// Env overrides:
+//   WALLET_SEED=<64-hex>   maker wallet seed (must have NIGHT for dust fees)
+//   MINT_AMOUNT=1000000000 amount to mint per token in base units
+
+import { dirname, resolve } from "node:path";
+import { writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { findDeployedContract } from "@midnight-ntwrk/midnight-js-contracts";
+import { CompiledContract } from "@midnight-ntwrk/compact-js";
+import {
+  buildWalletFacade,
+  registerNightForDust,
+  configureMidnightNodeProviders,
+} from "@effectstream/midnight-contracts";
+import { OfferFilesContract, witnesses } from "@zswap-da/contract-offer-files";
+import { config, get, post, header } from "./config.ts";
+
+globalThis.WebSocket = WebSocket;
+
+const toHex = (u: Uint8Array): string =>
+  Array.from(u, (x) => x.toString(16).padStart(2, "0")).join("");
+
+// ── ZK artifacts path ──────────────────────────────────────────────────────────
+// Resolved relative to this script file so it works regardless of cwd.
+const SCRIPT_DIR = dirname(new URL(import.meta.url).pathname);
+const ZK_PATH = resolve(
+  SCRIPT_DIR,
+  "../packages/contracts-midnight/contract-offer-files/src/managed",
+);
+const PRIVATE_STATE_STORE = "offerFilesPrivateState";
+
+const MINTED_FILE = "/tmp/zswap-minted-tokens.json";
+const MINT_AMOUNT = BigInt(process.env.MINT_AMOUNT ?? "1000000000");
+
+// Fixed domain separators → same token colors on every run.
+const SEP_A = new Uint8Array(32).fill(0xa1);
+const SEP_B = new Uint8Array(32).fill(0xb2);
+const SEP_U = new Uint8Array(32).fill(0xc3);
+
+header("Mint Test Tokens");
+console.log(`Wallet seed : ${config.walletSeed.slice(0, 8)}…`);
+console.log(`Mint amount : ${MINT_AMOUNT.toLocaleString()} base units`);
+console.log(`ZK path     : ${ZK_PATH}\n`);
+
+// ── 1. Midnight config ─────────────────────────────────────────────────────────
+const midnightCfg = await get<{
+  contractAddress: string;
+  indexerUri: string;
+  indexerWsUri: string;
+  proofServerUri: string;
+  networkId: string;
+}>("/api/midnight/config");
+
+setNetworkId(midnightCfg.networkId as any);
+
+const networkUrls = {
+  id:          midnightCfg.networkId as any,
+  indexer:     midnightCfg.indexerUri,
+  indexerWS:   midnightCfg.indexerWsUri,
+  node:        midnightCfg.indexerUri,
+  proofServer: midnightCfg.proofServerUri,
+};
+
+console.log(`Network     : ${midnightCfg.networkId}`);
+console.log(`Contract    : ${midnightCfg.contractAddress}`);
+console.log(`Proof server: ${midnightCfg.proofServerUri}\n`);
+
+// ── 2. Build wallet ────────────────────────────────────────────────────────────
+console.log("Building wallet + syncing (shielded + unshielded)…");
+const wr = await buildWalletFacade(networkUrls, config.walletSeed, midnightCfg.networkId as any);
+
+try {
+  await registerNightForDust(wr as any);
+} catch {
+  console.log("  (NIGHT already registered for dust fees — continuing)");
+}
+
+// ── 3. Connect to contract ─────────────────────────────────────────────────────
+const compiledContract = CompiledContract.make(
+  "contract-offer-files",
+  OfferFilesContract.Contract as any,
+).pipe(
+  CompiledContract.withWitnesses(witnesses as unknown as never),
+  CompiledContract.withCompiledFileAssets(ZK_PATH),
+);
+
+const providers = (await configureMidnightNodeProviders(
+  wr.wallet,
+  wr.zswapSecretKeys,
+  wr.walletZswapSecretKeys,
+  wr.dustSecretKey,
+  wr.walletDustSecretKey,
+  { indexer: networkUrls.indexer, indexerWS: networkUrls.indexerWS, node: networkUrls.node, proofServer: networkUrls.proofServer },
+  PRIVATE_STATE_STORE,
+  ZK_PATH,
+  wr.unshieldedKeystore,
+)) as any;
+
+console.log("Joining deployed contract…");
+const deployed = await findDeployedContract(providers, {
+  contractAddress: midnightCfg.contractAddress,
+  compiledContract: compiledContract as any,
+  privateStateId: PRIVATE_STATE_STORE,
+  initialPrivateState: {},
+});
+console.log("  Joined.\n");
+
+// ── 4. Mint tokens ─────────────────────────────────────────────────────────────
+const nonceBase = BigInt(Date.now());
+const minted: Record<string, string> = {};
+
+for (const [label, sep, idx] of [
+  ["shieldedA", SEP_A, 0n],
+  ["shieldedB", SEP_B, 1n],
+] as const) {
+  console.log(`Minting ${label} (proving…)`);
+  const tx = await (deployed.callTx as any).mint_shielded(sep, MINT_AMOUNT, nonceBase + idx);
+  const coin = tx.private?.result;
+  const colorRaw = coin?.color ?? coin?.type;
+  if (colorRaw == null) throw new Error(`mint_shielded ${label}: no color in result`);
+  const color = (colorRaw instanceof Uint8Array ? toHex(colorRaw) : String(colorRaw)).replace(/^0x/, "").toLowerCase();
+  minted[label] = color;
+  console.log(`  ✅ ${label}: ${color.slice(0, 16)}…`);
+}
+
+console.log("Minting unshielded (proving…)");
+const recipientBytes = wr.unshieldedKeystore.getBech32Address
+  ? (wr.unshieldedKeystore as any).getPublicKey?.() ?? SEP_U
+  : SEP_U;
+const utx = await (deployed.callTx as any).mint_unshielded(SEP_U, MINT_AMOUNT, { bytes: recipientBytes instanceof Uint8Array ? recipientBytes : SEP_U });
+const ures = utx.private?.result;
+minted.unshielded = (ures instanceof Uint8Array ? toHex(ures) : String(ures ?? toHex(SEP_U))).replace(/^0x/, "").toLowerCase();
+console.log(`  ✅ unshielded: ${minted.unshielded.slice(0, 16)}…\n`);
+
+// ── 5. Register names ──────────────────────────────────────────────────────────
+const registrations = [
+  { color: minted.shieldedA,  name: "TESTA", kind: "shielded"   },
+  { color: minted.shieldedB,  name: "TESTB", kind: "shielded"   },
+  { color: minted.unshielded, name: "TESTU", kind: "unshielded" },
+];
+
+console.log("Registering token names…");
+for (const r of registrations) {
+  try {
+    await post("/api/known-tokens", r);
+    console.log(`  ✅ ${r.name} registered`);
+  } catch (e: any) {
+    if (e.message?.includes("409") || e.message?.includes("already")) {
+      console.log(`  ⚠️  ${r.name} already registered (OK)`);
+    } else {
+      console.warn(`  ⚠️  ${r.name}: ${e.message}`);
+    }
+  }
+}
+
+// ── 6. Write token file for downstream scripts ─────────────────────────────────
+writeFileSync(MINTED_FILE, JSON.stringify(minted, null, 2));
+console.log(`\nMinted colors written to ${MINTED_FILE}`);
+console.log(JSON.stringify(minted, null, 2));
+
+console.log("\n✅  Mint complete. Run 10-submit-offer.ts to place a ZSwap using these tokens.");
+
+await wr.wallet.stop?.().catch(() => {});

--- a/templates/zswap-da/api-examples/09-mint.ts
+++ b/templates/zswap-da/api-examples/09-mint.ts
@@ -19,10 +19,10 @@
 
 import { dirname, resolve } from "node:path";
 import { writeFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
 import { findDeployedContract } from "@midnight-ntwrk/midnight-js-contracts";
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
+import { MidnightBech32m } from "@midnight-ntwrk/wallet-sdk-address-format";
 import {
   buildWalletFacade,
   registerNightForDust,
@@ -140,10 +140,9 @@ for (const [label, sep, idx] of [
 }
 
 console.log("Minting unshielded (proving…)");
-const recipientBytes = wr.unshieldedKeystore.getBech32Address
-  ? (wr.unshieldedKeystore as any).getPublicKey?.() ?? SEP_U
-  : SEP_U;
-const utx = await (deployed.callTx as any).mint_unshielded(SEP_U, MINT_AMOUNT, { bytes: recipientBytes instanceof Uint8Array ? recipientBytes : SEP_U });
+const parsed = MidnightBech32m.parse(wr.unshieldedAddress);
+const recipientBytes = Uint8Array.prototype.slice.call(parsed.data, 0, 32);
+const utx = await (deployed.callTx as any).mint_unshielded(SEP_U, MINT_AMOUNT, { bytes: recipientBytes });
 const ures = utx.private?.result;
 minted.unshielded = (ures instanceof Uint8Array ? toHex(ures) : String(ures ?? toHex(SEP_U))).replace(/^0x/, "").toLowerCase();
 console.log(`  ✅ unshielded: ${minted.unshielded.slice(0, 16)}…\n`);

--- a/templates/zswap-da/api-examples/09-submit-offer.ts
+++ b/templates/zswap-da/api-examples/09-submit-offer.ts
@@ -1,0 +1,131 @@
+// 09-submit-offer.ts — Build a ZSwap offer and submit it to Celestia via the node.
+//
+// What this does:
+//   1. Syncs the maker wallet (WALLET_SEED) to find shielded balances.
+//   2. Picks a give-token and want-token from the first two known tokens.
+//   3. Calls wallet.initSwap() → finalizeTransaction() to produce a signed offer.
+//   4. Encodes it as a zswapoffer1… blob.
+//   5. POSTs to /api/zswap/submit (validates crypto + liveness, then forwards to batcher).
+//   6. Polls /api/zswap/status until status = "open" (landed in Celestia + indexed).
+//
+// Env overrides:
+//   WALLET_SEED=<64-hex>          maker wallet seed
+//   GIVE_TOKEN=<64-hex>           token color to give (default: first known token)
+//   WANT_TOKEN=<64-hex>           token color to want (default: second known token)
+//   GIVE_AMOUNT=500000            amount in base units
+//   WANT_AMOUNT=750000
+//   TTL_MINUTES=30
+
+import { config, get, post, header } from "./config.ts";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { buildWalletAndWaitForFunds } from "@effectstream/midnight-contracts";
+import { encodeOffer } from "mip-zswap-offer";
+
+globalThis.WebSocket = WebSocket;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+header("Submit Offer");
+
+// ── 1. Midnight config from node ──────────────────────────────────────────────
+const midnightCfg = await get<any>("/api/midnight/config");
+setNetworkId(midnightCfg.networkId as any);
+
+const networkUrls = {
+  id:          midnightCfg.networkId as any,
+  indexer:     midnightCfg.indexerUri,
+  indexerWS:   midnightCfg.indexerWsUri,
+  node:        midnightCfg.indexerUri,
+  proofServer: midnightCfg.proofServerUri,
+};
+
+// ── 2. Resolve give/want tokens ───────────────────────────────────────────────
+const tokens = await get<any[]>("/api/known-tokens");
+if (tokens.length < 2) {
+  console.error("Need at least 2 registered tokens. Register tokens first (02-tokens.ts).");
+  process.exit(1);
+}
+
+const GIVE_TOKEN  = process.env.GIVE_TOKEN  ?? tokens[0].token_color;
+const WANT_TOKEN  = process.env.WANT_TOKEN  ?? tokens[1].token_color;
+const GIVE_AMOUNT = BigInt(process.env.GIVE_AMOUNT ?? "500000");
+const WANT_AMOUNT = BigInt(process.env.WANT_AMOUNT ?? "750000");
+const TTL_MS      = (Number(process.env.TTL_MINUTES ?? "30")) * 60_000;
+
+console.log(`Give : ${GIVE_AMOUNT} of ${GIVE_TOKEN.slice(0, 16)}…`);
+console.log(`Want : ${WANT_AMOUNT} of ${WANT_TOKEN.slice(0, 16)}…`);
+console.log(`TTL  : ${TTL_MS / 60_000} minutes`);
+console.log(`Seed : ${config.walletSeed.slice(0, 8)}…\n`);
+
+// ── 3. Build wallet ───────────────────────────────────────────────────────────
+console.log("Syncing maker wallet…");
+const { wallet, zswapSecretKeys, dustSecretKey } =
+  await buildWalletAndWaitForFunds(networkUrls, config.walletSeed, midnightCfg.networkId as any);
+const keys = { shieldedSecretKeys: zswapSecretKeys, dustSecretKey };
+
+// ── 4. Verify balance ─────────────────────────────────────────────────────────
+const state = await wallet.shielded.waitForSyncedState();
+const balances: Record<string, bigint> = state.balances as any;
+const available = balances[GIVE_TOKEN] ?? 0n;
+
+console.log(`Maker balance of give-token: ${available}`);
+if (available < GIVE_AMOUNT) {
+  console.error(`Insufficient balance: have ${available}, need ${GIVE_AMOUNT}`);
+  await wallet.stop().catch(() => {});
+  process.exit(1);
+}
+
+// ── 5. Build offer ────────────────────────────────────────────────────────────
+console.log("\nBuilding offer (proving…)");
+const ttl = new Date(Date.now() + TTL_MS);
+const address = state.address.coinPublicKeyString();
+
+const recipe = await wallet.initSwap(
+  { shielded: { [GIVE_TOKEN]: GIVE_AMOUNT } },
+  [{ type: "shielded", outputs: [{ type: WANT_TOKEN, amount: WANT_AMOUNT, receiverAddress: address }] } as any],
+  keys,
+  { ttl, payFees: false },
+);
+const offerFinalized = await wallet.finalizeTransaction(recipe.transaction);
+const blob = encodeOffer(offerFinalized.serialize());
+
+console.log(`Encoded blob: ${blob.slice(0, 40)}…  (${blob.length} chars)`);
+
+// ── 6. Submit to node ─────────────────────────────────────────────────────────
+console.log("\nSubmitting to /api/zswap/submit…");
+let submitResult: any;
+for (let attempt = 0; attempt < 12; attempt++) {
+  try {
+    submitResult = await post("/api/zswap/submit", { blob });
+    break;
+  } catch (e: any) {
+    if (e.message?.includes("ROOT_UNKNOWN") && attempt < 11) {
+      console.log(`  ROOT_UNKNOWN — node may still be syncing; retrying in 10s… (${attempt + 1}/12)`);
+      await sleep(10_000);
+    } else {
+      await wallet.stop().catch(() => {});
+      throw e;
+    }
+  }
+}
+
+console.log("Submit result:", JSON.stringify(submitResult, null, 2));
+const { txhash, height } = submitResult?.result ?? {};
+console.log(`\n✅  Blob published to Celestia  txhash=${txhash}  height=${height}`);
+
+// ── 7. Wait for indexer to pick it up ─────────────────────────────────────────
+console.log("\nWaiting for offer to appear in the indexer…");
+for (let i = 0; i < 30; i++) {
+  await sleep(5_000);
+  const { status } = await get<any>(`/api/zswap/status?blob=${encodeURIComponent(blob)}`);
+  console.log(`  status: ${status}`);
+  if (status === "open") {
+    console.log("✅  Offer is live in the order book.");
+    break;
+  }
+  if (status === "completed" || status === "expired") break;
+}
+
+await wallet.stop().catch(() => {});
+console.log("\nBlob for settlement (copy for 10-settle-offer.ts):");
+console.log(`  OFFER_BLOB="${blob}"`);

--- a/templates/zswap-da/api-examples/10-settle-offer.ts
+++ b/templates/zswap-da/api-examples/10-settle-offer.ts
@@ -1,0 +1,95 @@
+// 10-settle-offer.ts — Take and settle an open offer on Midnight.
+//
+// What this does:
+//   1. Fetches the first open offer from the book (or use OFFER_BLOB env var).
+//   2. Builds the taker wallet (TAKER_SEED).
+//   3. Calls wallet.balanceFinalizedTransaction() to produce a settlement tx.
+//   4. Finalizes and submits to Midnight.
+//   5. Polls the nullifier set until the offer is ARCHIVED (CONSUMED).
+//
+// Env overrides:
+//   TAKER_SEED=<64-hex>     taker wallet seed (must have enough NIGHT for dust fees)
+//   OFFER_BLOB=zswapoffer1… specific offer to settle; defaults to first open offer
+
+import { config, get, header } from "./config.ts";
+import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
+import { buildWalletAndWaitForFunds } from "@effectstream/midnight-contracts";
+import { Transaction } from "@midnight-ntwrk/ledger-v8";
+import { decodeOffer } from "mip-zswap-offer";
+
+globalThis.WebSocket = WebSocket;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+header("Settle Offer");
+
+// ── 1. Midnight config ────────────────────────────────────────────────────────
+const midnightCfg = await get<any>("/api/midnight/config");
+setNetworkId(midnightCfg.networkId as any);
+
+const networkUrls = {
+  id:          midnightCfg.networkId as any,
+  indexer:     midnightCfg.indexerUri,
+  indexerWS:   midnightCfg.indexerWsUri,
+  node:        midnightCfg.indexerUri,
+  proofServer: midnightCfg.proofServerUri,
+};
+
+// ── 2. Pick an offer ──────────────────────────────────────────────────────────
+let blob = process.env.OFFER_BLOB ?? "";
+let offerId: number | undefined;
+
+if (!blob) {
+  const offers = await get<any[]>("/api/zswaps?limit=1");
+  if (offers.length === 0) {
+    console.error("No open offers. Submit one first with 09-submit-offer.ts.");
+    process.exit(1);
+  }
+  blob    = offers[0].transaction_hex;
+  offerId = offers[0].id;
+  console.log(`Using offer id=${offerId}  celestia=#${offers[0].celestia_height}`);
+  console.log(`  gives: ${JSON.stringify(offers[0].gives)}`);
+  console.log(`  wants: ${JSON.stringify(offers[0].wants)}\n`);
+} else {
+  console.log(`Using OFFER_BLOB (${blob.slice(0, 32)}…)\n`);
+}
+
+// ── 3. Build taker wallet ─────────────────────────────────────────────────────
+console.log(`Building taker wallet (seed ${config.takerSeed.slice(0, 8)}…)…`);
+const { wallet, zswapSecretKeys, dustSecretKey } =
+  await buildWalletAndWaitForFunds(networkUrls, config.takerSeed, midnightCfg.networkId as any);
+const keys = { shieldedSecretKeys: zswapSecretKeys, dustSecretKey };
+
+// ── 4. Balance and finalize ───────────────────────────────────────────────────
+console.log("Balancing settlement transaction (proving…)");
+const offerTx = Transaction.deserialize("signature", "proof", "binding", decodeOffer(blob));
+
+const balRecipe = await (wallet as any).balanceFinalizedTransaction(offerTx, keys, {
+  ttl: new Date(Date.now() + 30 * 60_000),
+});
+const settleTx = await wallet.finalizeRecipe(balRecipe);
+
+// ── 5. Submit to Midnight ─────────────────────────────────────────────────────
+console.log("Submitting settlement transaction to Midnight…");
+await (wallet as any).submitTransaction(settleTx);
+
+const txHash = settleTx.transactionHash?.().toString?.().slice(0, 24) ?? "(tx)";
+console.log(`\n✅  Settlement submitted: ${txHash}…`);
+
+// ── 6. Wait for offer to be archived ─────────────────────────────────────────
+console.log("\nWaiting for offer to be archived (nullifier consumed)…");
+for (let i = 0; i < 36; i++) {
+  await sleep(5_000);
+  const { status } = await get<any>(`/api/zswap/status?blob=${encodeURIComponent(blob)}`);
+  console.log(`  status: ${status}`);
+  if (status === "completed") {
+    console.log("✅  Offer archived as CONSUMED — settlement confirmed.");
+    break;
+  }
+  if (status === "expired" || status === "not_found") {
+    console.log(`Offer ended with status: ${status}`);
+    break;
+  }
+}
+
+await wallet.stop().catch(() => {});

--- a/templates/zswap-da/api-examples/10-submit-offer.ts
+++ b/templates/zswap-da/api-examples/10-submit-offer.ts
@@ -17,7 +17,7 @@
 //   WANT_AMOUNT=750000
 //   TTL_MINUTES=30
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { config, get, post, header } from "./config.ts";
 import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
 import { buildWalletAndWaitForFunds } from "@effectstream/midnight-contracts";
@@ -130,17 +130,32 @@ console.log(`\n✅  Blob published to Celestia  txhash=${txhash}  height=${heigh
 
 // ── 7. Wait for indexer to pick it up ─────────────────────────────────────────
 console.log("\nWaiting for offer to appear in the indexer…");
+let landed = false;
 for (let i = 0; i < 30; i++) {
   await sleep(5_000);
   const { status } = await get<any>(`/api/zswap/status?blob=${encodeURIComponent(blob)}`);
-  console.log(`  status: ${status}`);
+  console.log(`  [${i + 1}/30] status: ${status}`);
   if (status === "open") {
+    landed = true;
     console.log("✅  Offer is live in the order book.");
     break;
   }
-  if (status === "completed" || status === "expired") break;
+  if (status === "completed" || status === "expired") {
+    console.error(`Offer ended with status "${status}" before it could be seen as open.`);
+    break;
+  }
 }
 
 await wallet.stop().catch(() => {});
-console.log("\nBlob for settlement (copy for 10-settle-offer.ts):");
+
+if (!landed) {
+  console.error("\n✗  Offer did not reach 'open' status within the polling window.");
+  console.error("   Check node sync and Celestia indexer lag, then retry.");
+  process.exit(1);
+}
+
+// Write blob to a handoff file so run-all.ts can confirm and pass it to 11-settle-offer.
+writeFileSync("/tmp/zswap-last-offer.json", JSON.stringify({ blob, status: "open" }));
+console.log("\nBlob written to /tmp/zswap-last-offer.json");
+console.log("Blob for settlement (copy for 11-settle-offer.ts):");
 console.log(`  OFFER_BLOB="${blob}"`);

--- a/templates/zswap-da/api-examples/10-submit-offer.ts
+++ b/templates/zswap-da/api-examples/10-submit-offer.ts
@@ -1,8 +1,9 @@
-// 09-submit-offer.ts — Build a ZSwap offer and submit it to Celestia via the node.
+// 10-submit-offer.ts — Build a ZSwap offer and submit it to Celestia via the node.
 //
 // What this does:
 //   1. Syncs the maker wallet (WALLET_SEED) to find shielded balances.
-//   2. Picks a give-token and want-token from the first two known tokens.
+//   2. Picks give/want tokens: GIVE_TOKEN/WANT_TOKEN env vars, or colors from
+//      09-mint.ts output (/tmp/zswap-minted-tokens.json), or first two known tokens.
 //   3. Calls wallet.initSwap() → finalizeTransaction() to produce a signed offer.
 //   4. Encodes it as a zswapoffer1… blob.
 //   5. POSTs to /api/zswap/submit (validates crypto + liveness, then forwards to batcher).
@@ -10,12 +11,13 @@
 //
 // Env overrides:
 //   WALLET_SEED=<64-hex>          maker wallet seed
-//   GIVE_TOKEN=<64-hex>           token color to give (default: first known token)
-//   WANT_TOKEN=<64-hex>           token color to want (default: second known token)
+//   GIVE_TOKEN=<64-hex>           token color to give
+//   WANT_TOKEN=<64-hex>           token color to want
 //   GIVE_AMOUNT=500000            amount in base units
 //   WANT_AMOUNT=750000
 //   TTL_MINUTES=30
 
+import { readFileSync } from "node:fs";
 import { config, get, post, header } from "./config.ts";
 import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
 import { buildWalletAndWaitForFunds } from "@effectstream/midnight-contracts";
@@ -40,14 +42,27 @@ const networkUrls = {
 };
 
 // ── 2. Resolve give/want tokens ───────────────────────────────────────────────
-const tokens = await get<any[]>("/api/known-tokens");
-if (tokens.length < 2) {
-  console.error("Need at least 2 registered tokens. Register tokens first (02-tokens.ts).");
-  process.exit(1);
-}
+// Priority: explicit env vars → colors from 09-mint.ts temp file → first two known tokens.
+let GIVE_TOKEN = process.env.GIVE_TOKEN ?? "";
+let WANT_TOKEN = process.env.WANT_TOKEN ?? "";
 
-const GIVE_TOKEN  = process.env.GIVE_TOKEN  ?? tokens[0].token_color;
-const WANT_TOKEN  = process.env.WANT_TOKEN  ?? tokens[1].token_color;
+if (!GIVE_TOKEN || !WANT_TOKEN) {
+  try {
+    const minted = JSON.parse(readFileSync("/tmp/zswap-minted-tokens.json", "utf-8"));
+    GIVE_TOKEN = GIVE_TOKEN || minted.shieldedA;
+    WANT_TOKEN = WANT_TOKEN || minted.shieldedB;
+    console.log("Using minted tokens from 09-mint.ts output.");
+  } catch {
+    const tokens = await get<any[]>("/api/known-tokens");
+    if (tokens.length < 2) {
+      console.error("Need at least 2 tokens. Run 09-mint.ts first, or set GIVE_TOKEN/WANT_TOKEN.");
+      process.exit(1);
+    }
+    GIVE_TOKEN = GIVE_TOKEN || tokens[0].token_color;
+    WANT_TOKEN = WANT_TOKEN || tokens[1].token_color;
+    console.log("Using first two tokens from /api/known-tokens.");
+  }
+}
 const GIVE_AMOUNT = BigInt(process.env.GIVE_AMOUNT ?? "500000");
 const WANT_AMOUNT = BigInt(process.env.WANT_AMOUNT ?? "750000");
 const TTL_MS      = (Number(process.env.TTL_MINUTES ?? "30")) * 60_000;

--- a/templates/zswap-da/api-examples/11-settle-offer.ts
+++ b/templates/zswap-da/api-examples/11-settle-offer.ts
@@ -1,4 +1,4 @@
-// 10-settle-offer.ts — Take and settle an open offer on Midnight.
+// 11-settle-offer.ts — Take and settle an open offer on Midnight.
 //
 // What this does:
 //   1. Fetches the first open offer from the book (or use OFFER_BLOB env var).

--- a/templates/zswap-da/api-examples/config.ts
+++ b/templates/zswap-da/api-examples/config.ts
@@ -1,0 +1,81 @@
+// api-examples/config.ts
+// Run any script: bun run api-examples/<script>.ts
+// Override env vars to point at a different environment.
+
+export type NetworkId = "undeployed" | "preview" | "mainnet";
+
+export interface EnvConfig {
+  nodeUrl: string;
+  batcherUrl: string;
+  networkId: NetworkId;
+  /** Hex wallet seed (64 chars). Required for wallet / offer / settle scripts. */
+  walletSeed: string;
+  /** Optional second wallet seed for taker-side settlement demo. */
+  takerSeed: string;
+}
+
+const PRESETS: Record<NetworkId, Pick<EnvConfig, "nodeUrl" | "batcherUrl" | "networkId">> = {
+  undeployed: {
+    networkId: "undeployed",
+    nodeUrl:   "http://localhost:9999",
+    batcherUrl:"http://localhost:3334",
+  },
+  preview: {
+    networkId: "preview",
+    nodeUrl:   "https://api-zswap.zkdojo.com",
+    batcherUrl:"https://api-zswap.zkdojo.com:3334",
+  },
+  mainnet: {
+    networkId: "mainnet",
+    nodeUrl:   "https://api-zswap.zkdojo.com",   // update for mainnet deployment
+    batcherUrl:"https://api-zswap.zkdojo.com:3334",
+  },
+};
+
+const network = (process.env.MIDNIGHT_NETWORK_ID ?? "preview") as NetworkId;
+const preset  = PRESETS[network] ?? PRESETS.preview;
+
+export const config: EnvConfig = {
+  ...preset,
+  nodeUrl:    process.env.NODE_URL    ?? preset.nodeUrl,
+  batcherUrl: process.env.BATCHER_URL ?? preset.batcherUrl,
+  // Preview genesis wallet (seed 0x…0001) — has funds on undeployed only.
+  // On preview/mainnet set WALLET_SEED to your own funded hex seed, or set
+  // MIDNIGHT_WALLET_MNEMONIC and run mnemonic-to-seed.ts to derive it.
+  walletSeed: process.env.WALLET_SEED ?? "0000000000000000000000000000000000000000000000000000000000000001",
+  takerSeed:  process.env.TAKER_SEED  ?? "0000000000000000000000000000000000000000000000000000000000000002",
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+export async function get<T = unknown>(path: string): Promise<T> {
+  const url = `${config.nodeUrl}${path}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GET ${url} → ${res.status} ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+export async function post<T = unknown>(path: string, body: unknown, base = config.nodeUrl): Promise<T> {
+  const url = `${base}${path}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let detail: string;
+    try { detail = JSON.stringify(await res.json()); } catch { detail = await res.text(); }
+    throw new Error(`POST ${url} → ${res.status}: ${detail}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function print(label: string, data: unknown) {
+  console.log(`\n── ${label} ${"─".repeat(Math.max(0, 60 - label.length))}`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function header(title: string) {
+  const line = "═".repeat(64);
+  console.log(`\n${line}\n  ${title}\n${line}`);
+}

--- a/templates/zswap-da/api-examples/run-all.ts
+++ b/templates/zswap-da/api-examples/run-all.ts
@@ -12,7 +12,8 @@
 //   WALLET_SEED  TAKER_SEED  WALLET_OPS
 //   GIVE_TOKEN  WANT_TOKEN  GIVE_AMOUNT  WANT_AMOUNT  TTL_MINUTES  MINT_AMOUNT
 
-import { config, header } from "./config.ts";
+import { readFileSync } from "node:fs";
+import { config, header, get } from "./config.ts";
 
 const WALLET_OPS = process.env.WALLET_OPS === "1";
 // Gap between wallet/chain operations — Midnight batcher queues serially.
@@ -97,10 +98,34 @@ if (!submitOk) {
   process.exit(1);
 }
 
+// ── Confirm the offer is actually open before handing off to the settler ──────
+// Script 10 writes /tmp/zswap-last-offer.json on success; re-check the status
+// via the API here so we never launch the settler against a stale or missing offer.
+console.log("\n── Confirming offer is open before settlement ──────────────────────");
+let offerBlob = "";
+try {
+  const handoff = JSON.parse(readFileSync("/tmp/zswap-last-offer.json", "utf-8"));
+  offerBlob = handoff.blob ?? "";
+} catch {
+  console.error("✗  /tmp/zswap-last-offer.json not found — script 10 may not have completed cleanly.");
+  process.exit(1);
+}
+
+const { status: offerStatus } = await get<any>(
+  `/api/zswap/status?blob=${encodeURIComponent(offerBlob)}`,
+);
+console.log(`   /api/zswap/status → "${offerStatus}"`);
+if (offerStatus !== "open") {
+  console.error(`✗  Offer is not open (status: "${offerStatus}"). Aborting settlement.`);
+  process.exit(1);
+}
+console.log("✅  Offer confirmed open — proceeding to settlement.\n");
+
 // Settle offer (taker wallet → Midnight)
 await sleep(PAUSE_MS);
 await run("11 · Settle offer on Midnight", "api-examples/11-settle-offer.ts", {
   TAKER_SEED: config.takerSeed,
+  OFFER_BLOB: offerBlob,   // pin the exact offer — no guessing from the book
 });
 
 // ── Summary ───────────────────────────────────────────────────────────────────

--- a/templates/zswap-da/api-examples/run-all.ts
+++ b/templates/zswap-da/api-examples/run-all.ts
@@ -1,0 +1,98 @@
+// run-all.ts — Master coordinator. Runs all api-example scripts in series.
+//
+// Usage:
+//   bun run api-examples/run-all.ts              # read-only: 01–06
+//   WALLET_OPS=1 bun run api-examples/run-all.ts # also runs 08–10 (wallet + offer + settle)
+//
+// The batcher and Midnight node cannot handle concurrent calls — every step
+// runs sequentially, with a configurable pause between wallet operations.
+//
+// Env overrides (passed through to child scripts):
+//   MIDNIGHT_NETWORK_ID  NODE_URL  BATCHER_URL
+//   WALLET_SEED  TAKER_SEED  WALLET_OPS
+//   GIVE_TOKEN  WANT_TOKEN  GIVE_AMOUNT  WANT_AMOUNT  TTL_MINUTES
+
+import { config, header } from "./config.ts";
+
+const WALLET_OPS = process.env.WALLET_OPS === "1";
+// Gap between wallet/chain operations — Midnight batcher queues serially.
+const PAUSE_MS = 3_000;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function run(label: string, script: string, env: Record<string, string> = {}) {
+  console.log(`\n${"▶".repeat(1)} ${label}`);
+  const proc = Bun.spawn(
+    ["bun", "run", script],
+    {
+      cwd: new URL("..", import.meta.url).pathname,
+      env: { ...process.env, ...env },
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+  const code = await proc.exited;
+  if (code !== 0) {
+    console.error(`\n✗  ${label} exited with code ${code}`);
+    if (process.env.FAIL_FAST === "1") process.exit(code);
+  }
+  return code === 0;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+header(`ZSwap-DA API Examples — ${config.networkId.toUpperCase()}`);
+console.log(`Node    : ${config.nodeUrl}`);
+console.log(`Batcher : ${config.batcherUrl}`);
+console.log(`Mode    : ${WALLET_OPS ? "read + wallet ops" : "read-only (set WALLET_OPS=1 for full run)"}`);
+
+// ── Phase 1: Read-only — no chain interaction ─────────────────────────────────
+await run("01 · Health check",       "api-examples/01-health.ts");
+await run("02 · Known tokens",       "api-examples/02-tokens.ts");
+await run("03 · Live offer book",    "api-examples/03-offers.ts");
+await run("04 · Trading pairs",      "api-examples/04-pairs.ts");
+await run("05 · Market data",        "api-examples/05-market.ts");
+await run("06 · Midnight config",    "api-examples/06-midnight-config.ts");
+// Note: 07-events.ts runs forever (SSE stream) — skip in run-all.
+
+if (!WALLET_OPS) {
+  console.log("\n──────────────────────────────────────────────────────────────");
+  console.log("  Read-only phase complete.");
+  console.log("  Run with WALLET_OPS=1 to also execute wallet + offer scripts.");
+  process.exit(0);
+}
+
+// ── Phase 2: Wallet operations — sequential, pauses between each ──────────────
+console.log("\n──────────────────────────────────────────────────────────────");
+console.log("  Starting wallet operations (series — batcher is single-threaded)");
+console.log("──────────────────────────────────────────────────────────────");
+
+// Wallet inspection
+await sleep(PAUSE_MS);
+const walletOk = await run("08 · Wallet sync + balances", "api-examples/08-wallet.ts", {
+  WALLET_SEED: config.walletSeed,
+});
+if (!walletOk) {
+  console.error("Wallet sync failed — check WALLET_SEED and that the proof server is reachable.");
+  process.exit(1);
+}
+
+// Submit offer (maker wallet → Celestia via batcher)
+await sleep(PAUSE_MS);
+const submitOk = await run("09 · Build + submit offer", "api-examples/09-submit-offer.ts", {
+  WALLET_SEED: config.walletSeed,
+});
+if (!submitOk) {
+  console.error("Offer submission failed — check WALLET_SEED balance and node sync status.");
+  process.exit(1);
+}
+
+// Settle offer (taker wallet → Midnight)
+await sleep(PAUSE_MS);
+await run("10 · Settle offer on Midnight", "api-examples/10-settle-offer.ts", {
+  TAKER_SEED: config.takerSeed,
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log("\n══════════════════════════════════════════════════════════════════");
+console.log("  All steps complete.");
+console.log("══════════════════════════════════════════════════════════════════");

--- a/templates/zswap-da/api-examples/run-all.ts
+++ b/templates/zswap-da/api-examples/run-all.ts
@@ -2,7 +2,7 @@
 //
 // Usage:
 //   bun run api-examples/run-all.ts              # read-only: 01–06
-//   WALLET_OPS=1 bun run api-examples/run-all.ts # also runs 08–10 (wallet + offer + settle)
+//   WALLET_OPS=1 bun run api-examples/run-all.ts # also runs 08–11 (wallet + mint + offer + settle)
 //
 // The batcher and Midnight node cannot handle concurrent calls — every step
 // runs sequentially, with a configurable pause between wallet operations.
@@ -10,7 +10,7 @@
 // Env overrides (passed through to child scripts):
 //   MIDNIGHT_NETWORK_ID  NODE_URL  BATCHER_URL
 //   WALLET_SEED  TAKER_SEED  WALLET_OPS
-//   GIVE_TOKEN  WANT_TOKEN  GIVE_AMOUNT  WANT_AMOUNT  TTL_MINUTES
+//   GIVE_TOKEN  WANT_TOKEN  GIVE_AMOUNT  WANT_AMOUNT  TTL_MINUTES  MINT_AMOUNT
 
 import { config, header } from "./config.ts";
 
@@ -76,9 +76,20 @@ if (!walletOk) {
   process.exit(1);
 }
 
-// Submit offer (maker wallet → Celestia via batcher)
+// Mint test tokens (maker wallet → on-chain contract circuits)
+// Domain separators are fixed so re-runs top up the same token colors.
 await sleep(PAUSE_MS);
-const submitOk = await run("09 · Build + submit offer", "api-examples/09-submit-offer.ts", {
+const mintOk = await run("09 · Mint test tokens", "api-examples/09-mint.ts", {
+  WALLET_SEED: config.walletSeed,
+});
+if (!mintOk) {
+  console.error("Mint failed — check WALLET_SEED has NIGHT for dust fees and proof server is reachable.");
+  process.exit(1);
+}
+
+// Submit offer using the freshly minted tokens (maker wallet → Celestia via batcher)
+await sleep(PAUSE_MS);
+const submitOk = await run("10 · Build + submit offer", "api-examples/10-submit-offer.ts", {
   WALLET_SEED: config.walletSeed,
 });
 if (!submitOk) {
@@ -88,7 +99,7 @@ if (!submitOk) {
 
 // Settle offer (taker wallet → Midnight)
 await sleep(PAUSE_MS);
-await run("10 · Settle offer on Midnight", "api-examples/10-settle-offer.ts", {
+await run("11 · Settle offer on Midnight", "api-examples/11-settle-offer.ts", {
   TAKER_SEED: config.takerSeed,
 });
 

--- a/templates/zswap-da/packages/database/migrations/000-init.sql
+++ b/templates/zswap-da/packages/database/migrations/000-init.sql
@@ -1,3 +1,8 @@
+-- DEMO / TEMPORARY: known_tokens is a manually curated convenience table for
+-- this demo. The official Midnight token-metadata standard is not yet live.
+-- Names and kinds stored here are unverified and MUST NOT be treated as
+-- authoritative token information. This table and its API endpoints will be
+-- replaced once the standard is finalised.
 CREATE TABLE known_tokens (
     id SERIAL PRIMARY KEY,
     token_color TEXT UNIQUE NOT NULL,

--- a/templates/zswap-da/packages/frontend-new/src/screens/Market.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/screens/Market.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Coin, Icon, isShielded } from '../ui/icons';
 import { api, type ChartHistoryRow, type ChartStats, type PairInfo } from '../services/api';
 import { shortToken } from '../utils';
+import { TokenChip } from '../ui/TokenChip';
 import type { Order, ZSwapApp } from '../state/useZSwapApp';
 
 type Side = 'ask' | 'bid';
@@ -335,7 +336,7 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
             <Stat label="High">{fmtPrice(stats.high)}</Stat>
             <Stat label="Low">{fmtPrice(stats.low)}</Stat>
             <Stat label="Volume" sub={fmtQty(stats.volume_quote) + ' ' + quote}>{fmtQty(stats.volume_base)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{base}</span></Stat>
-            <Stat label={base + ' asset ID'}>{shortToken(baseColor)}</Stat>
+            <Stat label="Asset ID"><TokenChip color={baseColor} knownTokens={st.knownTokens} size="sm" /></Stat>
           </div>
         )}
 
@@ -394,7 +395,9 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
               </div>
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', padding: '10px 12px 6px', fontSize: 11, fontWeight: 700, letterSpacing: '.05em', textTransform: 'uppercase', color: 'var(--ink-3)' }}>
-              <span>Price ({quote})</span><span style={{ textAlign: 'right' }}>Amount ({base})</span><span style={{ textAlign: 'right' }}>Total ({base})</span>
+              <span>Price (<TokenChip color={quoteColor} knownTokens={st.knownTokens} inline />)</span>
+              <span style={{ textAlign: 'right' }}>Amount (<TokenChip color={baseColor} knownTokens={st.knownTokens} inline />)</span>
+              <span style={{ textAlign: 'right' }}>Total (<TokenChip color={baseColor} knownTokens={st.knownTokens} inline />)</span>
             </div>
 
             {!realDepth ? (
@@ -443,7 +446,9 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
               <span className="zs-pill"><Icon.clock /> {base}/{quote}</span>
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.2fr', padding: '10px 12px 6px', fontSize: 11, fontWeight: 700, letterSpacing: '.05em', textTransform: 'uppercase', color: 'var(--ink-3)' }}>
-              <span>Price ({quote})</span><span style={{ textAlign: 'right' }}>Amount ({base})</span><span style={{ textAlign: 'right' }}>Time</span>
+              <span>Price (<TokenChip color={quoteColor} knownTokens={st.knownTokens} inline />)</span>
+              <span style={{ textAlign: 'right' }}>Amount (<TokenChip color={baseColor} knownTokens={st.knownTokens} inline />)</span>
+              <span style={{ textAlign: 'right' }}>Time</span>
             </div>
             <div style={{ maxHeight: 432, overflowY: 'auto' }}>
               {history.length === 0 && <div style={{ padding: '40px 0', textAlign: 'center', color: 'var(--ink-3)', fontSize: 13 }}>{loading ? 'Loading…' : 'No trades.'}</div>}

--- a/templates/zswap-da/packages/frontend-new/src/styles/tokens.css
+++ b/templates/zswap-da/packages/frontend-new/src/styles/tokens.css
@@ -181,6 +181,50 @@ body { background: var(--bg); color: var(--ink); font-family: var(--font-ui); -w
   .zs-coin--tip::after { transition: none; }
 }
 
+/* zs-token-id — inline token label: hover 2 s → full hex tooltip, click → copy */
+.zs-token-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 1px 4px;
+  transition: background 0.12s;
+  user-select: none;
+}
+.zs-token-id:hover { background: var(--surface-2); }
+.zs-token-id::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface);
+  color: var(--ink-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 5px 9px;
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: var(--sh-pop);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease 0s;
+  z-index: 99;
+}
+.zs-token-id:hover::after {
+  opacity: 1;
+  transition-delay: 2s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .zs-token-id::after { transition: none; }
+}
+
 /* shielded coin — blue-cyan forcefield glow that breathes */
 .zs-coin--shielded { animation: zs-forcefield 2.1s ease-in-out infinite; }
 .zs-coin--sm.zs-coin--shielded { animation: zs-forcefield-sm 2.1s ease-in-out infinite; }

--- a/templates/zswap-da/packages/frontend-new/src/ui/TokenChip.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/TokenChip.tsx
@@ -1,0 +1,121 @@
+// TokenChip — structured token display used everywhere a token ID appears in the UI.
+//
+// Full (default): [coin logo]  Name  short-id
+//   The Coin logo already shows the full 64-hex address after a 2s hover via
+//   the .zs-coin--tip CSS class. Clicking the chip copies the full ID.
+//
+// Inline: Name short-id — rendered as a tight inline <span>, same hover + copy.
+//   Used in compact contexts like order-book column headers.
+
+import { useState, useCallback } from 'react';
+import { Coin } from './icons';
+import { shortToken } from '../utils';
+import type { KnownToken } from '../types';
+
+interface TokenChipProps {
+  color: string;
+  knownTokens?: KnownToken[];
+  size?: 'sm' | 'md';
+  /** Omit the Coin logo; render as a tight inline span. */
+  inline?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function TokenChip({
+  color,
+  knownTokens = [],
+  size = 'md',
+  inline = false,
+  className,
+  style,
+}: TokenChipProps) {
+  const [copied, setCopied] = useState(false);
+
+  const token = knownTokens.find((t) => t.token_color === color);
+  const name = token?.name ?? shortToken(color);
+  const short = shortToken(color);
+  const hasName = name !== short;
+
+  const copy = useCallback(() => {
+    navigator.clipboard.writeText(color).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    });
+  }, [color]);
+
+  if (inline) {
+    return (
+      <span
+        className={'zs-token-id' + (className ? ' ' + className : '')}
+        data-tip={color}
+        onClick={copy}
+        style={{ position: 'relative', ...style }}
+      >
+        <span style={{ fontWeight: 700 }}>{name}</span>
+        {hasName && (
+          <span className="zs-num" style={{ color: 'var(--ink-3)', fontSize: '0.82em' }}>
+            {short}
+          </span>
+        )}
+        {copied && <CopiedFlash />}
+      </span>
+    );
+  }
+
+  const sm = size === 'sm';
+  return (
+    <span
+      onClick={copy}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: sm ? 6 : 8,
+        cursor: 'pointer',
+        userSelect: 'none',
+        position: 'relative',
+        ...style,
+      }}
+      className={className}
+      title="Click to copy token ID"
+    >
+      <Coin sym={name} address={color} size={sm ? 'sm' : undefined} />
+      <span style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.3, minWidth: 0 }}>
+        <span style={{ fontWeight: 700, fontSize: sm ? 12.5 : 13.5, whiteSpace: 'nowrap' }}>
+          {name}
+        </span>
+        {hasName && (
+          <span className="zs-num" style={{ fontSize: 10.5, color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>
+            {short}
+          </span>
+        )}
+      </span>
+      {copied && <CopiedFlash />}
+    </span>
+  );
+}
+
+function CopiedFlash() {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        bottom: 'calc(100% + 4px)',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'var(--pos)',
+        color: '#fff',
+        padding: '3px 9px',
+        borderRadius: 6,
+        fontSize: 11,
+        fontWeight: 600,
+        whiteSpace: 'nowrap',
+        zIndex: 101,
+        pointerEvents: 'none',
+        boxShadow: '0 2px 6px rgba(0,0,0,.22)',
+      }}
+    >
+      Copied!
+    </span>
+  );
+}

--- a/templates/zswap-da/packages/frontend-new/src/ui/WalletMenu.tsx
+++ b/templates/zswap-da/packages/frontend-new/src/ui/WalletMenu.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { WalletPill, type WalletInfo } from './WalletPill';
 import { Icon } from './icons';
-import { shortToken, truncateAddress } from '../utils';
+import { truncateAddress } from '../utils';
 import { fmtBalance } from '../state/format';
+import { TokenChip } from './TokenChip';
+import type { KnownToken } from '../types';
 
 interface WalletMenuState {
   wallet: WalletInfo | null;
@@ -12,12 +14,13 @@ interface WalletMenuState {
   unshieldedAddress: string | null;
   shieldedBalances: Record<string, string> | null;
   unshieldedBalances: Record<string, string> | null;
+  knownTokens?: KnownToken[];
   disconnect: () => void;
   refreshBalances?: () => void;
   refreshing?: boolean;
 }
 
-function BalRows({ title, balances }: { title: string; balances: Record<string, string> | null }) {
+function BalRows({ title, balances, knownTokens }: { title: string; balances: Record<string, string> | null; knownTokens: KnownToken[] }) {
   const entries = Object.entries(balances ?? {}).filter(([, v]) => Number(v) > 0);
   return (
     <div style={{ marginBottom: 10 }}>
@@ -25,11 +28,11 @@ function BalRows({ title, balances }: { title: string; balances: Record<string, 
       {entries.length === 0 ? (
         <div style={{ fontSize: 12.5, color: 'var(--ink-3)' }}>none</div>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {entries.map(([color, amt]) => (
-            <div key={color} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 13, gap: 12 }}>
-              <span className="zs-num" style={{ color: 'var(--ink-3)' }}>{shortToken(color)}</span>
-              <span className="zs-num" style={{ fontWeight: 600 }}>{fmtBalance(amt)}</span>
+            <div key={color} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+              <TokenChip color={color} knownTokens={knownTokens} size="sm" />
+              <span className="zs-num" style={{ fontWeight: 600, fontSize: 13 }}>{fmtBalance(amt)}</span>
             </div>
           ))}
         </div>
@@ -63,8 +66,8 @@ export function WalletMenu({ st }: { st: WalletMenuState }) {
             <Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} />
             <span className="zs-num" style={{ fontSize: 12.5, fontWeight: 600, wordBreak: 'break-all', color: 'var(--ink-2)' }}>{truncateAddress(addr)}</span>
           </div>
-          <BalRows title="Shielded" balances={st.shieldedBalances} />
-          <BalRows title="Unshielded" balances={st.unshieldedBalances} />
+          <BalRows title="Shielded" balances={st.shieldedBalances} knownTokens={st.knownTokens ?? []} />
+          <BalRows title="Unshielded" balances={st.unshieldedBalances} knownTokens={st.knownTokens ?? []} />
           <button className="zs-btn zs-btn--block" style={{ padding: 11, fontSize: 14 }} onClick={() => { setOpen(false); st.disconnect(); }}>Disconnect</button>
         </div>
       )}

--- a/templates/zswap-da/packages/node/state-machine.ts
+++ b/templates/zswap-da/packages/node/state-machine.ts
@@ -429,9 +429,12 @@ stm.addStateTransition("celestia-zswap", function* (data) {
     }
 
     // ── Auto-register new token colors ──
+    // DEMO / TEMPORARY: known_tokens is a manually curated convenience table.
+    // The Midnight token-metadata standard is not yet live — names written here
+    // are placeholder abbreviations and MUST NOT be trusted as authoritative.
     // Any token color appearing in this offer that isn't already in
     // known_tokens gets a placeholder entry. ON CONFLICT DO NOTHING means
-    // existing entries (including the pre-seeded native_* tokens) are never
+    // existing entries (including the pre-seeded NIGHT token) are never
     // overwritten. kind is always 'shielded': ZSwap offers are structurally
     // shielded-only; unshielded tokens only appear inside Intent structures.
     const seenColors = new Set<string>();


### PR DESCRIPTION
## Summary

- **Celestia concurrent fetcher** (`ea3312e4`, `4050badc`): parallel worker pool with timeout-guarded RPC; retry RPC forever instead of bounded retries
- **Template-tests CI fix** (`95f8b5f9`, `ed38615b`): upgrade `@fastify/rate-limit` v9→v10 for Fastify 5 compatibility; rename genesis tokens (`native_0` → `NIGHT`)
- **API.md rewrite**: full environment table (Undeployed/Preview/Mainnet), complete env-var reference, all endpoints documented with curl examples, error-code table for `/api/zswap/submit`; known-tokens endpoints carry a demo-only warning (Midnight token-metadata standard not yet live)
- **`api-examples/`**: 13 runnable Bun scripts targeting the live preview node by default; covers health, tokens, offers, pairs, market data, SSE events, wallet sync, offer submission, and taker settlement; `run-all.ts` coordinates the full flow in series (batcher is single-threaded); no real secrets — wallet seeds are all-zeros dev placeholders overridable via env vars
- **`TokenChip` component**: structured token display used wherever a token ID appears — full mode (coin logo + name + short-id), inline mode for column headers; hover 2 s shows full 64-hex tooltip; click copies to clipboard
- **WalletMenu + Market**: balance rows and order-book/trade-history column headers now use `TokenChip`; asset ID stat replaced with full chip
- **known-tokens demo warning**: `000-init.sql`, `state-machine.ts`, `02-tokens.ts`, and `API.md` all annotate that `known_tokens` is a temporary demo table — Midnight token-metadata standard is not yet live

## Test plan

- [ ] `bun test packages/` passes (template-tests no longer fail on rate-limit version mismatch)
- [ ] `bun run api-examples/run-all.ts` completes phases 01–06 against `https://api-zswap.zkdojo.com` with no errors
- [ ] Wallet balance rows in the connected wallet dropdown show coin logo + token name + short-id
- [ ] Hovering a `TokenChip` for 2 s reveals the full 64-hex token ID tooltip
- [ ] Clicking a `TokenChip` copies the full ID and briefly shows "Copied!"
- [ ] Order-book column headers show inline token chips for base/quote; clicking copies the color