### PR TITLE
fix(ci): drop stale wallets/npm build-output entries from bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -946,51 +946,6 @@
         "@midnight-ntwrk/wallet-sdk-unshielded-wallet",
       ],
     },
-    "packages/effectstream-sdk/wallets/npm": {
-      "name": "@effectstream/wallets-dnt-output",
-      "version": "0.3.0",
-      "dependencies": {
-        "@aurowallet/mina-provider": "^1.0.12",
-        "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
-        "@coderspirit/nominal": "^4.1.1",
-        "@foxglove/crc": "^1.0.1",
-        "@metamask/providers": "^22.1.0",
-        "@midnight-ntwrk/dapp-connector-api": "4.0.1",
-        "@perawallet/connect": "^1.4.2",
-        "@polkadot/extension-dapp": "^0.58.10",
-        "@polkadot/extension-inject": "^0.58.10",
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/util-crypto": "^13.4.3",
-        "@sinclair/typebox": "0.34.41",
-        "@subsquid/ss58-codec": "^1.2.3",
-        "abitype": "1.1.0",
-        "algosdk": "^3.4.0",
-        "assert-never": "^1.4.0",
-        "avail-js-sdk": "^0.4.2",
-        "bech32": "^2.0.0",
-        "bs58": "^6.0.0",
-        "bs58check": "^4.0.0",
-        "effection": "^3.5.0",
-        "ethers": "^6.15.0",
-        "hi-base32": "^0.5.1",
-        "js-base64": "^3.7.7",
-        "js-sha3": "^0.9.3",
-        "js-sha512": "^0.9.0",
-        "mina-signer": "^3.0.7",
-        "mqtt": "^5.14.0",
-        "mqtt-pattern": "^2.1.0",
-        "semver": "^7.7.3",
-        "viem": "2.37.3",
-        "web3": "^4.16.0",
-        "web3-utils": "^4.3.3",
-      },
-    },
-    "packages/effectstream-sdk/wallets/npm/esm": {
-      "name": "@effectstream/wallets-npm-esm-stub",
-    },
-    "packages/effectstream-sdk/wallets/npm/script": {
-      "name": "@effectstream/wallets-npm-script-stub",
-    },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
       "version": "0.101.1",
@@ -1390,12 +1345,6 @@
     "@effectstream/utils": ["@effectstream/utils@workspace:packages/effectstream-sdk/utils"],
 
     "@effectstream/wallets": ["@effectstream/wallets@workspace:packages/effectstream-sdk/wallets"],
-
-    "@effectstream/wallets-dnt-output": ["@effectstream/wallets-dnt-output@workspace:packages/effectstream-sdk/wallets/npm"],
-
-    "@effectstream/wallets-npm-esm-stub": ["@effectstream/wallets-npm-esm-stub@workspace:packages/effectstream-sdk/wallets/npm/esm"],
-
-    "@effectstream/wallets-npm-script-stub": ["@effectstream/wallets-npm-script-stub@workspace:packages/effectstream-sdk/wallets/npm/script"],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 
@@ -4231,10 +4180,6 @@
 
     "@effectstream/wallets/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
 
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto": ["@polkadot/util-crypto@13.5.9", "", { "dependencies": { "@noble/curves": "^1.3.0", "@noble/hashes": "^1.3.3", "@polkadot/networks": "13.5.9", "@polkadot/util": "13.5.9", "@polkadot/wasm-crypto": "^7.5.3", "@polkadot/wasm-util": "^7.5.3", "@polkadot/x-bigint": "13.5.9", "@polkadot/x-randomvalues": "13.5.9", "@scure/base": "^1.1.7", "tslib": "^2.8.0" } }, "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg=="],
-
-    "@effectstream/wallets-dnt-output/@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
-
     "@ethersproject/abi/@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
 
     "@ethersproject/hash/@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
@@ -4872,14 +4817,6 @@
     "@effectstream/grafana-alloy/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@15.2.0", "", { "dependencies": { "@xhmikosr/archive-type": "^7.1.0", "@xhmikosr/decompress": "^10.2.0", "content-disposition": "^0.5.4", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^20.5.0", "filenamify": "^6.0.0", "get-stream": "^6.0.1", "got": "^13.0.0" } }, "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g=="],
 
     "@effectstream/grafana-loki/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@15.2.0", "", { "dependencies": { "@xhmikosr/archive-type": "^7.1.0", "@xhmikosr/decompress": "^10.2.0", "content-disposition": "^0.5.4", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^20.5.0", "filenamify": "^6.0.0", "get-stream": "^6.0.1", "got": "^13.0.0" } }, "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/networks": ["@polkadot/networks@13.5.9", "", { "dependencies": { "@polkadot/util": "13.5.9", "@substrate/ss58-registry": "^1.51.0", "tslib": "^2.8.0" } }, "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/x-bigint": ["@polkadot/x-bigint@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" } }, "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g=="],
-
-    "@effectstream/wallets-dnt-output/@polkadot/util-crypto/@polkadot/x-randomvalues": ["@polkadot/x-randomvalues@13.5.9", "", { "dependencies": { "@polkadot/x-global": "13.5.9", "tslib": "^2.8.0" }, "peerDependencies": { "@polkadot/util": "13.5.9", "@polkadot/wasm-util": "*" } }, "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw=="],
 
     "@effectstream/wallets/@polkadot/util-crypto/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 


### PR DESCRIPTION
## Problem

`bun install --frozen-lockfile` has failed the **frontend-build** job — and therefore the **ci-ok** required gate — on every push to `v-next` since 2026-07-06:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

## Cause

`packages/effectstream-sdk/wallets/npm` is a DNT **build-output** directory — it is neither tracked nor gitignored. A `bun install` run while that output happened to be present locally let the `packages/**` workspace glob in `package.json` pick it up, baking three phantom workspace entries into `bun.lock` (introduced in 215c8e19):

- `@effectstream/wallets-dnt-output` — `wallets/npm`
- `@effectstream/wallets-npm-esm-stub` — `wallets/npm/esm`
- `@effectstream/wallets-npm-script-stub` — `wallets/npm/script`

On a clean CI checkout the directory is absent, so bun wants to drop those entries and the frozen install aborts. Because the directory is untracked, it never surfaced as a missing file locally.

## Fix

Regenerated `bun.lock`. The diff is a **pure deletion — 63 lines removed, 0 added**: no dependency additions, removals, or version changes.

## Verification

- `bun install --frozen-lockfile` → passes
- `bun test packages/frontend/test/` (the job's other step) → **5 pass, 0 fail**

## Not addressed here

`template-tests` has a separate, independent failure: `templates/zswap-da/package.json` declares

```
"@zswap-da/contract-offer-files": "file:../../../zswap-offerfile-kernel/packages/contracts-midnight/contract-offer-files"
```

which resolves three levels above the repo root — a sibling checkout that does not exist in CI (`ENOENT: failed opening cache/package/version dir`). It is currently masked because the change filter only builds templates that changed, but `zswap-da` is in the `ENABLED` list in `templates/run-template-tests.ts`, so any push touching that template will fail. Fixing it needs a product call (publish the package, vendor the contract files, or drop the template from `ENABLED`) and is left for a follow-up.

Also worth a follow-up: adding `packages/*/*/npm/` to `.gitignore` so this build output cannot be re-globbed into the lockfile again.