### PR TITLE
fix: MQTT broker URLs read process.env; deployMidnightContract accepts live wallet

### DIFF
--- a/packages/chains/midnight-contracts/src/deploy.ts
+++ b/packages/chains/midnight-contracts/src/deploy.ts
@@ -92,6 +92,7 @@ export async function deployMidnightContract(
   config: DeployConfig,
   networkUrls?: NetworkUrls,
   seedOrMnemonic?: { seed: string; mnemonic: string },
+  opts?: { walletResult?: WalletResult },
 ): Promise<string> {
   checkEnvVariables();
 
@@ -141,30 +142,32 @@ export async function deployMidnightContract(
 
   setNetworkId(resolvedNetworkId);
 
-  let walletResult: WalletResult | null = null;
+  let walletResult: WalletResult | null = opts?.walletResult ?? null;
   let providers: ReturnType<typeof configureMidnightNodeProviders> | null = null;
 
   try {
-    log.info("Building wallet...");
-    let seed;
-    if (seedOrMnemonic?.seed) {
-      seed = seedOrMnemonic.seed;
-    } else if (seedOrMnemonic?.mnemonic) {
-      seed = Buffer.from(
-        await mnemonicToSeed(seedOrMnemonic.mnemonic),
-      ).toString("hex");
-    } else {
-      seed = midnightNetworkConfig.walletSeed;
-    }
-    if (!seed) {
-      throw new Error("No seed or mnemonic provided");
-    }
+    if (!walletResult) {
+      log.info("Building wallet...");
+      let seed;
+      if (seedOrMnemonic?.seed) {
+        seed = seedOrMnemonic.seed;
+      } else if (seedOrMnemonic?.mnemonic) {
+        seed = Buffer.from(
+          await mnemonicToSeed(seedOrMnemonic.mnemonic),
+        ).toString("hex");
+      } else {
+        seed = midnightNetworkConfig.walletSeed;
+      }
+      if (!seed) {
+        throw new Error("No seed or mnemonic provided");
+      }
 
-    walletResult = await buildWalletAndWaitForFunds(
-      resolvedNetworkUrls,
-      seed,
-      resolvedNetworkId,
-    );
+      walletResult = await buildWalletAndWaitForFunds(
+        resolvedNetworkUrls,
+        seed,
+        resolvedNetworkId,
+      );
+    }
 
     const {
       wallet,
@@ -174,7 +177,7 @@ export async function deployMidnightContract(
       walletDustSecretKey,
       dustAddress,
       unshieldedKeystore,
-    } = walletResult;
+    } = walletResult!;
     const resolvedDustReceiverAddress =
       getEnv("MIDNIGHT_DUST_RECEIVER_ADDRESS") ?? dustAddress;
     if (resolvedDustReceiverAddress === dustAddress) {

--- a/packages/effectstream-sdk/events/src/event-connect.ts
+++ b/packages/effectstream-sdk/events/src/event-connect.ts
@@ -4,6 +4,7 @@ import { toPattern } from './utils.ts';
 import { extract, matches } from 'mqtt-pattern';
 import { EventBrokerNames } from './types.ts';
 import { getRuntime } from '@effectstream/utils/runtime';
+import { ENV } from '@effectstream/utils/node-env';
 
 export interface MqttClientAdapter {
   subscribe(topic: string, qos: number): Promise<void>;
@@ -88,13 +89,6 @@ async function createMqttJsClient(url: string): Promise<MqttClientAdapter> {
   };
 }
 
-// TODO This should come from @effectstream/utils/node-env ENV
-const ENV = {
-  MQTT_ENGINE_BROKER_URL: 'mqtt://localhost:8883',
-  MQTT_BATCHER_BROKER_URL: 'mqtt://localhost:8884',
-  MQTT_ENGINE_BROKER_WS_URL: 'ws://localhost:9883',
-  MQTT_BATCHER_BROKER_WS_URL: 'ws://localhost:9884',
-};
 
 export class EventConnect {
   private static clients: {


### PR DESCRIPTION
## Summary

Two bugs surfaced while bringing **zswap-presale** up on Preview alongside **zswap-da**. Both are in the effectstream monorepo. The zswap-presale patch (operator deploy rewrite) lives in that repo separately.

- **`@effectstream/event-client` `event-connect.ts`** — MQTT broker URLs were hardcoded to `localhost:8883/8884` and never read `process.env`, so both stacks on the same host connected to the same broker (cross-talk). Replace the local `ENV` const with the already-planned import from `@effectstream/utils/node-env`. All four URLs (`MQTT_ENGINE_BROKER_URL`, `MQTT_BATCHER_BROKER_URL`, `MQTT_ENGINE_BROKER_WS_URL`, `MQTT_BATCHER_BROKER_WS_URL`) now respect env vars with `127.0.0.1` defaults.

- **`@effectstream/midnight-contracts` `deploy.ts`** — `deployMidnightContract` always built a throwaway wallet via `buildWalletAndWaitForFunds`. That wallet's dust spend proof is stale by evaluation time → `MalformedError::InvalidDustSpendProof` (error 170). Add optional `opts?: { walletResult?: WalletResult }` fourth parameter. When provided, skip wallet construction and use the caller's continuously-synced wallet directly. Backwards-compatible: all existing callers are unaffected.

## Test plan

- [x] `bun test ./packages` — 138 pass, 5 pre-existing Cardano peer-dep failures (unchanged)
- [x] `bun run e2e/runner.ts midnight` — 21/21 tests pass