### PR TITLE
fix(process-blocks): rethrow transient PostgreSQL errors in processFinalizedBlock

### DIFF
--- a/packages/node-sdk/runtime/src/process-blocks.ts
+++ b/packages/node-sdk/runtime/src/process-blocks.ts
@@ -260,6 +260,7 @@ export function* processFinalizedBlock(
             blockEvents.push(...inputEvents);
           }
         } catch (err) {
+          if (isTransientPgError(err)) throw err;
           success = false;
           log.remote(
             ComponentNames.EFFECTSTREAM_SYNC,


### PR DESCRIPTION
Added a check to rethrow transient PostgreSQL errors in the processFinalizedBlock function to ensure proper error handling and logging.Added a check to rethrow transient PostgreSQL errors in the processFinalizedBlock function to ensure proper error handling and logging.

