### PR TITLE
Update midnight binaries jul 2026

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -478,7 +478,7 @@
     },
     "packages/batcher": {
       "name": "@effectstream/batcher-sdk",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/event-client": "workspace:*",
@@ -521,7 +521,7 @@
     },
     "packages/binaries/avail-light-client": {
       "name": "@effectstream/npm-avail-light-client",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "npm-avail-light-client": "index.js",
       },
@@ -532,7 +532,7 @@
     },
     "packages/binaries/avail-node": {
       "name": "@effectstream/npm-avail-node",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "npm-avail-node": "index.js",
       },
@@ -543,7 +543,7 @@
     },
     "packages/binaries/bitcoin-core": {
       "name": "@effectstream/bitcoin-core",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "bitcoin-core": "./index.js",
       },
@@ -553,7 +553,7 @@
     },
     "packages/binaries/celestia": {
       "name": "@effectstream/celestia",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "celestia": "./index.js",
       },
@@ -563,7 +563,7 @@
     },
     "packages/binaries/grafana-alloy": {
       "name": "@effectstream/grafana-alloy",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "grafana-alloy": "index.js",
       },
@@ -573,7 +573,7 @@
     },
     "packages/binaries/grafana-loki": {
       "name": "@effectstream/grafana-loki",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "grafana-loki": "index.js",
       },
@@ -583,7 +583,7 @@
     },
     "packages/binaries/midnight-indexer": {
       "name": "@effectstream/npm-midnight-indexer",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "npm-midnight-indexer": "index.js",
       },
@@ -596,7 +596,7 @@
     },
     "packages/binaries/midnight-node": {
       "name": "@effectstream/npm-midnight-node",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "npm-midnight-node": "index.js",
       },
@@ -608,7 +608,7 @@
     },
     "packages/binaries/midnight-proof-server": {
       "name": "@effectstream/npm-midnight-proof-server",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "npm-midnight-proof-server": "index.js",
       },
@@ -619,7 +619,7 @@
     },
     "packages/binaries/near-sandbox": {
       "name": "@effectstream/near-sandbox",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "near-sandbox": "./index.js",
       },
@@ -629,7 +629,7 @@
     },
     "packages/binaries/ord": {
       "name": "@effectstream/ord",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "ord": "./index.js",
       },
@@ -664,7 +664,7 @@
     },
     "packages/build-tools/orchestrator": {
       "name": "@effectstream/orchestrator",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "bin": {
         "orchestrator": "src/cli.ts",
       },
@@ -674,11 +674,11 @@
     },
     "packages/chains/avail-contracts": {
       "name": "@effectstream/avail-contracts",
-      "version": "0.101.0",
+      "version": "0.101.1",
     },
     "packages/chains/bitcoin-contracts": {
       "name": "@effectstream/bitcoin-contracts",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "bitcoinjs-lib": "^7.0.0",
         "ecpair": "^3.0.0",
@@ -687,11 +687,11 @@
     },
     "packages/chains/cardano-contracts": {
       "name": "@effectstream/cardano-contracts",
-      "version": "0.101.0",
+      "version": "0.101.1",
     },
     "packages/chains/evm-contracts": {
       "name": "@effectstream/evm-contracts",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@nomicfoundation/hardhat-ignition": "3.0.2",
         "@nomicfoundation/hardhat-ignition-viem": "3.0.2",
@@ -706,7 +706,7 @@
     },
     "packages/chains/evm-hardhat": {
       "name": "@effectstream/evm-hardhat",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -724,7 +724,7 @@
     },
     "packages/chains/midnight-contracts": {
       "name": "@effectstream/midnight-contracts",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@midnight-ntwrk/compact-js": "2.5.0",
@@ -755,14 +755,14 @@
     },
     "packages/effectstream-sdk/chain-types": {
       "name": "@effectstream/chain-types",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/concise": {
       "name": "@effectstream/concise",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -773,7 +773,7 @@
     },
     "packages/effectstream-sdk/config": {
       "name": "@effectstream/config",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@dcspark/carp-client": "^3.3.0",
         "@dcspark/cip34-js": "3.0.1",
@@ -790,7 +790,7 @@
     },
     "packages/effectstream-sdk/coroutine": {
       "name": "@effectstream/coroutine",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@pgtyped/parser": "2.4.2",
@@ -802,7 +802,7 @@
     },
     "packages/effectstream-sdk/crypto": {
       "name": "@effectstream/crypto",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
         "@effectstream/utils": "workspace:*",
@@ -829,7 +829,7 @@
     },
     "packages/effectstream-sdk/events": {
       "name": "@effectstream/event-client",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -843,7 +843,7 @@
     },
     "packages/effectstream-sdk/log": {
       "name": "@effectstream/log",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
@@ -865,14 +865,14 @@
     },
     "packages/effectstream-sdk/precompile": {
       "name": "@effectstream/precompile",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/utils": {
       "name": "@effectstream/utils",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@foxglove/crc": "^1.0.1",
@@ -893,7 +893,7 @@
     },
     "packages/effectstream-sdk/wallets": {
       "name": "@effectstream/wallets",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@aurowallet/mina-provider": "^1.0.12",
         "@effectstream/concise": "workspace:*",
@@ -946,16 +946,61 @@
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet",
       ],
     },
+    "packages/effectstream-sdk/wallets/npm": {
+      "name": "@effectstream/wallets-dnt-output",
+      "version": "0.3.0",
+      "dependencies": {
+        "@aurowallet/mina-provider": "^1.0.12",
+        "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
+        "@coderspirit/nominal": "^4.1.1",
+        "@foxglove/crc": "^1.0.1",
+        "@metamask/providers": "^22.1.0",
+        "@midnight-ntwrk/dapp-connector-api": "4.0.1",
+        "@perawallet/connect": "^1.4.2",
+        "@polkadot/extension-dapp": "^0.58.10",
+        "@polkadot/extension-inject": "^0.58.10",
+        "@polkadot/util": "^13.4.3",
+        "@polkadot/util-crypto": "^13.4.3",
+        "@sinclair/typebox": "0.34.41",
+        "@subsquid/ss58-codec": "^1.2.3",
+        "abitype": "1.1.0",
+        "algosdk": "^3.4.0",
+        "assert-never": "^1.4.0",
+        "avail-js-sdk": "^0.4.2",
+        "bech32": "^2.0.0",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "effection": "^3.5.0",
+        "ethers": "^6.15.0",
+        "hi-base32": "^0.5.1",
+        "js-base64": "^3.7.7",
+        "js-sha3": "^0.9.3",
+        "js-sha512": "^0.9.0",
+        "mina-signer": "^3.0.7",
+        "mqtt": "^5.14.0",
+        "mqtt-pattern": "^2.1.0",
+        "semver": "^7.7.3",
+        "viem": "2.37.3",
+        "web3": "^4.16.0",
+        "web3-utils": "^4.3.3",
+      },
+    },
+    "packages/effectstream-sdk/wallets/npm/esm": {
+      "name": "@effectstream/wallets-npm-esm-stub",
+    },
+    "packages/effectstream-sdk/wallets/npm/script": {
+      "name": "@effectstream/wallets-npm-script-stub",
+    },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/wallets": "workspace:*",
       },
     },
     "packages/node-sdk/db": {
       "name": "@effectstream/db",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/coroutine": "workspace:*",
         "@effectstream/log": "workspace:*",
@@ -978,7 +1023,7 @@
     },
     "packages/node-sdk/db-emulator": {
       "name": "@effectstream/db-emulator",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@pgtyped/runtime": "2.4.2",
         "effection": "^3.5.0",
@@ -987,7 +1032,7 @@
     },
     "packages/node-sdk/events": {
       "name": "@effectstream/event-server",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -995,7 +1040,7 @@
     },
     "packages/node-sdk/node": {
       "name": "@effectstream/node-sdk",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/chain-types": "workspace:*",
         "@effectstream/concise": "workspace:*",
@@ -1013,7 +1058,7 @@
     },
     "packages/node-sdk/runtime": {
       "name": "@effectstream/runtime",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1045,7 +1090,7 @@
     },
     "packages/node-sdk/sm": {
       "name": "@effectstream/sm",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1066,7 +1111,7 @@
     },
     "packages/node-sdk/sync": {
       "name": "@effectstream/sync",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "dependencies": {
         "@cardano-sdk/core": "^0.46.11",
         "@cardano-sdk/util": "^0.17.1",
@@ -1345,6 +1390,12 @@
     "@effectstream/utils": ["@effectstream/utils@workspace:packages/effectstream-sdk/utils"],
 
     "@effectstream/wallets": ["@effectstream/wallets@workspace:packages/effectstream-sdk/wallets"],
+
+    "@effectstream/wallets-dnt-output": ["@effectstream/wallets-dnt-output@workspace:packages/effectstream-sdk/wallets/npm"],
+
+    "@effectstream/wallets-npm-esm-stub": ["@effectstream/wallets-npm-esm-stub@workspace:packages/effectstream-sdk/wallets/npm/esm"],
+
+    "@effectstream/wallets-npm-script-stub": ["@effectstream/wallets-npm-script-stub@workspace:packages/effectstream-sdk/wallets/npm/script"],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 
@@ -4180,6 +4231,10 @@
 
     "@effectstream/wallets/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
 
+    "@effectstream/wallets-dnt-output/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
+
+    "@effectstream/wallets-dnt-output/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
+
     "@ethersproject/abi/@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
 
     "@ethersproject/hash/@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
@@ -4817,6 +4872,14 @@
     "@effectstream/grafana-alloy/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@15.2.0", "", { "dependencies": { "@xhmikosr/archive-type": "^7.1.0", "@xhmikosr/decompress": "^10.2.0", "content-disposition": "^0.5.4", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^20.5.0", "filenamify": "^6.0.0", "get-stream": "^6.0.1", "got": "^13.0.0" } }, "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g=="],
 
     "@effectstream/grafana-loki/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@15.2.0", "", { "dependencies": { "@xhmikosr/archive-type": "^7.1.0", "@xhmikosr/decompress": "^10.2.0", "content-disposition": "^0.5.4", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^20.5.0", "filenamify": "^6.0.0", "get-stream": "^6.0.1", "got": "^13.0.0" } }, "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g=="],
+
+    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
+
+    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
+
+    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
     "@effectstream/wallets/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 

--- a/packages/binaries/midnight-indexer/binary.js
+++ b/packages/binaries/midnight-indexer/binary.js
@@ -4,7 +4,7 @@ const axios = require("axios");
 const extract = require("extract-zip");
 const path = require("path");
 
-const CURRENT_BINARY_VERSION = "v4.2.0";
+const CURRENT_BINARY_VERSION = "v4.3.3";
 const FINAL_BINARY_NAME = "indexer-standalone";
 
 /*

--- a/packages/binaries/midnight-indexer/index.js
+++ b/packages/binaries/midnight-indexer/index.js
@@ -1,5 +1,7 @@
 const { binary, getPlatform, cleanBinaries } = require("./binary");
-const { runMidnightIndexer } = require("./run_midnight_indexer");
+const { runMidnightIndexer, waitForNodeBlock } = require(
+  "./run_midnight_indexer",
+);
 const { checkIfDockerExists, pullDockerImage, runDockerContainer } = require(
   "./docker",
 );
@@ -185,6 +187,10 @@ async function runWithBinary(env, args, forceClean = false) {
 
   // Set appropriate localhost defaults for binary execution
   const binaryEnv = setBinaryDefaults(env);
+
+  // Gate startup on block #1 so the bundled spo-indexer does not crash the
+  // process on a fresh chain (see waitForNodeBlock for details).
+  await waitForNodeBlock(binaryEnv);
 
   return runMidnightIndexer(binaryEnv, args);
 }

--- a/packages/binaries/midnight-indexer/indexer-standalone/config.yaml
+++ b/packages/binaries/midnight-indexer/indexer-standalone/config.yaml
@@ -11,6 +11,13 @@ application:
   # 1 by default
   # concurrency_limit:
 
+spo:
+  interval: 5000
+  stake_refresh:
+    period_secs: 900
+    page_size: 100
+    max_rps: 2
+
 infra:
   run_migrations: true
 
@@ -26,6 +33,15 @@ infra:
     reconnect_max_delay: "10s" # 10ms, 100ms, 1s, 10s
     reconnect_max_attempts: 30 # Roughly 5m
     subscription_recovery_timeout: "30s" # Re-subscribe if no block received within this time
+
+  spo_node:
+    url: "ws://localhost:9944"
+    reconnect_max_delay: "10s"
+    reconnect_max_attempts: 30
+    # blockfrost_id is required (must be a non-empty string). SPO/Cardano
+    # features are not exercised in local undeployed dev, so a placeholder is
+    # shipped here; override with APP__INFRA__SPO_NODE__BLOCKFROST_ID if needed.
+    blockfrost_id: "dummy-not-using-spo"
 
   api:
     address: "0.0.0.0"
@@ -44,17 +60,20 @@ infra:
         batch_size: 20
       dust_nullifier_transactions:
         batch_size: 20
+      shielded_nullifier_transactions:
+        batch_size: 20
       shielded_transactions:
         batch_size: 20
         progress_update_interval: "30s"
         keep_wallet_alive_interval: "1m"
-      shielded_nullifier_transactions:
-        batch_size: 20
       unshielded_transactions:
         batch_size: 20
         progress_update_interval: "30s"
       zswap_ledger_events:
         batch_size: 20
+    quota:
+      max_concurrent_per_connection: 20
+      max_session_subscriptions_per_minute: 10
 
 telemetry:
   tracing:

--- a/packages/binaries/midnight-indexer/run_midnight_indexer.js
+++ b/packages/binaries/midnight-indexer/run_midnight_indexer.js
@@ -2,8 +2,55 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const yaml = require("js-yaml");
+const axios = require("axios");
 
 const BINARY_NAME = "indexer-standalone";
+
+/**
+ * Waits until the Midnight node has produced at least `minBlock`.
+ *
+ * The v4.3.3 indexer bundles an spo-indexer that, on a fresh DB, reads block #1
+ * to anchor the first epoch and exits(1) — killing the whole indexer — if that
+ * block does not exist yet. Gating startup on block #1 avoids that startup race.
+ * 
+ * @param {Object} env - Environment variables (used to resolve the node URL)
+ * @param {Object} [opts]
+ * @param {number} [opts.minBlock=1] - Block number that must exist
+ * @param {number} [opts.timeoutMs=120000] - Give up (and proceed) after this
+ * @param {number} [opts.intervalMs=1000] - Poll interval
+ * @returns {Promise<void>}
+ */
+async function waitForNodeBlock(env, opts = {}) {
+  const { minBlock = 1, timeoutMs = 120000, intervalMs = 1000 } = opts;
+  const wsUrl = env.SUBSTRATE_NODE_WS_URL ||
+    env.APP__INFRA__NODE__URL ||
+    "ws://localhost:9944";
+  const httpUrl = wsUrl.replace(/^ws:/, "http:").replace(/^wss:/, "https:");
+
+  const deadline = Date.now() + timeoutMs;
+  console.log(
+    `Waiting for node to produce block #${minBlock} at ${httpUrl} (spo-indexer startup guard)...`,
+  );
+  while (Date.now() < deadline) {
+    try {
+      const { data } = await axios.post(
+        httpUrl,
+        { jsonrpc: "2.0", id: 1, method: "chain_getBlockHash", params: [minBlock] },
+        { headers: { "Content-Type": "application/json" }, timeout: 5000 },
+      );
+      if (data && data.result) {
+        console.log(`Node has block #${minBlock} (${data.result}); starting indexer.`);
+        return;
+      }
+    } catch {
+      // node not reachable yet; keep polling
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  console.warn(
+    `Timed out waiting for node block #${minBlock} after ${timeoutMs}ms; starting indexer anyway.`,
+  );
+}
 
 /**
  * Resolves the configuration file path
@@ -251,4 +298,4 @@ function runMidnightIndexer(env = process.env, args = []) {
   return childProcess;
 }
 
-module.exports = { runMidnightIndexer };
+module.exports = { runMidnightIndexer, waitForNodeBlock };

--- a/packages/binaries/midnight-node/binary.js
+++ b/packages/binaries/midnight-node/binary.js
@@ -4,7 +4,7 @@ const axios = require("axios");
 const extract = require("extract-zip");
 const path = require("path");
 
-const CURRENT_BINARY_VERSION = "0.22.5";
+const CURRENT_BINARY_VERSION = "1.0.0";
 const FINAL_BINARY_NAME = "midnight-node";
 
 /*

--- a/packages/binaries/midnight-proof-server/binary.js
+++ b/packages/binaries/midnight-proof-server/binary.js
@@ -4,7 +4,7 @@ const axios = require("axios");
 const extract = require("extract-zip");
 const path = require("path");
 
-const CURRENT_BINARY_VERSION = "ledger-8.0.3";
+const CURRENT_BINARY_VERSION = "ledger-8.1.0";
 const FINAL_BINARY_NAME = "midnight-proof-server";
 
 /**


### PR DESCRIPTION
Bumps the Midnight binaries to the node-1.0.0 preview set and publishes them to the `effectstream/binaries` `0.3.120` release (macos-arm64, linux-arm64, linux-amd64):

- **node** `1.0.0`, **indexer** `v4.3.3`, **proof-server** `ledger-8.1.0`
- indexer `config.yaml` migrated to the v4.3.3 schema (adds `spo`/`spo_node`/`quota`, `blockfrost_id` placeholder)
- `waitForNodeBlock()` guard in the indexer wrapper — gates startup on node block 1 so v4.3.3's bundled spo-indexer can't crash the indexer on a fresh chain

Verified: `bun run e2e/runner.ts midnight` green (21/21).