### PR TITLE
Catch the remaining uncaught sync-loop failures

### DIFF
--- a/packages/node-sdk/runtime/test/reproduction/error-survival.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/error-survival.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test: a thrown error from `updateState`, `producerChannel.send`,
+ * or the merge step must not crash the node — it should log, retry, and the
+ * sync loop must still reach its target height. This mirrors the design
+ * already documented for `stateToInput`/`readData` in
+ * packages/node-sdk/sync/CLAUDE.md ("Errors are swallowed via tryYield ...").
+ *
+ * Before this fix, none of these three call sites were wrapped: an error
+ * there propagated out of the spawned effection task and the `run()` root in
+ * node-runner.ts rejected (see its `bootErr` handling), so the node subprocess
+ * exited non-zero and `runToHeight` below would have rejected instead of
+ * resolving.
+ *
+ * Fault injection is one-shot and deterministic (see
+ * packages/node-sdk/sync/src/sync-protocols/test/control.ts): the very first
+ * call to the given stage for the given protocol throws; every later call
+ * succeeds — so each test proves both "the failure really happened" (the loop
+ * has to recover) and "the loop still finishes" (it did recover).
+ *
+ * Each scenario gets its own fresh harness/database rather than sharing one:
+ * a second run against an already-synced database might resume with nothing
+ * left to fetch, never touching the faulty call site, and pass vacuously.
+ */
+import { expect, test } from "bun:test";
+import { latestFinalizedHeight, setupHarness } from "./harness.ts";
+
+test("a one-shot updateState failure is logged and retried, not fatal", async () => {
+  const h = await setupHarness();
+  try {
+    await h.runToHeight({
+      events: [],
+      tips: { mainClock: 50, parallelP: 200 },
+      target: 50,
+      apiPort: 19141,
+      faults: [{ protocol: "mainClock", stage: "updateState", times: 1 }],
+    });
+    expect(await latestFinalizedHeight(h.pool)).toBe(50);
+  } finally {
+    await h.teardown();
+  }
+}, 30_000);
+
+test("a one-shot producerChannel.send failure is logged and retried, not fatal", async () => {
+  const h = await setupHarness();
+  try {
+    await h.runToHeight({
+      events: [],
+      tips: { mainClock: 50, parallelP: 200 },
+      target: 50,
+      apiPort: 19142,
+      faults: [{ protocol: "parallelP", stage: "producerChannel", times: 1 }],
+    });
+    expect(await latestFinalizedHeight(h.pool)).toBe(50);
+  } finally {
+    await h.teardown();
+  }
+}, 30_000);
+
+test("a one-shot merge failure discards the candidate block and retries, not fatal", async () => {
+  const h = await setupHarness();
+  try {
+    await h.runToHeight({
+      events: [],
+      tips: { mainClock: 50, parallelP: 200 },
+      target: 50,
+      apiPort: 19143,
+      faults: [{ protocol: "mainClock", stage: "merge", times: 1 }],
+    });
+    expect(await latestFinalizedHeight(h.pool)).toBe(50);
+  } finally {
+    await h.teardown();
+  }
+}, 30_000);

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -26,7 +26,7 @@ import { platform, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { EventSpec } from "./scenario.ts";
-import { TestChainControl } from "@effectstream/sync";
+import { type FailStage, TestChainControl } from "@effectstream/sync";
 import { toSyncProtocolWithNetwork } from "@effectstream/config";
 
 export type RunNodeOpts = {
@@ -317,6 +317,8 @@ export type RunToHeightOpts = {
   securityNamespace?: string;
   /** Enable/disable empty-block coalescing. */
   coalesce?: boolean;
+  /** One-shot failures to inject into the synthetic chain's pipeline. */
+  faults?: { protocol: string; stage: FailStage; times?: number }[];
 };
 
 const RUNNER = join(import.meta.dir, "node-runner.ts");
@@ -342,6 +344,7 @@ function makeRunToHeight(
       apiPort: opts.apiPort,
       waitPages: opts.waitPages,
       coalesce: opts.coalesce,
+      faults: opts.faults,
     };
     return new Promise<void>((resolve, reject) => {
       const child = spawn("bun", [RUNNER, JSON.stringify(spec)], {

--- a/packages/node-sdk/runtime/test/reproduction/node-runner.ts
+++ b/packages/node-sdk/runtime/test/reproduction/node-runner.ts
@@ -22,7 +22,7 @@ import {
   toSyncProtocolWithNetwork,
   withEffectstreamStaticConfig,
 } from "@effectstream/config";
-import { TestChainControl } from "@effectstream/sync";
+import { type FailStage, TestChainControl } from "@effectstream/sync";
 import { init, start } from "../../src/main.ts";
 import type { StartConfigGameStateTransitions } from "../../src/types.ts";
 import {
@@ -49,6 +49,8 @@ export type RunSpec = {
    */
   waitPages?: Record<string, number>;
   coalesce?: boolean;
+  /** One-shot failures to inject into the synthetic chain's pipeline (see TestChainControl.failNext). */
+  faults?: { protocol: string; stage: FailStage; times?: number }[];
 };
 
 const noopStf: StartConfigGameStateTransitions = function* () {};
@@ -66,6 +68,9 @@ async function main() {
 
   for (const [name, tip] of Object.entries(spec.tips)) {
     TestChainControl.setTip(name, tip);
+  }
+  for (const fault of spec.faults ?? []) {
+    TestChainControl.failNext(fault.protocol, fault.stage, fault.times);
   }
 
   const pool = new pg.Pool({

--- a/packages/node-sdk/sync/CLAUDE.md
+++ b/packages/node-sdk/sync/CLAUDE.md
@@ -100,6 +100,10 @@ iteration it walks protocols in order:
   `T`* (proving it scanned all data up to `T`), then drain every buffered datum with
   timestamp ≤ `T` into the root via `mergeDatum`.
 - send the block downstream, **then** run cleanups that pop consumed data from each Deque.
+- if any protocol's `toRootOutput`/`mergeDatum` throws while building the candidate block,
+  the whole in-progress block is discarded (no protocol's cleanup has run yet, so every
+  chain's buffered data is untouched) and retried after a short backoff — same
+  swallow/log/retry treatment as the polling loop above, extended to merge.
 
 ## Key design ideas
 

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/merge.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/merge.ts
@@ -1,4 +1,5 @@
 import type { Channel, Operation } from "effection";
+import { sleep } from "effection";
 import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import type {
   AllSyncProtocols,
@@ -12,6 +13,10 @@ import type { ChainBlock } from "../common/root.ts";
 import { chainPageRelation } from "../common/root.ts";
 import type { CacheCleanup, OutputAndCleanup } from "../base/state.ts";
 import { ENV } from "@effectstream/utils/node-env";
+import { tryYield } from "@effectstream/utils";
+
+/** Backoff before retrying a candidate block after a merge failure (see startMerge). */
+const MERGE_ERROR_RETRY_MS = 1000;
 
 export const mergeCoalescingBoundaries = {
   minScheduledBlockHeight: null as number | null,
@@ -107,16 +112,23 @@ export function* startMerge(
     let newBlock: ChainBlock | undefined = undefined;
 
     const cleanup: CacheCleanup[] = [];
+    let mergeError: unknown = null;
+    let erroredProtocol: AllSyncProtocols | null = null;
 
     for (let i = 0; i < syncProtocols.length; i++) {
-      const mergeInfo: MergeResult<RootOutput> = yield* mergeIntoRoot(
-        syncProtocols[i],
-        {
+      const mergeResult = yield* tryYield(
+        mergeIntoRoot(syncProtocols[i], {
           value: newBlock,
           toPage: (block) => block.timestamp,
           comparePage: chainPageRelation,
-        },
+        }),
       );
+      if (mergeResult.error != null) {
+        mergeError = mergeResult.error;
+        erroredProtocol = syncProtocols[i];
+        break;
+      }
+      const mergeInfo: MergeResult<RootOutput> = mergeResult.data;
       cleanup.push(mergeInfo.updateCache);
       if (mergeInfo.newRoot != null) {
         newBlock = mergeInfo.newRoot;
@@ -129,6 +141,22 @@ export function* startMerge(
           (log) => log(`new block ${mergeInfo.newRoot?.blockNumber}`),
         );
       }
+    }
+
+    if (mergeError != null) {
+      // Nothing merged so far for this candidate block has been consumed yet
+      // (updateCache/cleanup only runs below, once every protocol succeeds) —
+      // so every chain's buffered data is still intact and safe to retry.
+      erroredProtocol!.consecutiveErrors++;
+      erroredProtocol!.lastErrorTimestamp = Date.now();
+      log.remote(
+        ComponentNames.EFFECTSTREAM_SYNC,
+        [...erroredProtocol!.getNamespace(), "merge"],
+        SeverityNumber.ERROR,
+        (log) => log(mergeError),
+      );
+      yield* sleep(MERGE_ERROR_RETRY_MS);
+      continue;
     }
     if (newBlock == null) continue;
 

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
@@ -65,9 +65,48 @@ export function* startSync(
         SeverityNumber.TRACE,
         (log) => log(result.data),
       );
-      yield* iState.updateState(input, result.data);
+
+      const updateResult = yield* tryYield(
+        iState.updateState(input, result.data),
+      );
+      if (updateResult.error != null) {
+        state.consecutiveErrors++;
+        state.lastErrorTimestamp = Date.now();
+        log.remote(
+          ComponentNames.EFFECTSTREAM_SYNC,
+          [...state.getNamespace(), "updateState"],
+          SeverityNumber.ERROR,
+          (l) => l(updateResult.error),
+        );
+        if ("pollingInterval" in config.syncProtocol) {
+          yield* sleep(config.syncProtocol.pollingInterval);
+        }
+        continue;
+      }
+
+      let sendError: unknown = null;
       for (const datum of result.data.output) {
-        yield* iState.fetcher.producerChannel.send(datum.output);
+        const sendResult = yield* tryYield(
+          iState.fetcher.producerChannel.send(datum.output),
+        );
+        if (sendResult.error != null) {
+          sendError = sendResult.error;
+          break;
+        }
+      }
+      if (sendError != null) {
+        state.consecutiveErrors++;
+        state.lastErrorTimestamp = Date.now();
+        log.remote(
+          ComponentNames.EFFECTSTREAM_SYNC,
+          [...state.getNamespace(), "producerChannel"],
+          SeverityNumber.ERROR,
+          (l) => l(sendError),
+        );
+        if ("pollingInterval" in config.syncProtocol) {
+          yield* sleep(config.syncProtocol.pollingInterval);
+        }
+        continue;
       }
     }
   });

--- a/packages/node-sdk/sync/src/sync-protocols/test/control.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/control.ts
@@ -11,6 +11,15 @@
  */
 const tips = new Map<string, number>();
 
+/**
+ * Stages of the sync/merge pipeline that tests can force to fail, to prove
+ * a failure there doesn't crash the process (see sync.ts / merge.ts).
+ */
+export type FailStage = "readData" | "updateState" | "producerChannel" | "merge";
+
+const faults = new Map<string, number>();
+const faultKey = (protocolName: string, stage: FailStage) => `${protocolName}:${stage}`;
+
 export const TestChainControl = {
   /** Set the current chain tip (latest available block) for a protocol. */
   setTip(protocolName: string, tip: number): void {
@@ -20,8 +29,25 @@ export const TestChainControl = {
   getTip(protocolName: string): number | undefined {
     return tips.get(protocolName);
   },
-  /** Reset all tips (call between tests). */
+  /** Make the next `times` calls to `stage` for this protocol throw a synthetic error. */
+  failNext(protocolName: string, stage: FailStage, times = 1): void {
+    faults.set(faultKey(protocolName, stage), times);
+  },
+  /**
+   * Called by the synthetic protocol at each injectable stage. Returns true (and
+   * consumes one pending failure) if this call should throw.
+   */
+  consumeFailure(protocolName: string, stage: FailStage): boolean {
+    const key = faultKey(protocolName, stage);
+    const remaining = faults.get(key) ?? 0;
+    if (remaining <= 0) return false;
+    if (remaining === 1) faults.delete(key);
+    else faults.set(key, remaining - 1);
+    return true;
+  },
+  /** Reset all tips and pending faults (call between tests). */
   clear(): void {
     tips.clear();
+    faults.clear();
   },
 };

--- a/packages/node-sdk/sync/src/sync-protocols/test/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/fetcher.ts
@@ -52,6 +52,17 @@ export class TestFetcher
     readonly config: TestConfig,
   ) {
     super(config.syncProtocol.name);
+    // Test-only fault injection for producerChannel.send (see control.ts /
+    // sync.ts). Reassigning `send` in place keeps the channel's real
+    // subscriber wiring intact; only this fetcher's calls are intercepted.
+    const name = this.name;
+    const realSend = this.producerChannel.send.bind(this.producerChannel);
+    this.producerChannel.send = function* (message) {
+      if (TestChainControl.consumeFailure(name, "producerChannel")) {
+        throw new Error(`test-fault:producerChannel:${name}`);
+      }
+      return yield* realSend(message);
+    };
   }
 
   private blockOf(page: Page): Output["raw"] {
@@ -69,6 +80,10 @@ export class TestFetcher
     data: Input,
     rootConversion: RootConversion<Output, RootOutput, RootPage>,
   ): Operation<DataFetched<Output, Page, RootPage>> {
+    if (TestChainControl.consumeFailure(this.name, "readData")) {
+      throw new Error(`test-fault:readData:${this.name}`);
+    }
+
     // Events are declared on the (parallel) sync protocol config. The primitive
     // instance name to tag them with is the first declared primitive's id.
     const events: TestEvent[] =

--- a/packages/node-sdk/sync/src/sync-protocols/test/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/test/state.ts
@@ -5,11 +5,13 @@ import { getPage } from "@effectstream/db";
 import type { PoolClient } from "pg";
 import { bound, type BlockNumber } from "@effectstream/utils";
 import { type LastPage, SyncState } from "../base/state.ts";
+import type { DataFetched } from "../base/fetcher.ts";
 import type { RootOutput, RootPage } from "../types.ts";
 import type { TestFetcher } from "./fetcher.ts";
 import { bufferAtCap, genInputRange } from "../common/page-helpers.ts";
 import type { Input, Output, Page } from "./types.ts";
 import { toMsTimestamp } from "./types.ts";
+import { TestChainControl } from "./control.ts";
 import type {
   ConfigNetworkType,
   SyncProtocolWithNetwork,
@@ -51,7 +53,21 @@ export class TestSyncState extends SyncState<
   }
 
   @bound
+  override *updateState(
+    input: Input,
+    data: DataFetched<Output, Page, RootPage>,
+  ): Operation<void> {
+    if (TestChainControl.consumeFailure(this.name, "updateState")) {
+      throw new Error(`test-fault:updateState:${this.name}`);
+    }
+    yield* super.updateState(input, data);
+  }
+
+  @bound
   override toRootOutput(data: Output): RootOutput {
+    if (TestChainControl.consumeFailure(this.name, "merge")) {
+      throw new Error(`test-fault:merge:${this.name}`);
+    }
     return {
       blockInfo: data.blockHashes.map((h) => ({
         protocol_name: this.config.syncProtocol.name,
@@ -103,6 +119,9 @@ export class TestSyncState extends SyncState<
     ourOutput: Output,
     rootOutput: RootOutput,
   ): void {
+    if (TestChainControl.consumeFailure(this.name, "merge")) {
+      throw new Error(`test-fault:merge:${this.name}`);
+    }
     const primitives = ourOutput.primitives.map((p) => ({
       ...p,
       source: this.config.syncProtocol.name,


### PR DESCRIPTION
## TL;DR

Three spots in the sync/merge pipeline could throw an error that crashed the whole node: `updateState()`, `producerChannel.send()`, and the merge step.
This PR wraps all three in the same "log it, wait a bit, try again" pattern already used elsewhere in the same loop, so a failure there degrades instead of taking the process down. Retries are **unbounded** — it keeps trying forever, it never gives up and crashes on its own. A merge failure discards and rebuilds the whole block being built (never ships a half-built one).
Proved it works with new tests that inject a fake one-time failure at each of the three spots and check the node keeps going; also proved the tests are meaningful by confirming they fail against the old (unfixed) code.

## Summary

`startSync`'s polling loop already swallows errors from `stateToInput()` and `readData()` (log, bump `consecutiveErrors`, sleep, continue) — this is the documented design in `packages/node-sdk/sync/CLAUDE.md`. Two calls in the same loop, `updateState()` and `producerChannel.send()`, were never wrapped, and neither was anything in the merge loop (`startMerge`/`mergeIntoRoot`). An error at any of those three sites escaped the spawned effection task and crashed the whole node process — not through Node's `unhandledRejection` (the global `installUnhandledRejectionLogger` only ever guards Postgres pool errors), but through effection's own error propagation up to the process entrypoint.

This PR wraps the three remaining call sites in the same swallow/log/retry pattern, adds a test-only fault-injection mechanism to the synthetic `test` sync protocol, and adds three e2e reproduction tests that inject a one-shot failure at each site and assert the node reaches its target height instead of dying.

## Why (background)

Traced in the branch `release/0.100.20` while investigating a global `buildUnhandledRejectionHandler`.
Full trace:
`startSync`/`startMerge` are spawned as effection child tasks under the runtime's `start()`. In production, the entrypoint calls effection's `main()` fire-and-forget; `main()` itself catches any error that reaches it and calls `process.exit(1)` directly — before Node ever gets a chance to emit `unhandledRejection`. So the handler added a few commits ago is real and correctly scoped (Postgres pool errors), but it was never going to see a sync or merge failure either way.

## Changes

### Production fix

- **`packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts`**
Wraps `iState.updateState(input, result.data)` and each `iState.fetcher.producerChannel.send(datum.output)` call in `tryYield`,  mirroring the existing `stateToInput`/`readData` treatment exactly: on  error, bump `consecutiveErrors`/`lastErrorTimestamp`, log at `ERROR` via  `log.remote`, sleep `pollingInterval`, `continue`. The send loop stops at the first failing datum for that iteration rather than looping through the rest — same per-step granularity as the other three stages.

- **`packages/node-sdk/sync/src/sync-protocols/orchestration/merge.ts`**
  Wraps each protocol's `mergeIntoRoot(...)` call (inside `startMerge`'s  per-block loop) in `tryYield`. If any protocol's `toRootOutput`/`mergeDatum` throws, the **entire in-progress candidate block is discarded** — not just  that one protocol's contribution — and the whole `while(true)` iteration  retries from protocol 0 after a fixed `MERGE_ERROR_RETRY_MS` (1000 ms)  backoff. This is deliberately coarser than a per-protocol retry: a root block is only valid once every protocol has merged into it, and by the time any single protocol's hook can throw, that protocol's own `mergeWaitingForPage` bookkeeping has already been reset and no `updateCache`/cleanup has run for *any* protocol in this attempt — so every chain's buffered data is provably untouched and safe to recompute from scratch. Silently completing a block with one protocol's data missing would be a worse outcome than retrying.

- **`packages/node-sdk/sync/CLAUDE.md`** — one-line addition documenting the new merge failure-handling behavior (nothing described it before this PR).

### Test infrastructure (test-only, no production surface)

- **`packages/node-sdk/sync/src/sync-protocols/test/control.ts`** — extends the existing `TestChainControl` test-only control plane (previously just chain-tip control) with a one-shot fault registry:
  - `failNext(protocolName, stage, times)` arms `times` failures for a given `FailStage` (`"readData" | "updateState" | "producerChannel" | "merge"`);
  - `consumeFailure(protocolName, stage)` is called by the synthetic protocol at each injectable site and returns `true` (decrementing the counter) exactly `times` times.
- **`packages/node-sdk/sync/src/sync-protocols/test/fetcher.ts`** — checks `consumeFailure(name, "readData")` at the top of `readData` (parity with the two sites that already survived, so the fault-injection story is symmetric across all four stages); reassigns `producerChannel.send` in the constructor to check `consumeFailure(name, "producerChannel")` before delegating to the real `send`.
- **`packages/node-sdk/sync/src/sync-protocols/test/state.ts`** — overrides `updateState` to check `consumeFailure(name, "updateState")` before delegating to `super.updateState`; `toRootOutput` and `mergeDatum` (the main-chain and parallel-chain merge hooks respectively) both check `consumeFailure(name, "merge")`.
- **`packages/node-sdk/runtime/test/reproduction/node-runner.ts`** / **`harness.ts`** — thread an optional `faults: { protocol, stage, times? }[]` field through `RunSpec`/`RunToHeightOpts`, applied via `TestChainControl.failNext(...)` at child boot (same plumbing already used for `tips`).
- **`packages/node-sdk/runtime/test/reproduction/error-survival.test.ts`**
  (new) — three tests, one per production call site, each spinning up its own fresh harness (not sharing one across tests: a second run against an already-synced database might resume with nothing left to fetch and never
  touch the faulty call site, passing vacuously). Each injects exactly one failure and asserts `runToHeight` resolves and the finalized height reaches target.

## Confirming this was the intended design

- For `updateState`/`producerChannel.send`: **yes, directly confirmed.** `packages/node-sdk/sync/CLAUDE.md` already documented, before this PR, that the whole `stateToInput → readData → updateState → producerChannel.send` loop is meant to swallow errors via `tryYield` — the code just didn't match the doc for the last two steps. This PR closes that gap; no new behavior is being invented here.
- For merge: **not previously documented anywhere — this PR is proposing a new extension of that design philosophy, not confirming an existing one.** Verified it can be done safely (see the merge.ts section above: any
  mid-build error leaves all buffered data untouched, so retrying is provably correct), but there's a real product trade-off worth a reviewer's explicit sign-off: a merge failure is more likely than a fetch failure to indicate a **configuration bug** (e.g. `evm/state.ts`'s `toRootOutput` throws "Only main chains create root outputs" if a chain is wired at the wrong index) rather than a transient external fault. Swallowing that turns a loud, immediately-actionable crash (visible via process exit code / restart policy / alerting) into a quiet stall — block production for that chain halts, but the process keeps reporting healthy while retrying every second forever. The existing `consecutiveErrors`/`lastErrorTimestamp` fields (now also bumped on merge errors, reusing the exact fields already surfaced elsewhere) give operators a way to notice this, but nothing pages on them today. Flagging this explicitly rather than asserting it's obviously fine.

## Testing

- `bun test packages/node-sdk/sync packages/node-sdk/runtime` — 24 pass, 2 skip (pre-existing, unrelated), 0 fail.
- `bun test packages/node-sdk/runtime/test/reproduction` — all existing reproduction tests (`sanity`, `buffering`, `coalesce`, `coalesce-memory`, `resume`) still pass unchanged, plus the 3 new tests. - Verified the new tests actually catch the bug: temporarily reverted `sync.ts`/`merge.ts` (kept the test infra) and confirmed all 3 new tests  fail (timeout / non-zero subprocess exit) against the old code, then pass in ~10s once the fix is restored.

## Out of scope / follow-ups

- No alerting/metrics wired to `consecutiveErrors` for merge specifically — flagged above as a reviewer decision, not built speculatively here.
- `producerChannel` remains otherwise dead code (per existing CLAUDE.md note, "nothing consumes this today"); this PR only makes its failure mode non-fatal, it doesn't add a consumer.
