### PR TITLE
fix(orchestrator): teardown kills only listeners + serialize hardhat node after compile

### DIFF
--- a/e2e/wallets-ui/vite.config.ts
+++ b/e2e/wallets-ui/vite.config.ts
@@ -62,6 +62,12 @@ export default defineConfig({
       "@e2e/midnight-contract-eip-20/contract": midnightContractEip20Path + "index.js",
       "@e2e/midnight-contract-counter-basic/contract": midnightContractCounterBasicPath + "index.js",
       "@effectstream/utils/runtime": utilsPath + "src/runtime.ts",
+      // Subpath alias must precede the base `@effectstream/utils` alias — vite
+      // prefix-matches, so without this `@effectstream/utils/node-env` (imported
+      // by @effectstream/events/event-connect.ts) resolves to `src/mod.ts/node-env`
+      // → ENOTDIR, failing the build. `./node-env` maps to config.ts (per the
+      // utils package exports).
+      "@effectstream/utils/node-env": utilsPath + "src/config.ts",
       "@effectstream/utils": utilsPath + "src/mod.ts",
       "@effectstream/config": configPath + "src/mod.ts",
       "@effectstream/concise": concisePath + "src/mod.ts",

--- a/packages/build-tools/orchestrator/scripts/launch-evm.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-evm.ts
@@ -60,6 +60,13 @@ export function launchEvm(
       args: ["run", "chain:start"],
       waitToExit: false,
       critical: true,
+      // Must wait for `hardhat compile` to finish. The node's EDR provider reads
+      // every build-info JSON under build/artifacts/hardhat/build-info/ on
+      // connect; if it reads while `hardhat compile` is still writing them it
+      // hits a truncated file ("Failed to parse build info: EOF…"), poisoning
+      // the node and stalling deploy/generate-mod. COMPILE is waitToExit:true,
+      // so this serializes writer→reader without blocking COMPILE_FORGE.
+      dependsOn: [EvmNames.COMPILE],
     },
     {
       name: EvmNames.HARDHAT_WAIT,

--- a/packages/build-tools/orchestrator/src/port-check.ts
+++ b/packages/build-tools/orchestrator/src/port-check.ts
@@ -29,7 +29,11 @@ export async function waitForPort(port: number, timeoutMs = 60_000): Promise<boo
  * Uses `lsof -ti tcp:<port>` (macOS / Linux).
  */
 export function pidsByPort(port: number): number[] {
-  const result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`], {
+  // `-sTCP:LISTEN` restricts to the process LISTENING on the port. Without it,
+  // `lsof -ti tcp:<port>` also returns CLIENTS with an open connection to the
+  // port (e.g. a test harness holding a keepalive fetch to the sync API), which
+  // callers like freePort() would then wrongly SIGTERM.
+  const result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
     stderr: "pipe",
   });
   if (result.exitCode !== 0) return [];
@@ -48,7 +52,12 @@ export function pidsByPort(port: number): number[] {
 export async function freePort(port: number): Promise<void> {
   if (!(await isPortInUse(port))) return;
 
-  const result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`], {
+  // `-sTCP:LISTEN` so we only kill the listener, never a client connected to
+  // the port (see pidsByPort). During shutdown a template's test process often
+  // holds an open connection to the sync API / chain ports; without this filter
+  // freePort would SIGTERM the test process (and its `bun run test` wrapper),
+  // failing an otherwise-green run with exit 143.
+  const result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
     stderr: "pipe",
   });
 


### PR DESCRIPTION
Two independent bugs in `@effectstream/orchestrator` that surface when running template/e2e test suites. Split out of the templates work (#803) so they can ship in an orchestrator release; templates then bump to it.

## 1. `freePort`/`pidsByPort` kill connected clients, not just the listener
`freePort()` (run for every process's `stopProcessAtPort` on shutdown) and `pidsByPort()` used `lsof -ti tcp:<port>` with **no state filter**, so they matched *every* process with the port open — **including clients holding an open connection**. During a test's teardown the harness keeps keepalive connections to the sync API / chain ports (e.g. a bitcoin RPC connection to bitcoind's 18443, which is a `stopProcessAtPort`), so `freePort` SIGTERM'd the **test process itself** (and its `bun run test` wrapper) → exit 143, failing an otherwise-green run. Timing-dependent, so it hit heavier templates (night-bitcoin) intermittently.

**Fix:** add `-sTCP:LISTEN` so both only ever target the process *listening* on the port.

## 2. `launchEvm` races `hardhat node` against `hardhat compile`
`launchEvm` launched `hardhat node` (chain:start) with no `dependsOn`, concurrently with `hardhat compile`. The node's EDR provider reads every build-info JSON under `build/artifacts/hardhat/build-info/` on connect; if it reads while `hardhat compile` is still writing them it hits a truncated file (`UnknownError: Failed to parse build info: EOF…`), poisoning the node and stalling deploy/generate-mod (observed as `generate-evm-mod did not complete within 300s`, killing dependents with 143). Affects all EVM templates flakily.

**Fix:** `HARDHAT dependsOn [COMPILE]` (COMPILE is `waitToExit:true`), serializing writer→reader without blocking the independent forge build.

Both verified against the affected template suites. No behavior change for healthy runs; only removes the teardown/startup races.