### PR TITLE
Implement robust comparison for config snapshots and add unit tests

### DIFF
--- a/packages/node-sdk/runtime/src/config-snapshot.ts
+++ b/packages/node-sdk/runtime/src/config-snapshot.ts
@@ -71,6 +71,23 @@ function extractImmutableConfig(protocol: SyncProtocolWithNetwork): Record<strin
 }
 
 /**
+ * Compares a saved snapshot value against the current in-memory value.
+ * Falls back to structural JSON comparison for nested objects (which are
+ * always freshly constructed plain objects with stable key-insertion order
+ * from `extractImmutableConfig`), and to reference/identity comparison for
+ * everything else.
+ */
+function valuesDiffer(saved: unknown, current: unknown): boolean {
+  if (
+    typeof saved === "object" && saved !== null &&
+    typeof current === "object" && current !== null
+  ) {
+    return JSON.stringify(saved) !== JSON.stringify(current);
+  }
+  return saved !== current;
+}
+
+/**
  * Checks the saved config snapshot for each sync protocol against the current config.
  *
  * On the first run (no snapshot in DB), the current config is persisted as the canonical snapshot.
@@ -85,7 +102,6 @@ export function* validateAndSnapshotConfig(
   syncInfo: SyncProtocolWithNetwork[],
   dbConn: Client,
 ): Operation<void> {
-  console.log("validateAndSnapshotConfig");
   const useDbStartHeight = getEnv("USE_DB_STARTHEIGHT") !== undefined;
 
   for (const protocol of syncInfo) {
@@ -119,20 +135,9 @@ export function* validateAndSnapshotConfig(
 
     const saved = rows[0].immutable_config as Record<string, unknown>;
     const mismatches: string[] = [];
-    console.log("saved", saved);
     for (const [key, savedValue] of Object.entries(saved)) {
-      console.log("key", key, savedValue, currentImmutable[key]);
-      // if (currentImmutable[key] !== savedValue) {
-      //   mismatches.push(`  ${key}: saved=${JSON.stringify(savedValue)}, current=${JSON.stringify(currentImmutable[key])}`);
-      // }
-      if (typeof savedValue === "object" && savedValue !== null) {
-        for (const [k, v] of Object.entries(savedValue)) {
-          if ((currentImmutable[key] as any)[k] !== v) {
-            mismatches.push(`  ${key}.${k}: saved=${JSON.stringify(v)},\n current=${JSON.stringify((currentImmutable[key] as any)[k])}`);
-          }
-        }
-      } else if (currentImmutable[key] !== savedValue) {
-        mismatches.push(`  ${key}: saved=${JSON.stringify(savedValue)},\n current=${JSON.stringify(currentImmutable[key])}`);
+      if (valuesDiffer(savedValue, currentImmutable[key])) {
+        mismatches.push(`  ${key}: saved=${JSON.stringify(savedValue)}, current=${JSON.stringify(currentImmutable[key])}`);
       }
     }
 

--- a/packages/node-sdk/runtime/test/config-snapshot.unit.test.ts
+++ b/packages/node-sdk/runtime/test/config-snapshot.unit.test.ts
@@ -1,0 +1,99 @@
+import { expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { run } from "effection";
+import type { Client } from "pg";
+import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+
+/**
+ * In-memory backing store for the mocked `@effectstream/db` query objects.
+ * `validateAndSnapshotConfig` only touches two queries — `get…Snapshot`
+ * (returns rows) and `upsert…Snapshot` (writes) — so stubbing those two is
+ * sufficient to exercise the comparison loop end-to-end without a real DB.
+ */
+type StoredRow = { networkType: ConfigNetworkType; immutable_config: unknown };
+let store: Record<string, StoredRow | undefined> = {};
+
+mock.module("@effectstream/db", () => ({
+  getSyncProtocolConfigSnapshot: {
+    run: ({ protocolName }: { protocolName: string }) =>
+      Promise.resolve(store[protocolName] ? [store[protocolName]] : []),
+  },
+  upsertSyncProtocolConfigSnapshot: {
+    run: ({
+      protocolName,
+      networkType,
+      immutableConfig,
+    }: {
+      protocolName: string;
+      networkType: ConfigNetworkType;
+      immutableConfig: string;
+    }) => {
+      store[protocolName] = { networkType, immutable_config: JSON.parse(immutableConfig) };
+      return Promise.resolve([]);
+    },
+  },
+}));
+
+const { validateAndSnapshotConfig } = await import("../src/config-snapshot.ts");
+
+const STUB_DB = {} as Client;
+
+function cardanoUtxoRpcProtocol(
+  startChainPoint: unknown,
+): SyncProtocolWithNetwork {
+  return {
+    networkType: ConfigNetworkType.CARDANO,
+    syncProtocolType: ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL,
+    syncProtocol: { name: "cardano-utxorpc", startChainPoint },
+    network: {},
+  } as unknown as SyncProtocolWithNetwork;
+}
+
+async function runValidate(
+  protocols: SyncProtocolWithNetwork[],
+): Promise<void> {
+  await run(function* () {
+    yield* validateAndSnapshotConfig(protocols, STUB_DB);
+  });
+}
+
+beforeEach(() => {
+  store = {};
+  delete process.env.USE_DB_STARTHEIGHT;
+});
+
+afterEach(() => {
+  delete process.env.USE_DB_STARTHEIGHT;
+});
+
+test("first run persists the snapshot and succeeds", async () => {
+  const protocol = cardanoUtxoRpcProtocol({ slot: 1, hash: "0xabc" });
+  await expect(runValidate([protocol])).resolves.toBeUndefined();
+  expect(store["cardano-utxorpc"]?.immutable_config).toEqual({
+    startChainPoint: { slot: 1, hash: "0xabc" },
+  });
+});
+
+test("matching nested-object snapshot succeeds on subsequent runs", async () => {
+  // Seed the snapshot from a first run.
+  await runValidate([cardanoUtxoRpcProtocol({ slot: 5, hash: "0xdead" })]);
+
+  // Same shape on restart — must not throw.
+  await expect(
+    runValidate([cardanoUtxoRpcProtocol({ slot: 5, hash: "0xdead" })]),
+  ).resolves.toBeUndefined();
+});
+
+test("reports a clean mismatch (no TypeError) when a saved nested object has no current counterpart", async () => {
+  // Snapshot persisted with a nested startChainPoint object.
+  await runValidate([cardanoUtxoRpcProtocol({ slot: 42, hash: "0xbeef" })]);
+
+  // On restart the current config has lost that field (shape drift / undefined).
+  const drifted = cardanoUtxoRpcProtocol(undefined);
+
+  // The robust comparator must surface this as a clean CRITICAL mismatch
+  // rather than throwing a `TypeError: Cannot read properties of undefined`.
+  await expect(runValidate([drifted])).rejects.toThrow(
+    /\[config-snapshot\] CRITICAL/,
+  );
+});


### PR DESCRIPTION
## The bug
The old mismatch loop assumed that whenever a saved snapshot value was an object, the current value at the same key was also an object. It read into it unconditionally:
```ts
if (typeof savedValue === "object" && savedValue !== null) {
  for (const [k, v] of Object.entries(savedValue)) {
    if ((currentImmutable[key] as any)[k] !== v) {   // ← reads [k] off current
```
If `currentImmutable[key]` was `undefined` (or any non-object), (`currentImmutable[key])[k]` threw:
`TypeError: Cannot read properties of undefined (reading '<k>')`
## Exactly when it fails
It only fails for protocols whose immutable config value is a nested object. Today that's exactly one:
- `CARDANO_UTXORPC_PARALLEL` → `{ startChainPoint: { slot, hash } }`
All others (NTP, EVM, Bitcoin, Midnight, Avail, Celestia, Cardano CARP, NEAR) store primitives (number), which take the else if branch and never hit the crash.
So the crash fires when all three are true:
1. A Cardano UTXOrpc protocol previously persisted a snapshot with startChainPoint as an object.
2. On a later restart, the current in-memory config has no value at that key — i.e. syncProtocol.startChainPoint is undefined (shape drift from a config edit, a schema/type change, or a malformed/partial protocol object).
3. The DB row from step 1 still exists (so it enters the comparison path rather than first-run persist).