### PR TITLE
fix(sync): harden the sync service against external failures

### DIFF
--- a/.github/Dockerfile.sync-repro
+++ b/.github/Dockerfile.sync-repro
@@ -1,0 +1,50 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# sync-repro test image
+# ══════════════════════════════════════════════════════════════════════════════
+# A deliberately small image for the `sync-repro` e2e suite. Unlike
+# .github/Dockerfile (which builds foundry, the Midnight compact compiler, solc
+# and Playwright Chromium because it runs the whole e2e matrix), this suite
+# needs none of that: it starts no chains, uses no orchestrator, and its
+# database is in-process PGLite.
+#
+# The reason to containerise it at all is isolation. The reproduction harness
+# binds a PGLite gateway port and an API port per node; running in a container
+# gives those their own network namespace so the suite can run while other test
+# suites are using the same ports on the host.
+#
+# Build + run:
+#   bun run e2e/sync-repro/run-tests.ts --docker
+# or directly:
+#   docker build -t effectstream-sync-repro -f .github/Dockerfile.sync-repro .
+#   docker run --rm effectstream-sync-repro
+FROM oven/bun:1.3.10-debian
+
+WORKDIR /app
+
+# Node is needed by postinstall scripts during `bun install` (core-js and
+# friends shell out to `node`), even though nothing here runs under Node.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# node_modules is excluded by .dockerignore, so this is the source tree only.
+COPY . .
+
+# Not --frozen-lockfile: `packages/effectstream-sdk/wallets/npm` is a generated
+# build output that is present in the lockfile but not in the source tree, so a
+# frozen install always reports drift. .github/Dockerfile does the same.
+RUN bun install
+
+# PGLite (WASM) is the default backend; the Postgres-only consistency tests
+# skip themselves unless PGLITE=false. MQTT binds fixed ports that the harness
+# never frees, so it stays off.
+ENV PGLITE=true
+ENV MQTT_BROKER=false
+ENV EFFECTSTREAM_STDOUT=true
+ENV POLKADOTJS_DISABLE_ESM_CJS_WARNING=1
+
+# --in-container stops run-tests.ts from recursing back into docker.
+CMD ["bun", "run", "e2e/sync-repro/run-tests.ts", "--in-container"]

--- a/.github/Dockerfile.sync-repro
+++ b/.github/Dockerfile.sync-repro
@@ -33,10 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # node_modules is excluded by .dockerignore, so this is the source tree only.
 COPY . .
 
-# Not --frozen-lockfile: `packages/effectstream-sdk/wallets/npm` is a generated
-# build output that is present in the lockfile but not in the source tree, so a
-# frozen install always reports drift. .github/Dockerfile does the same.
-RUN bun install
+RUN bun install --frozen-lockfile
 
 # PGLite (WASM) is the default backend; the Postgres-only consistency tests
 # skip themselves unless PGLITE=false. MQTT binds fixed ports that the harness

--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -67,6 +67,9 @@ async function runGroups(): Promise<number> {
       cwd: repoRoot,
       stdout: "inherit",
       stderr: "inherit",
+      // Spread order is deliberate: an ambient PGLITE=false must win, so the
+      // Postgres-backed consistency tests can be selected from the environment.
+      // PGLITE=true is only the default when nothing is set.
       env: { PGLITE: "true", ...process.env },
     });
     const code = await proc.exited;

--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -1,28 +1,46 @@
 /**
  * E2E suite: deterministic sync-service reproductions.
  *
- * Unlike the other suites, this one needs no orchestrator/chains. Each node runs
- * in its own subprocess over the synthetic `test` chain (so a restart is a
- * genuine new OS process whose in-memory Deque is gone while the committed
- * database survives — the production restart condition).
+ * Unlike the other suites, this one needs no orchestrator/chains. Two groups:
+ *
+ * 1. **Runtime reproductions** (`runtime/test/reproduction/`) — each node runs in
+ *    its own subprocess over the synthetic `test` chain (so a restart is a
+ *    genuine new OS process whose in-memory Deque is gone while the committed
+ *    database survives — the production restart condition).
+ *
+ * 2. **Sync-service reproductions** (`sync/test/`) — external-failure repros that
+ *    need no database: RPC clients pointed at a blackholed socket, and the
+ *    `startSync` orchestration loop driven with fake states. Several are marked
+ *    KNOWN-BROKEN: they assert today's (wrong) behaviour so the fix has a
+ *    failing-to-passing signal to flip.
  *
  * Runs in the default PGLite mode; the Postgres-only consistency tests skip
  * unless invoked with `PGLITE=false` (which needs `postgresql` installed).
- *
  */
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..", "..");
 
-const proc = Bun.spawn(
-  ["bun", "test", "packages/node-sdk/runtime/test/reproduction/"],
-  {
+const groups = [
+  { name: "runtime reproductions", path: "packages/node-sdk/runtime/test/reproduction/" },
+  { name: "sync-service reproductions", path: "packages/node-sdk/sync/test/" },
+];
+
+let failed = 0;
+
+for (const group of groups) {
+  console.log(`\n--- ${group.name} (${group.path}) ---\n`);
+  const proc = Bun.spawn(["bun", "test", group.path], {
     cwd: repoRoot,
     stdout: "inherit",
     stderr: "inherit",
     env: { PGLITE: "true", ...process.env },
-  },
-);
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    console.error(`\n[sync-repro] ${group.name} FAILED (exit ${code})`);
+    failed = code;
+  }
+}
 
-const code = await proc.exited;
-process.exit(code);
+process.exit(failed);

--- a/e2e/sync-repro/run-tests.ts
+++ b/e2e/sync-repro/run-tests.ts
@@ -16,31 +16,67 @@
  *
  * Runs in the default PGLite mode; the Postgres-only consistency tests skip
  * unless invoked with `PGLITE=false` (which needs `postgresql` installed).
+ *
+ * Usage:
+ *   bun run e2e/sync-repro/run-tests.ts             # on the host
+ *   bun run e2e/sync-repro/run-tests.ts --docker    # inside a container
+ *
+ * `--docker` builds .github/Dockerfile.sync-repro and runs the suite there, so
+ * the harness's PGLite gateway and API ports live in the container's own
+ * network namespace and cannot collide with suites running on the host.
  */
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..", "..");
+const args = process.argv.slice(2);
 
-const groups = [
-  { name: "runtime reproductions", path: "packages/node-sdk/runtime/test/reproduction/" },
-  { name: "sync-service reproductions", path: "packages/node-sdk/sync/test/" },
-];
+const IMAGE = "effectstream-sync-repro";
 
-let failed = 0;
+/** Build the image and re-run this script inside it. */
+async function runInDocker(): Promise<number> {
+  console.log(`[sync-repro] building ${IMAGE}...`);
+  const build = Bun.spawn(
+    ["docker", "build", "-t", IMAGE, "-f", ".github/Dockerfile.sync-repro", "."],
+    { cwd: repoRoot, stdout: "inherit", stderr: "inherit" },
+  );
+  const buildCode = await build.exited;
+  if (buildCode !== 0) {
+    console.error(`[sync-repro] image build FAILED (exit ${buildCode})`);
+    return buildCode;
+  }
 
-for (const group of groups) {
-  console.log(`\n--- ${group.name} (${group.path}) ---\n`);
-  const proc = Bun.spawn(["bun", "test", group.path], {
+  console.log(`[sync-repro] running suite in container...`);
+  const run = Bun.spawn(["docker", "run", "--rm", IMAGE], {
     cwd: repoRoot,
     stdout: "inherit",
     stderr: "inherit",
-    env: { PGLITE: "true", ...process.env },
   });
-  const code = await proc.exited;
-  if (code !== 0) {
-    console.error(`\n[sync-repro] ${group.name} FAILED (exit ${code})`);
-    failed = code;
-  }
+  return await run.exited;
 }
 
-process.exit(failed);
+async function runGroups(): Promise<number> {
+  const groups = [
+    { name: "runtime reproductions", path: "packages/node-sdk/runtime/test/reproduction/" },
+    { name: "sync-service reproductions", path: "packages/node-sdk/sync/test/" },
+  ];
+
+  let failed = 0;
+  for (const group of groups) {
+    console.log(`\n--- ${group.name} (${group.path}) ---\n`);
+    const proc = Bun.spawn(["bun", "test", group.path], {
+      cwd: repoRoot,
+      stdout: "inherit",
+      stderr: "inherit",
+      env: { PGLITE: "true", ...process.env },
+    });
+    const code = await proc.exited;
+    if (code !== 0) {
+      console.error(`\n[sync-repro] ${group.name} FAILED (exit ${code})`);
+      failed = code;
+    }
+  }
+  return failed;
+}
+
+const code = args.includes("--docker") ? await runInDocker() : await runGroups();
+process.exit(code);

--- a/packages/effectstream-sdk/config/src/schema/common.ts
+++ b/packages/effectstream-sdk/config/src/schema/common.ts
@@ -14,6 +14,12 @@ export const PollingSyncProtocol = new ConfigSchema({
     pollingInterval: TypeboxHelpers.IntervalMs(),
   }),
   optional: Type.Object({
+    /**
+     * Intentionally has NO default, unlike its neighbour below. The effective
+     * cap is derived from the protocol's `stepSize`
+     * (`common/page-helpers.ts:bufferCapFor`), so a static default here would
+     * override that per-chain sizing. `undefined` means "derive it".
+     */
     maxBufferedPages: Type.Optional(Type.Number()),
     /**
      * Hard deadline for a single RPC request made by this protocol's client.

--- a/packages/effectstream-sdk/config/src/schema/common.ts
+++ b/packages/effectstream-sdk/config/src/schema/common.ts
@@ -15,6 +15,15 @@ export const PollingSyncProtocol = new ConfigSchema({
   }),
   optional: Type.Object({
     maxBufferedPages: Type.Optional(Type.Number()),
+    /**
+     * Hard deadline for a single RPC request made by this protocol's client.
+     *
+     * `fetch` has no default timeout, so without this a blackholed endpoint
+     * hangs `readData` forever and silently stalls block production — see
+     * `@effectstream/sync` `sync-protocols/common/http.ts`. The fetch loop
+     * supplies the retry; this only bounds one attempt.
+     */
+    requestTimeoutMs: TypeboxHelpers.IntervalMs({ default: 15_000 }),
   }),
 });
 

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/utxorpc.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/cardano/utxorpc.ts
@@ -1,7 +1,11 @@
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
 import { ConfigSyncProtocolType } from "../types.ts";
-import { NameField, StartStopChainPoint } from "../../common.ts";
+import {
+  NameField,
+  PollingSyncProtocol,
+  StartStopChainPoint,
+} from "../../common.ts";
 import {
   CommonResponseParallelSyncProtocol,
   type ConfigSyncProtocolCommonResponse,
@@ -75,9 +79,23 @@ export type UtxorpcTxPredicate = Static<typeof UtxorpcTxPredicate>;
 // Base schema
 // ===========
 
+// `PollingSyncProtocol` is merged in for `pollingInterval` (plus
+// `maxBufferedPages` and `requestTimeoutMs`), exactly as every other polling
+// protocol does. utxorpc used to be the sole exception, which made
+// `pollingInterval` undeclared and untyped even though the runtime fetch loop
+// keys its sleeps off that property name — so a config built strictly from
+// this schema produced a node that starved its own event loop on the first
+// "caught up" pass and never recovered. See
+// `sync/test/poll-loop-spin.test.ts`.
 export const ConfigSyncProtocolSchemaCardanoUtxoRpcBase = NameField
   .cloneMerge(
     StartStopChainPoint,
+  ).cloneMerge(
+    // Supplies pollingInterval (required) + maxBufferedPages/requestTimeoutMs.
+    // The backpressure cap matters here because utxorpc has no stepSize, so the
+    // defaults apply — see "Backpressure (`maxBufferedPages`)" in the
+    // @effectstream/sync README.
+    PollingSyncProtocol,
   ).cloneMerge({
     required: Type.Object({
       name: Type.String(),
@@ -85,9 +103,6 @@ export const ConfigSyncProtocolSchemaCardanoUtxoRpcBase = NameField
     }),
     optional: Type.Object({
       headers: Type.Record(Type.String(), Type.String()),
-      // Fetch-backpressure cap (utxorpc has no stepSize → defaults apply). See the
-      // "Backpressure (`maxBufferedPages`)" section in @effectstream/sync's README.
-      maxBufferedPages: Type.Optional(Type.Number()),
     }),
   });
 

--- a/packages/effectstream-sdk/utils/src/viem.ts
+++ b/packages/effectstream-sdk/utils/src/viem.ts
@@ -15,6 +15,17 @@ export function truncateSelector(fullSelector: EvmSelector): Evm4ByteSelector {
   return fullSelector.slice(0, 10) as Evm4ByteSelector;
 }
 
+/** Transport-level options the caller may set per sync protocol. */
+export type ViemTransportOptions = {
+  /**
+   * Per-request deadline in ms. Without one, viem's own default applies; an
+   * endpoint that accepts the connection and never answers would otherwise
+   * hang the caller indefinitely. Sync protocols pass their
+   * `requestTimeoutMs`.
+   */
+  timeout?: number;
+};
+
 export function createViemPublicClient<
   chain extends Chain,
   transport extends Transport = HttpTransport,
@@ -27,15 +38,18 @@ export function createViemPublicClient<
       PublicClientConfig<transport, chain, accountOrAddress, rpcSchema>,
       "chain"
     >
-  >,
+  > & ViemTransportOptions,
 ): PublicClient<transport, chain, ParseAccount<accountOrAddress>, rpcSchema> {
+  // `timeout` is a transport option, not a client option; pull it out so it
+  // reaches `http()` rather than being spread onto the client config.
+  const { timeout, ...clientOverride } = override ?? {};
   return createPublicClient({
     chain,
     transport: http(chain.rpcUrls.default.http[0], {
       // batch is needed for sync protocols to be efficient. Does this ever cause issues in other scenarios?
       batch: true,
-      // TODO: transport options should come from the sync protocol configuration
+      ...(timeout != null ? { timeout } : {}),
     }),
-    ...override,
+    ...clientOverride,
   }) as any;
 }

--- a/packages/node-sdk/runtime/src/api/health.ts
+++ b/packages/node-sdk/runtime/src/api/health.ts
@@ -51,6 +51,10 @@ export type ProtocolHealth = {
   consecutiveErrors: number;
   /** Streaming producers only: restarts since boot. A climb means flapping. */
   producerRestarts: number;
+  /** Producer failures, counted independently of `consecutiveErrors`. */
+  producerErrors: number;
+  /** ms since the last producer failure; null if there has never been one. */
+  sinceLastProducerErrorMs: number | null;
   /**
    * True when the merge is currently waiting for THIS chain's page to advance.
    * When the node is stalled, this is the field that says where to look.
@@ -67,8 +71,11 @@ export type HealthReport = {
   db: ReturnType<typeof poolErrors.state>;
   apply: {
     blockHeight: number | null;
-    /** ms since the node last applied ANY block — the liveness signal. */
-    sinceLastAppliedMs: number | null;
+    /**
+     * ms since the node last applied ANY block — the liveness signal. Never
+     * null: before the first block it measures from process start instead.
+     */
+    sinceLastAppliedMs: number;
     /** Block-time lag. Informational: large during legitimate catch-up. */
     lagMs: number | null;
   };
@@ -87,15 +94,22 @@ export type HealthReport = {
  * bounded by `requestTimeoutMs` anyway, so a healthy loop always cycles.
  */
 const WEDGED_POLL_MULTIPLE = 20;
-/** Floor for the above, so fast-polling chains don't trip on a single hiccup. */
+/** Floor for the above, so fast-polling chains don't trip on a single hiccup.
+ *
+ * Caveat worth knowing before alerting on `wedged`: one `readData` pass fetches
+ * a whole chunk, which can be many sequential RPCs, so during deep catch-up a
+ * legitimately-progressing chain can exceed this without returning to the top of
+ * the loop and briefly read as `wedged`. Node-level status stays 200 while
+ * blocks keep applying, so this is cosmetic — but alert on the node's `status`,
+ * not on a single protocol's. */
 const WEDGED_MIN_MS = 60_000;
 
-function pollingIntervalOf(protocol: AllSyncProtocols): number {
-  const syncProtocol = (protocol as unknown as {
-    fetcher?: { config?: { syncProtocol?: { pollingInterval?: number } } };
-  }).fetcher?.config?.syncProtocol;
-  return syncProtocol?.pollingInterval ?? 1_000;
-}
+/**
+ * How long after a producer failure the chain still reports `erroring`. Twice
+ * the supervisor's max backoff, so a producer that recovers on its first or
+ * second restart clears the flag on its own.
+ */
+const PRODUCER_FLAP_WINDOW_MS = 60_000;
 
 function protocolHealth(
   protocol: AllSyncProtocols,
@@ -108,16 +122,31 @@ function protocolHealth(
     ? now - protocol.lastSuccessfulFetchMs
     : null;
 
+  // `pollingIntervalMs` is published by startSync, so this and the loop agree on
+  // one value. It is 0 until startSync stamps it; fall back until then.
   const wedgedAfterMs = Math.max(
-    WEDGED_POLL_MULTIPLE * pollingIntervalOf(protocol),
+    WEDGED_POLL_MULTIPLE * (protocol.pollingIntervalMs || 1_000),
     WEDGED_MIN_MS,
   );
+
+  const sinceLastProducerErrorMs = protocol.lastProducerErrorMs > 0
+    ? now - protocol.lastProducerErrorMs
+    : null;
 
   let status: ProtocolStatus;
   if (sinceLastPollMs != null && sinceLastPollMs > wedgedAfterMs) {
     // The loop itself stopped cycling: stuck inside a call that never returned.
     status = "wedged";
   } else if (protocol.consecutiveErrors > 0) {
+    status = "erroring";
+  } else if (
+    sinceLastProducerErrorMs != null &&
+    sinceLastProducerErrorMs < PRODUCER_FLAP_WINDOW_MS
+  ) {
+    // A producer that failed recently but has been restarted. Reported so a
+    // flapping stream is visible, and time-bounded so a single old blip does
+    // not pin the chain to `erroring` forever (which is what sharing
+    // `consecutiveErrors` used to do for an idle streaming chain).
     status = "erroring";
   } else if (protocol.lastPage == null) {
     status = "starting";
@@ -133,6 +162,8 @@ function protocolHealth(
     sinceLastSuccessfulFetchMs,
     consecutiveErrors: protocol.consecutiveErrors,
     producerRestarts: protocol.producerRestarts,
+    producerErrors: protocol.producerErrors,
+    sinceLastProducerErrorMs,
     blockingMerge: protocol.mergeWaitingForPage,
     buffered: protocol.bufferedData.size(),
     bufferCap: protocol.bufferCap,

--- a/packages/node-sdk/runtime/src/api/health.ts
+++ b/packages/node-sdk/runtime/src/api/health.ts
@@ -1,0 +1,204 @@
+/**
+ * Sync liveness for `/health`.
+ *
+ * `/health` used to report database reachability only. That misses every
+ * failure this service actually suffers: a blackholed RPC, a producer whose
+ * stream ended, a chain that stopped advancing. All of them end the same way —
+ * the merge blocks on one chain's page and block production stops — while the
+ * database stays perfectly healthy. A node that has not applied a block in an
+ * hour would answer `200 {"status":"ok"}`.
+ *
+ * Two deliberate choices:
+ *
+ * 1. **Liveness is measured in wall-clock time since the last APPLIED block**,
+ *    not in block-timestamp lag. A chain replaying history is legitimately
+ *    hours behind in block time while being perfectly healthy; what matters is
+ *    whether the pipeline is still moving.
+ *
+ * 2. **503 is reserved for "not doing its job"** — database unreachable, or no
+ *    block applied within the threshold. A chain that is erroring or restarting
+ *    its producer while blocks still flow reports `degraded` with a 200, so an
+ *    orchestrator does not kill a node that is recovering on its own.
+ */
+import type { AllSyncProtocols } from "@effectstream/sync";
+import { poolErrors } from "@effectstream/db";
+import { appliedBlockStatus } from "./apply-status.ts";
+import { finalizedStreamStatus } from "./stream-status.ts";
+
+/**
+ * Node-level rollup. `ok` and `degraded` answer 200; `starting`, `stalled` and
+ * `db-unreachable` answer 503 (not ready to serve).
+ */
+export type HealthStatus =
+  | "ok"
+  | "degraded"
+  | "starting"
+  | "stalled"
+  | "db-unreachable";
+
+/** Per-protocol rollup. `blockingMerge` is reported separately. */
+export type ProtocolStatus = "ok" | "starting" | "erroring" | "wedged";
+
+export type ProtocolHealth = {
+  name: string;
+  status: ProtocolStatus;
+  /** Highest block of this chain that has been merged into a produced block. */
+  ownBlockNumber: number | null;
+  /** ms since this chain's fetch loop last completed a pass; null if never. */
+  sinceLastPollMs: number | null;
+  /** ms since `readData` last returned successfully; null if never. */
+  sinceLastSuccessfulFetchMs: number | null;
+  consecutiveErrors: number;
+  /** Streaming producers only: restarts since boot. A climb means flapping. */
+  producerRestarts: number;
+  /**
+   * True when the merge is currently waiting for THIS chain's page to advance.
+   * When the node is stalled, this is the field that says where to look.
+   */
+  blockingMerge: boolean;
+  /** In-memory fetched-not-yet-merged data, and the backpressure cap. */
+  buffered: number;
+  bufferCap: number;
+  paused: boolean;
+};
+
+export type HealthReport = {
+  status: HealthStatus;
+  db: ReturnType<typeof poolErrors.state>;
+  apply: {
+    blockHeight: number | null;
+    /** ms since the node last applied ANY block — the liveness signal. */
+    sinceLastAppliedMs: number | null;
+    /** Block-time lag. Informational: large during legitimate catch-up. */
+    lagMs: number | null;
+  };
+  finalizedStream: {
+    produced: number;
+    consumed: number;
+    inFlight: number;
+  };
+  protocols: ProtocolHealth[];
+};
+
+/**
+ * A fetch loop is "wedged" once its heartbeat is this many polling intervals
+ * stale. Generous, because the cost of a false positive (a flapping 503) is
+ * worse than noticing a genuine hang a minute late — and a hung request is now
+ * bounded by `requestTimeoutMs` anyway, so a healthy loop always cycles.
+ */
+const WEDGED_POLL_MULTIPLE = 20;
+/** Floor for the above, so fast-polling chains don't trip on a single hiccup. */
+const WEDGED_MIN_MS = 60_000;
+
+function pollingIntervalOf(protocol: AllSyncProtocols): number {
+  const syncProtocol = (protocol as unknown as {
+    fetcher?: { config?: { syncProtocol?: { pollingInterval?: number } } };
+  }).fetcher?.config?.syncProtocol;
+  return syncProtocol?.pollingInterval ?? 1_000;
+}
+
+function protocolHealth(
+  protocol: AllSyncProtocols,
+  now: number,
+): ProtocolHealth {
+  const sinceLastPollMs = protocol.lastPollAtMs > 0
+    ? now - protocol.lastPollAtMs
+    : null;
+  const sinceLastSuccessfulFetchMs = protocol.lastSuccessfulFetchMs > 0
+    ? now - protocol.lastSuccessfulFetchMs
+    : null;
+
+  const wedgedAfterMs = Math.max(
+    WEDGED_POLL_MULTIPLE * pollingIntervalOf(protocol),
+    WEDGED_MIN_MS,
+  );
+
+  let status: ProtocolStatus;
+  if (sinceLastPollMs != null && sinceLastPollMs > wedgedAfterMs) {
+    // The loop itself stopped cycling: stuck inside a call that never returned.
+    status = "wedged";
+  } else if (protocol.consecutiveErrors > 0) {
+    status = "erroring";
+  } else if (protocol.lastPage == null) {
+    status = "starting";
+  } else {
+    status = "ok";
+  }
+
+  return {
+    name: protocol.name,
+    status,
+    ownBlockNumber: protocol.lastPage?.ownBlockNumber ?? null,
+    sinceLastPollMs,
+    sinceLastSuccessfulFetchMs,
+    consecutiveErrors: protocol.consecutiveErrors,
+    producerRestarts: protocol.producerRestarts,
+    blockingMerge: protocol.mergeWaitingForPage,
+    buffered: protocol.bufferedData.size(),
+    bufferCap: protocol.bufferCap,
+    paused: protocol.pausedNow,
+  };
+}
+
+/**
+ * @param stallThresholdMs How long without applying a block counts as stalled.
+ *   Callers pass the same value used for lag logging and coalescing (20× the
+ *   main clock's block time, or `EFFECTSTREAM_LAG_THRESHOLD_MS`).
+ */
+export function buildHealthReport(
+  syncProtocols: AllSyncProtocols[],
+  stallThresholdMs: number,
+): HealthReport {
+  const now = Date.now();
+  const db = poolErrors.state();
+  const protocols = syncProtocols.map((p) => protocolHealth(p, now));
+
+  const appliedAtMs = appliedBlockStatus.appliedAtMs;
+  // Before the first block, measure from process start instead — a node that
+  // boots and never applies anything is stalled too, and that is exactly what a
+  // chain wedged from its very first request looks like.
+  const sinceLastAppliedMs = appliedAtMs != null
+    ? now - appliedAtMs
+    : Math.round(process.uptime() * 1000);
+  const appliedTs = appliedBlockStatus.timestamp;
+  const neverApplied = appliedAtMs == null;
+
+  let status: HealthStatus;
+  if (db.sustained) {
+    status = "db-unreachable";
+  } else if (neverApplied && sinceLastAppliedMs <= stallThresholdMs) {
+    // Booting: migrations, genesis sync, first merge. Not ready to serve, but
+    // distinct from `stalled` so an operator can tell "still coming up" from
+    // "was up and stopped".
+    status = "starting";
+  } else if (sinceLastAppliedMs > stallThresholdMs) {
+    status = "stalled";
+  } else if (protocols.some((p) => p.status !== "ok" && p.status !== "starting")) {
+    // Something is unhealthy but blocks are still flowing: worth alerting on,
+    // not worth restarting the node over.
+    status = "degraded";
+  } else {
+    status = "ok";
+  }
+
+  return {
+    status,
+    db,
+    apply: {
+      blockHeight: appliedBlockStatus.blockNumber,
+      sinceLastAppliedMs,
+      lagMs: appliedTs != null ? now - appliedTs : null,
+    },
+    finalizedStream: {
+      produced: finalizedStreamStatus.produced,
+      consumed: finalizedStreamStatus.consumed,
+      inFlight: finalizedStreamStatus.produced - finalizedStreamStatus.consumed,
+    },
+    protocols,
+  };
+}
+
+/** 503 only when the node is not (yet) doing its job; see the note at the top. */
+export function healthHttpStatus(status: HealthStatus): 200 | 503 {
+  return status === "ok" || status === "degraded" ? 200 : 503;
+}

--- a/packages/node-sdk/runtime/src/api/http-server.ts
+++ b/packages/node-sdk/runtime/src/api/http-server.ts
@@ -384,6 +384,8 @@ export const startHttpServer = function* (
     sinceLastSuccessfulFetchMs: Type.Union([Type.Number(), Type.Null()]),
     consecutiveErrors: Type.Number(),
     producerRestarts: Type.Number(),
+    producerErrors: Type.Number(),
+    sinceLastProducerErrorMs: Type.Union([Type.Number(), Type.Null()]),
     blockingMerge: Type.Boolean(),
     buffered: Type.Number(),
     bufferCap: Type.Number(),
@@ -394,7 +396,7 @@ export const startHttpServer = function* (
     db: HealthDbSchema,
     apply: Type.Object({
       blockHeight: Type.Union([Type.Number(), Type.Null()]),
-      sinceLastAppliedMs: Type.Union([Type.Number(), Type.Null()]),
+      sinceLastAppliedMs: Type.Number(),
       lagMs: Type.Union([Type.Number(), Type.Null()]),
     }),
     finalizedStream: Type.Object({

--- a/packages/node-sdk/runtime/src/api/http-server.ts
+++ b/packages/node-sdk/runtime/src/api/http-server.ts
@@ -2,6 +2,7 @@ import fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest }
 import { evmRpcEngine } from "./rpc-evm/eip1193.ts";
 import { appliedBlockStatus } from "./apply-status.ts";
 import { finalizedStreamStatus } from "./stream-status.ts";
+import { buildHealthReport, healthHttpStatus } from "./health.ts";
 import type { Pool } from "pg";
 import cors from "@fastify/cors";
 import { run, until } from "effection";
@@ -159,6 +160,8 @@ function* registerOpenApiDocumentation(
 export const startHttpServer = function* (
   dbConn: Pool,
   syncProtocols: AllSyncProtocols[],
+  /** How long without applying a block counts as stalled on `/health`. */
+  stallThresholdMs: number,
   apiRouter?: StartConfigApiRouter,
   grammar?: GrammarDefinition,
 ) {
@@ -373,9 +376,33 @@ export const startHttpServer = function* (
     sustainedDurationMs: Type.Number(),
     sustained: Type.Boolean(),
   });
+  const HealthProtocolSchema = Type.Object({
+    name: Type.String(),
+    status: Type.String(),
+    ownBlockNumber: Type.Union([Type.Number(), Type.Null()]),
+    sinceLastPollMs: Type.Union([Type.Number(), Type.Null()]),
+    sinceLastSuccessfulFetchMs: Type.Union([Type.Number(), Type.Null()]),
+    consecutiveErrors: Type.Number(),
+    producerRestarts: Type.Number(),
+    blockingMerge: Type.Boolean(),
+    buffered: Type.Number(),
+    bufferCap: Type.Number(),
+    paused: Type.Boolean(),
+  });
   const HealthResponseSchema = Type.Object({
     status: Type.String(),
     db: HealthDbSchema,
+    apply: Type.Object({
+      blockHeight: Type.Union([Type.Number(), Type.Null()]),
+      sinceLastAppliedMs: Type.Union([Type.Number(), Type.Null()]),
+      lagMs: Type.Union([Type.Number(), Type.Null()]),
+    }),
+    finalizedStream: Type.Object({
+      produced: Type.Number(),
+      consumed: Type.Number(),
+      inFlight: Type.Number(),
+    }),
+    protocols: Type.Array(HealthProtocolSchema),
   });
   server.get("/health", {
     schema: {
@@ -386,10 +413,10 @@ export const startHttpServer = function* (
       },
     },
   }, (_req, reply) => {
-    const db = poolErrors.state();
-    return reply
-      .status(db.sustained ? 503 : 200)
-      .send({ status: db.sustained ? "db-unreachable" : "ok", db });
+    // Reports sync liveness, not just database reachability — a stalled merge
+    // leaves the database perfectly healthy. See ./health.ts.
+    const report = buildHealthReport(syncProtocols, stallThresholdMs);
+    return reply.status(healthHttpStatus(report.status)).send(report);
   });
 
   server.get("/addresses", {

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -90,24 +90,27 @@ export function* start(config: StartConfig): Operation<void> {
     new EventBroker("effectstream-engine").createServer();
   }
 
-  yield* spawn(function* () {
-    yield* startHttpServer(
-      dbConn,
-      syncProtocols,
-      config.apiRouter,
-      config.grammar,
-    );
-  });
-
   // 20× main clock block time (NTP if present, else protocol 0).
   // Falls back to 60 s so coalescing is not silently disabled for chains that
   // don't expose a blockTimeMS on their network config (e.g. Midnight-as-main).
+  // Computed before the HTTP server starts because /health uses the same
+  // threshold to decide whether the node counts as stalled.
   const ntpConfig = syncInfo.find(s => s.networkType === ConfigNetworkType.NTP);
   const clockBlockTimeMS =
     (ntpConfig?.network as { blockTimeMS?: number } | undefined)?.blockTimeMS ??
     (syncInfo[0]?.network as { blockTimeMS?: number } | undefined)?.blockTimeMS;
   const lagThresholdMs = ENV.EFFECTSTREAM_LAG_THRESHOLD_MS ??
     (clockBlockTimeMS != null ? clockBlockTimeMS * 20 : 60_000);
+
+  yield* spawn(function* () {
+    yield* startHttpServer(
+      dbConn,
+      syncProtocols,
+      lagThresholdMs,
+      config.apiRouter,
+      config.grammar,
+    );
+  });
 
   // Bounded hand-off queue between the merge and the apply loop. Backpressure caps
   // the in-memory queue so deep catch-up can't grow it toward the whole backlog

--- a/packages/node-sdk/runtime/test/reproduction/determinism.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/determinism.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Timing must not change state.
+ *
+ * The whole pipeline rests on one property: two nodes syncing the same chains
+ * reach byte-identical state, regardless of how fast they got there. Block `n`
+ * always holds the same data on every machine, so the block-hash chain — and
+ * everything downstream of it — agrees.
+ *
+ * That property is easy to break by accident, and three changes in this branch
+ * touch the fetch path: per-request timeouts, unconditional loop pacing, and
+ * producer supervision. All three alter *when* a fetch happens, so this test
+ * varies exactly those knobs and asserts the resulting databases are identical.
+ *
+ * Why it holds, and what would break it:
+ *
+ *   - Pacing changes only how often the loop asks. A block's content is a pure
+ *     function of its height (the main clock derives timestamps arithmetically;
+ *     parallel data merges into the first root block whose timestamp is >= its
+ *     own), so polling faster only reaches the same answer sooner.
+ *
+ *   - A timeout makes `readData` throw, and `lastPage` only advances on a
+ *     COMPLETE `DataFetched` — so a timeout re-fetches the same range rather
+ *     than skipping it. A slower machine that times out where a faster one does
+ *     not therefore converges on the same data. It would NOT be safe if a
+ *     partial result were ever committed, which is why the fetchers build their
+ *     whole page-range before returning.
+ *
+ * The synthetic chain is deterministic by construction, so any difference here
+ * comes from the engine rather than from the chain.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import {
+  ConfigBuilder,
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+} from "@effectstream/config";
+import { TestChainControl } from "@effectstream/sync";
+import {
+  compareConsistencySnapshots,
+  type ConsistencySnapshot,
+  dumpConsistencySnapshot,
+  SYNC_BOOKKEEPING_TABLES,
+} from "./consistency-snapshot.ts";
+import { type Harness, setupHarness, TEST_PRIMITIVE_TYPE } from "./harness.ts";
+
+const START_TIME = 1_700_000_000_000;
+const BLOCK_TIME_MS = 1000;
+const TARGET = 60;
+/**
+ * The parallel chain is deliberately fetched further than the main clock. The
+ * merge only folds a parallel chain's data into root timestamp T once that
+ * chain's page is STRICTLY past T, so a parallel tip equal to the main tip
+ * stalls production one block short of the target (see the merge-boundary note
+ * in sync/CLAUDE.md).
+ */
+const PARALLEL_TIP = TARGET + 40;
+
+const MAIN = "detMain";
+const PAR = "detParallel";
+
+/** Events spread across the range so several blocks carry state. */
+const EVENTS = [
+  { atBlock: 12, payload: { v: "a" } },
+  { atBlock: 25, payload: { v: "b" } },
+  { atBlock: 44, payload: { v: "c" } },
+];
+
+type Timing = {
+  pollingInterval: number;
+  stepSize: number;
+  requestTimeoutMs: number;
+};
+
+function buildConfig(timing: Timing) {
+  return new ConfigBuilder()
+    .setNamespace((b) => b.setSecurityNamespace("sync-determinism"))
+    .buildNetworks((b) =>
+      b
+        .addNetwork({
+          name: "clock",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+        .addNetwork({
+          name: "chainP",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+    )
+    .buildDeployments((b) => b)
+    .buildSyncProtocols((b) =>
+      b
+        .addMain(
+          (n) => n.clock,
+          () => ({
+            name: MAIN,
+            type: ConfigSyncProtocolType.TEST_MAIN,
+            startBlockHeight: 1,
+            pollingInterval: timing.pollingInterval,
+            stepSize: timing.stepSize,
+            requestTimeoutMs: timing.requestTimeoutMs,
+          }),
+        )
+        .addParallel(
+          (n) => (n as any).chainP,
+          () => ({
+            name: PAR,
+            type: ConfigSyncProtocolType.TEST_PARALLEL,
+            startBlockHeight: 1,
+            pollingInterval: timing.pollingInterval,
+            stepSize: timing.stepSize,
+            requestTimeoutMs: timing.requestTimeoutMs,
+            delayMs: 0,
+            events: EVENTS,
+          }),
+        )
+    )
+    .buildPrimitives((b) =>
+      b.addPrimitive(
+        (sp) => (sp as any)[PAR],
+        () => ({ name: "detEvt", type: TEST_PRIMITIVE_TYPE, startBlockHeight: 1 }),
+      )
+    )
+    .build();
+}
+
+/** Sync a fresh database to TARGET under the given timing, then fingerprint it. */
+async function syncUnder(
+  timing: Timing,
+  apiPort: number,
+): Promise<ConsistencySnapshot> {
+  const h: Harness = await setupHarness();
+  try {
+    TestChainControl.clear();
+    TestChainControl.setTip(MAIN, TARGET);
+    TestChainControl.setTip(PAR, PARALLEL_TIP);
+
+    await h.runToHeight({
+      events: [],
+      // Keyed by THIS config's protocol names; a mismatch would leave the
+      // synthetic chain on its wall-clock fallback tip and sync to "now".
+      tips: { [MAIN]: TARGET, [PAR]: PARALLEL_TIP },
+      target: TARGET,
+      apiPort,
+      config: buildConfig(timing),
+    });
+
+    // Bookkeeping tables legitimately differ by path (the page queue records
+    // where a run happened to be), so compare observable state.
+    return await dumpConsistencySnapshot(h.pool, {
+      excludeTables: SYNC_BOOKKEEPING_TABLES,
+    });
+  } finally {
+    await h.teardown();
+  }
+}
+
+beforeEach(() => {
+  TestChainControl.clear();
+});
+afterEach(() => {
+  TestChainControl.clear();
+});
+
+test("state is identical regardless of polling speed, chunk size and timeouts", async () => {
+  // Fast + fine-grained: many small fetches, tight deadline.
+  const fast = await syncUnder(
+    { pollingInterval: 5, stepSize: 5, requestTimeoutMs: 1_000 },
+    19201,
+  );
+
+  // Slow + coarse: fewer, larger fetches, generous deadline. A different
+  // machine under different load is somewhere between these two.
+  const slow = await syncUnder(
+    { pollingInterval: 60, stepSize: 100, requestTimeoutMs: 30_000 },
+    19202,
+  );
+
+  const { diffs } = compareConsistencySnapshots(fast, slow);
+  expect(diffs).toEqual([]);
+
+  // Guard against the assertion passing vacuously on two empty databases.
+  const rows = [...fast.values()].reduce((sum, f) => sum + f.rowCount, 0);
+  expect(rows).toBeGreaterThan(0);
+}, 180_000);
+
+test("the block hash chain is identical across timings", async () => {
+  const a = await syncUnder(
+    { pollingInterval: 5, stepSize: 5, requestTimeoutMs: 1_000 },
+    19203,
+  );
+  const b = await syncUnder(
+    { pollingInterval: 60, stepSize: 100, requestTimeoutMs: 30_000 },
+    19204,
+  );
+
+  // effectstream_blocks carries block_height + effectstream_block_hash, so an
+  // identical fingerprint here means every block hashed the same on both runs —
+  // the property consensus actually depends on. Called out separately from the
+  // whole-database check so a failure points straight at the hash chain.
+  const key = "effectstream.effectstream_blocks";
+  expect(a.get(key)).toBeDefined();
+  expect(a.get(key)!.rowCount).toBeGreaterThan(0);
+  expect(b.get(key)?.fingerprint).toBe(a.get(key)!.fingerprint);
+}, 180_000);

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -317,6 +317,16 @@ export type RunToHeightOpts = {
   securityNamespace?: string;
   /** Enable/disable empty-block coalescing. */
   coalesce?: boolean;
+  /**
+   * Full ConfigBuilder output, for tests that need protocols the default
+   * scenario doesn't provide. When omitted the node-runner builds the standard
+   * two-protocol scenario from `events`/`parallelStepSize`.
+   *
+   * NOTE: `tips` must then be keyed by THIS config's protocol names — a
+   * mismatch leaves the synthetic chain on its wall-clock fallback tip, which
+   * silently syncs to "now" instead of the intended height.
+   */
+  config?: any;
 };
 
 const RUNNER = join(import.meta.dir, "node-runner.ts");
@@ -342,6 +352,9 @@ function makeRunToHeight(
       apiPort: opts.apiPort,
       waitPages: opts.waitPages,
       coalesce: opts.coalesce,
+      // Forwarded so a caller can supply its own protocols; node-runner already
+      // prefers `spec.config` over the default scenario.
+      config: opts.config,
     };
     return new Promise<void>((resolve, reject) => {
       const child = spawn("bun", [RUNNER, JSON.stringify(spec)], {

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -458,8 +458,14 @@ function makeRunNode(
       }
     })();
 
+    // Readiness here means "the HTTP server is listening", not "the node is
+    // healthy": /health answers 503 while the node is still `starting` (no
+    // block applied yet) or `stalled`, and several tests deliberately boot a
+    // node into exactly those states.
     const up = await pollUntil(
-      () => fetch(`http://127.0.0.1:${opts.apiPort}/health`).then((r) => r.ok),
+      () =>
+        fetch(`http://127.0.0.1:${opts.apiPort}/health`)
+          .then((r) => r.status === 200 || r.status === 503),
       10_000,
     );
     if (!up) {

--- a/packages/node-sdk/runtime/test/reproduction/health.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/health.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Sync liveness on `/health` (sync/CLAUDE.md Finding #6).
+ *
+ * `/health` used to report only `poolErrors.state()` — database reachability.
+ * Every failure mode found in this investigation is invisible to that check:
+ * a blackholed RPC, a producer whose stream ended, or simply one chain that
+ * stopped advancing all end the same way — the merge blocks on that chain's
+ * page and block production stops — while the database stays perfectly
+ * healthy and `/health` keeps answering `200 {"status":"ok"}`.
+ *
+ * This test stalls the merge deterministically (a parallel chain pinned far
+ * behind the main clock, the head-of-line case from `buffering.test.ts` 1b) and
+ * asserts that `/health` now:
+ *   - reports 503 with `status: "stalled"`,
+ *   - names the protocol the merge is waiting on (`blockingMerge`),
+ *   - and still reports the healthy chain as `ok`.
+ *
+ * The apply-lag threshold is driven by EFFECTSTREAM_LAG_THRESHOLD_MS so this
+ * runs in seconds rather than the 20× block-time default.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import {
+  ConfigBuilder,
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+} from "@effectstream/config";
+import { TestChainControl } from "@effectstream/sync";
+import {
+  type Harness,
+  type RunningNode,
+  setupHarness,
+  sleep,
+  TEST_PRIMITIVE_TYPE,
+} from "./harness.ts";
+
+const START_TIME = 1_700_000_000_000;
+const BLOCK_TIME_MS = 1000;
+const STEP_SIZE = 1000;
+
+const MAIN = "healthMain";
+const PAR_OK = "healthParallelOk";
+const PAR_STALLED = "healthParallelStalled";
+
+/** Main clock runs far ahead; the stalled chain is pinned just above genesis. */
+const MAIN_TIP = 5_000;
+const OK_TIP = 5_000;
+const STALLED_TIP = 5;
+
+/** Well below the time this test spends waiting, so "stalled" latches quickly. */
+const LAG_THRESHOLD_MS = 2_000;
+
+function buildConfig() {
+  return new ConfigBuilder()
+    .setNamespace((b) => b.setSecurityNamespace("sync-health"))
+    .buildNetworks((b) =>
+      b
+        .addNetwork({
+          name: "clock",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+        .addNetwork({
+          name: "chainOk",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+        .addNetwork({
+          name: "chainStalled",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+    )
+    .buildDeployments((b) => b)
+    .buildSyncProtocols((b) =>
+      b
+        .addMain(
+          (n) => n.clock,
+          () => ({
+            name: MAIN,
+            type: ConfigSyncProtocolType.TEST_MAIN,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: STEP_SIZE,
+          }),
+        )
+        .addParallel(
+          (n) => (n as any).chainOk,
+          () => ({
+            name: PAR_OK,
+            type: ConfigSyncProtocolType.TEST_PARALLEL,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: STEP_SIZE,
+            delayMs: 0,
+            events: [],
+          }),
+        )
+        .addParallel(
+          (n) => (n as any).chainStalled,
+          () => ({
+            name: PAR_STALLED,
+            type: ConfigSyncProtocolType.TEST_PARALLEL,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: STEP_SIZE,
+            delayMs: 0,
+            events: [],
+          }),
+        )
+    )
+    .buildPrimitives((b) =>
+      b.addPrimitive(
+        (sp) => (sp as any)[PAR_OK],
+        () => ({ name: "noEvtHealth", type: TEST_PRIMITIVE_TYPE, startBlockHeight: 1 }),
+      )
+    )
+    .build();
+}
+
+type HealthProtocol = {
+  name: string;
+  status: string;
+  blockingMerge: boolean;
+  ownBlockNumber: number | null;
+  consecutiveErrors: number;
+  producerRestarts: number;
+};
+type HealthBody = {
+  status: string;
+  db: { sustained: boolean };
+  apply: {
+    blockHeight: number | null;
+    sinceLastAppliedMs: number | null;
+    lagMs: number | null;
+  };
+  protocols: HealthProtocol[];
+};
+
+async function getHealth(
+  port: number,
+): Promise<{ httpStatus: number; body: HealthBody }> {
+  const res = await fetch(`http://127.0.0.1:${port}/health`);
+  return { httpStatus: res.status, body: (await res.json()) as HealthBody };
+}
+
+let h: Harness;
+let node: RunningNode | undefined;
+
+beforeEach(async () => {
+  TestChainControl.clear();
+  process.env.EFFECTSTREAM_LAG_THRESHOLD_MS = String(LAG_THRESHOLD_MS);
+  h = await setupHarness();
+});
+afterEach(async () => {
+  await node?.stop();
+  node = undefined;
+  delete process.env.EFFECTSTREAM_LAG_THRESHOLD_MS;
+  await h?.teardown();
+});
+
+test("/health reports a stalled merge instead of a bare 'ok'", async () => {
+  TestChainControl.setTip(MAIN, MAIN_TIP);
+  TestChainControl.setTip(PAR_OK, OK_TIP);
+  // Pinned far behind: once the root timestamp passes this chain's tip, the
+  // merge blocks on its page and block production stops for good.
+  TestChainControl.setTip(PAR_STALLED, STALLED_TIP);
+
+  node = await h.runNode({ config: buildConfig(), apiPort: 19171 });
+
+  // Let the node apply what it can, then sit past the lag threshold.
+  await sleep(LAG_THRESHOLD_MS * 3);
+
+  const { httpStatus, body } = await getHealth(node.apiPort);
+
+  // The database is fine — this is exactly why the old db-only check passed.
+  expect(body.db.sustained).toBe(false);
+
+  // ...but the node has not applied a block in a long time. Measured in
+  // wall-clock time since the last apply, not block-timestamp lag: the
+  // synthetic chain's blocks are dated 2023, and a node replaying history is
+  // legitimately far behind in block time while being perfectly healthy.
+  expect(body.status).toBe("stalled");
+  expect(httpStatus).toBe(503);
+  expect(body.apply.sinceLastAppliedMs).toBeGreaterThan(LAG_THRESHOLD_MS);
+
+  // The report must name WHICH chain is holding up the merge, otherwise an
+  // operator has a stalled node and no idea where to look.
+  const stalled = body.protocols.find((p) => p.name === PAR_STALLED);
+  expect(stalled).toBeDefined();
+  expect(stalled!.blockingMerge).toBe(true);
+
+  // The healthy chains are still reported healthy — "stalled" is a property of
+  // the pipeline, not of every protocol in it.
+  const ok = body.protocols.find((p) => p.name === PAR_OK);
+  expect(ok).toBeDefined();
+  expect(ok!.blockingMerge).toBe(false);
+  expect(ok!.consecutiveErrors).toBe(0);
+}, 120_000);
+
+test("/health reports ok while blocks are flowing", async () => {
+  // All chains advancing: the merge is never gated, blocks keep applying.
+  TestChainControl.setTip(MAIN, MAIN_TIP);
+  TestChainControl.setTip(PAR_OK, OK_TIP);
+  TestChainControl.setTip(PAR_STALLED, OK_TIP);
+
+  node = await h.runNode({ config: buildConfig(), apiPort: 19172 });
+
+  // Poll: the node needs a moment to apply its first block, and once it does
+  // the status must be ok (not merely "not stalled").
+  let body: HealthBody | undefined;
+  let httpStatus = 0;
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    ({ httpStatus, body } = await getHealth(node.apiPort));
+    if (body.status === "ok") break;
+    await sleep(100);
+  }
+
+  expect(body!.status).toBe("ok");
+  expect(httpStatus).toBe(200);
+  expect(body!.apply.blockHeight).toBeGreaterThan(0);
+  for (const p of body!.protocols) {
+    expect(p.consecutiveErrors).toBe(0);
+    expect(p.producerRestarts).toBe(0);
+  }
+}, 120_000);

--- a/packages/node-sdk/sync/CLAUDE.md
+++ b/packages/node-sdk/sync/CLAUDE.md
@@ -69,8 +69,10 @@ config (syncProtocols.main + syncProtocols.parallel)
    - `toRootPage()` — map a block → millisecond timestamp (the **merge key**)
    - `toRootOutput()` — **main only** — produce a root `ChainBlock`
    - `mergeDatum()` — **parallel only** — fold this chain's data into the root
-   - `updateState()` (`state.ts:109`) — push outputs to the Deque, wake CondVars, and
-     persist the page (`upsertPage`, `state.ts:132`).
+   - `updateState()` — push outputs to the Deque and wake the CondVars. It does **not**
+     persist anything: `lastPage` is in-memory only, because the fetch loop runs ahead of
+     commits and its chunk-end page is not a safe resume point. The runtime is the sole
+     writer of the persisted resume marker (design idea #5).
 
 3. **types.ts** — `Input` / `Output` / `Page` aliases (+ a `Client.ts` per chain where an
    RPC client is needed).
@@ -84,12 +86,16 @@ chains merge into root". **The main chain must be at index 0.**
 ## The two driving loops
 
 **`startSync(state)`** (`src/sync-protocols/orchestration/sync.ts`) spawns:
-- `startAsync()` — optional background producer (websocket subs for utxorpc/midnight;
-  no-op for NTP/EVM).
+- `startAsync()` — optional background producer (websocket/gRPC subs for utxorpc; no-op
+  for polled chains). **Supervised** when the state sets `hasAsyncProducer`: both a throw
+  and a clean return count as failure (a producer that returns has ended its stream) and
+  are restarted with capped backoff, counted in `producerRestarts`. Polled chains run
+  their no-op once.
 - the **polling loop**: `stateToInput()` → `readData()` → `updateState()` →
-  `producerChannel.send()` (`sync.ts:70`). Errors are swallowed via `tryYield`, bump
-  `consecutiveErrors`, log, sleep `pollingInterval`, continue. The loop only sleeps when
-  `stateToInput` returns `undefined` (caught up); while behind it fetches chunks
+  `producerChannel.send()`. Errors are swallowed via `tryYield`, bump
+  `consecutiveErrors`, log, sleep, continue. Every branch sleeps
+  `pollingInterval` (falling back to 1 s if a config somehow lacks one) — a pass that
+  neither fetches nor sleeps starves the whole event loop. While behind it fetches chunks
   back-to-back.
 
 **`startMerge(syncProtocols, finalizedBlockStream)`** (`orchestration/merge.ts`) loops; per
@@ -214,15 +220,73 @@ catch-up.
 catch-up blocks into fewer transactions while preserving steady-state semantics and the
 block-hash chain.
 
-> This PR adds the synthetic `test` chain (`src/sync-protocols/test/`) and an
-> in-process harness (`packages/node-sdk/runtime/test/reproduction/`, in the
-> runtime package because it boots the full `start()`, which sync must not depend
-> on). `sanity.test.ts` proves the chain syncs, processes a configured event, and
-> survives a restart. See `docs/ADDING-A-SYNC-PROTOCOL.md` for how to add a chain
-> (with `test` as the worked example).
+### 4. No RPC timeouts — a hung fetch stalled the node silently (correctness) — ✅ FIXED
+
+`fetch` has no default timeout. Bitcoin, NEAR and Avail used it bare, so a blackholed
+endpoint (dropped LB backend, half-open socket) hung `readData` forever. That is the worst
+shape of failure here: the fetch loop never reaches its `catch`, so `consecutiveErrors`
+stays 0 and `lastSuccessfulFetchMs` freezes while the merge blocks on that chain's page.
+Block production stopped and nothing reported it.
+
+→ Fix: `common/http.ts:fetchWithTimeout` (AbortSignal.timeout) on every client, configured
+per protocol by `requestTimeoutMs` on `PollingSyncProtocol` (default 15 s). Timeout-only,
+no internal retry — the fetch loop already retries the same page range idempotently, and
+retrying inside the client would hide the failure from the health endpoint. Regression
+test: `sync/test/rpc-timeout.test.ts` (each client vs a blackholed socket).
+
+### 5. An unpaced fetch loop starved the event loop (correctness) — ✅ FIXED
+
+`startSync` guarded its sleeps with `if ("pollingInterval" in config.syncProtocol)`, and
+the Cardano/utxorpc schema was the only sync protocol not merging `PollingSyncProtocol` —
+so that property was undeclared, untyped and undefaulted while the loop keyed its pacing
+off it. Cardano worked only because every config passed it anyway as an undeclared extra
+field; a config built strictly from the schema froze the node.
+
+Froze rather than span: a pass that neither fetches nor sleeps never yields to the
+macrotask queue. Measured 200k iterations in ~4 s while a 500 ms `setTimeout` never fired
+once — no HTTP server, no other chain's fetch loop, and for a streaming chain none of the
+callbacks that would let it escape.
+
+→ Fix: utxorpc merges `PollingSyncProtocol` like every other protocol, **and** the sleep is
+unconditional with a 1 s fallback. Regression test: `sync/test/poll-loop-spin.test.ts`.
+
+### 6. The streaming producer was unsupervised (correctness) — ✅ FIXED
+
+`startAsync` was spawned bare. A stream that **ended cleanly** left the chain receiving
+nothing forever with every health counter clean — a total, silent, unrecoverable stall. A
+stream that **threw** tore down the enclosing scope, i.e. `start()`, taking every unrelated
+chain with it.
+
+→ Fix: both treated as failure and restarted with capped backoff, counted in
+`producerRestarts`. Gated on `hasAsyncProducer` so polled chains still run their no-op
+once. Regression test: `sync/test/start-async-supervision.test.ts`.
+
+### 7. `/health` reported only database reachability (operability) — ✅ FIXED
+
+Every failure above leaves the database perfectly healthy, so a node that had not applied a
+block in an hour still answered `200 {"status":"ok"}`.
+
+→ Fix: `runtime/src/api/health.ts` reports per-protocol state — most of which `SyncState`
+already tracked and never exposed — keyed on wall-clock time since the last *applied*
+block rather than block-time lag (a node replaying history is legitimately far behind in
+block time while healthy). `blockingMerge` names the chain the merge is waiting on. 503 is
+reserved for `db-unreachable` / `stalled` / `starting`; a chain erroring while blocks still
+flow is `degraded` + 200. Regression test: `runtime/test/reproduction/health.test.ts`.
+
+---
+
+> The synthetic `test` chain (`src/sync-protocols/test/`) and the in-process harness
+> (`packages/node-sdk/runtime/test/reproduction/`, in the runtime package because it boots
+> the full `start()`, which sync must not depend on) back all of these. `sanity.test.ts`
+> proves the chain syncs, processes a configured event, and survives a restart. See
+> `docs/ADDING-A-SYNC-PROTOCOL.md` for how to add a chain (with `test` as the worked
+> example).
 >
-> Deterministic reproductions of #1/#2/#3 and their fixes land alongside each fix:
-> **#2 → block-accurate resume is DONE** (`consistency.test.ts`); **#1 → fetch
-> backpressure is DONE** (`buffering.test.ts`, incl. 1c/1d for the merge-demand
-> exemption). Still in follow-up PRs: #3 → opt-in empty-block commit batching during
-> catch-up.
+> Every finding above has a deterministic reproduction that was written to fail first.
+> Run them all, isolated from other suites, with:
+>
+> ```
+> bun run e2e/sync-repro/run-tests.ts --docker
+> ```
+>
+> Still open: #3 → opt-in empty-block commit batching during catch-up.

--- a/packages/node-sdk/sync/README.md
+++ b/packages/node-sdk/sync/README.md
@@ -108,6 +108,29 @@ was never needed in that run. Steady-state these sit at `0`; during a real deep
 catch-up (or under the perf harness's `PERF_APPLY_DELAY_MS` drain throttle) they climb
 as `buf` pins to `cap`.
 
+## Request timeouts (`requestTimeoutMs`)
+
+`fetch` has no default timeout, so an RPC endpoint that accepts the connection and
+then never answers — a load balancer that dropped its backend, a socket left
+half-open by a NAT rebind — would hang the fetch indefinitely. That is worse than
+an error: the fetch loop never reaches its `catch`, so no error is counted, while
+the merge blocks on that chain's page and block production stops.
+
+**Config.** `requestTimeoutMs` is an optional field on every polling sync-protocol
+config, defaulting to **15 s**. It bounds a single request; retry is the fetch
+loop's job (it re-runs the same page range and counts the failure, which is what
+`/health` reports on).
+
+```ts
+.addParallel((n) => n.myChain, () => ({
+  name: "myChain",
+  type: ConfigSyncProtocolType.EVM_RPC_PARALLEL,
+  pollingInterval: 1000,
+  requestTimeoutMs: 30_000, // slow archive node
+  // ...
+}))
+```
+
 ## Key exports
 
 - `genSyncProtocols(dbConn, syncInfo)` - Effection generator that instantiates a runtime fetcher + state pair for every protocol in `syncInfo` (from `config.syncProtocols`). Called from the runtime's process-blocks loop.

--- a/packages/node-sdk/sync/README.md
+++ b/packages/node-sdk/sync/README.md
@@ -121,6 +121,19 @@ config, defaulting to **15 s**. It bounds a single request; retry is the fetch
 loop's job (it re-runs the same page range and counts the failure, which is what
 `/health` reports on).
 
+**Coverage.** Honoured by EVM (as the viem transport timeout), Bitcoin, NEAR,
+Avail (light-client HTTP), Midnight and Celestia. Two exceptions:
+
+- **Celestia** retries internally, so the value bounds each *attempt* rather than
+  the whole call. It still falls back to `CELESTIA_RPC_TIMEOUT_MS` when no
+  protocol-level value is set.
+- **Cardano / utxorpc** reads its data from a gRPC stream rather than
+  request/response RPCs, so the field is inert there. That path is instead
+  protected by producer supervision — a stream that dies or ends is restarted
+  with backoff (see below).
+
+NTP and the synthetic `test` chain make no network calls at all.
+
 ```ts
 .addParallel((n) => n.myChain, () => ({
   name: "myChain",
@@ -130,6 +143,29 @@ loop's job (it re-runs the same page range and counts the failure, which is what
   // ...
 }))
 ```
+
+## Producer supervision (streaming chains)
+
+Chains whose data arrives over a subscription rather than by polling (utxorpc
+today) set `hasAsyncProducer` on their `SyncState`, and `startSync` supervises
+that producer instead of spawning it bare.
+
+Both of its exit modes count as failure and trigger a restart with capped
+exponential backoff (1s → 30s), including a **clean return** — a producer that
+returns has ended its stream, and the observable effect is identical to a throw:
+no more data. Left unsupervised, a stream that simply ended left the chain silent
+forever with every health counter clean, and a stream that threw tore down the
+whole node.
+
+The backoff de-escalates: a producer that ran longer than the maximum backoff
+before dying resets the delay, so an occasional incident over a long-lived stream
+does not permanently penalise it.
+
+Restarts are counted in `producerRestarts` and failures in `producerErrors`, both
+reported per protocol on `/health`. They are tracked separately from the fetch
+loop's `consecutiveErrors` on purpose: that counter is only cleared by a
+successful `readData`, so sharing it left an idle streaming chain reporting
+errors long after its producer recovered.
 
 ## Key exports
 

--- a/packages/node-sdk/sync/docs/ADDING-A-SYNC-PROTOCOL.md
+++ b/packages/node-sdk/sync/docs/ADDING-A-SYNC-PROTOCOL.md
@@ -73,6 +73,9 @@ latitude on its exact shape.
   `readData` (+ `PaginatedFetcher`: `getLatestPage`/`nextInterval`/
   `previousInterval`/`intervalFromStart`, and `PrimitiveFetcher` if it emits
   primitives). `lastPage.own`/`ownBlockNumber` = the **chunk end** (`data.to`).
+  **Bound every RPC call** with `common/http.ts:fetchWithTimeout` (or the client
+  library's own timeout) — a bare `fetch` against a blackholed endpoint hangs
+  `readData` forever, which silently stalls the whole node (CLAUDE.md #4).
   Page-request helpers live in `base/page.ts`
   (`genImmediatePageRequests`/`genOnDemandPageRequests`).
 - **`sync-protocols/<chain>/Client.ts`** (new, only if it talks to a node) — the
@@ -120,19 +123,23 @@ rows and optional scheduled STF inputs.
 
 - **One network → many sync protocols** is allowed (Cardano, `test`). `FlipObject`
   unions them, so `addMain`/`addParallel` narrow correctly.
-- **Resume is currently chunk-granular** (a known issue — CLAUDE.md finding #2):
-  on restart a chain resumes from the *end* of its oldest retained page chunk,
-  which can silently skip an un-committed tail. A block-accurate-resume fix is
-  planned; until then, avoid relying on exact restart positions mid-chunk.
+- **Resume is block-accurate** (CLAUDE.md finding #2, fixed): the runtime is the
+  sole writer of the persisted marker, written inside the block's transaction.
+  Your `state.ts` must implement `outputToLastPage`; `updateState` must not
+  persist anything.
+- **Declare `pollingInterval`** by merging `PollingSyncProtocol` into your schema.
+  It is not optional in practice — the fetch loop paces itself with it, and a
+  protocol without one used to starve the entire event loop (CLAUDE.md #5).
+- **Set `hasAsyncProducer = true`** on the state if your chain's data arrives via
+  `startAsync` rather than polling, so the producer is supervised and restarted
+  (CLAUDE.md #6).
 - **Merge boundary gate**: a parallel chain only merges into a root block at
   timestamp `T` once its own page is *strictly* past `T`. If the main clock runs
   to the same height as a parallel chain's fetched tip, the merge stalls at that
   boundary — keep the main clock at/behind the parallel tips.
-- **`finalizedBlockStream` is unbuffered**: a message sent with no active
-  subscriber is dropped. The merge is spawned before the consumer loop
-  subscribes, so a very fast producer could in principle drop early blocks
-  (RPC-paced chains don't hit this); a subscribe-before-spawn hardening is a
-  planned follow-up.
+- **`finalizedBlockStream` subscribes before the merge is spawned**
+  (`runtime/src/finalized-stream.ts`), because an effection channel drops sends
+  with no active subscriber.
 - **`isPresync`** is currently ~always false (`genInputRange` TODO) — the
   historical-presync path may not trigger as intended.
 

--- a/packages/node-sdk/sync/src/sync-protocols/avail/AvailClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/AvailClient.ts
@@ -45,9 +45,14 @@ export class AvailClient {
   }
 
   async getLatestBlockHeight(): Promise<number> {
-    const api = (await this.sdk).client.api;
+    // Deliberately does NOT await `this.sdk`. The height comes from the light
+    // client below; the websocket SDK was only needed by the commented-out
+    // `api.rpc.chain.getHeader()` call, and awaiting it here reintroduced an
+    // unbounded wait on the sync path — if the node's websocket never connects,
+    // this never returns and the chain stalls silently. That is the exact
+    // failure `requestTimeoutMs` exists to prevent.
     // Block from avail node is slightly above the light client
-    // const header = await api.rpc.chain.getHeader();
+    // const header = await (await this.sdk).client.api.rpc.chain.getHeader();
     const status: AvailStatus = await this.getStatus();
 
     // If the available field is present, this is the real latest block 

--- a/packages/node-sdk/sync/src/sync-protocols/avail/AvailClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/AvailClient.ts
@@ -1,4 +1,5 @@
 import { SDK } from "avail-js-sdk";
+import { DEFAULT_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "../common/http.ts";
 import type {
   AvailBlock,
   AvailBlockDataItem,
@@ -12,13 +13,25 @@ const AVAIL_NODE_DEFAULT_URL = "ws://localhost:9955/ws";
 export class AvailClient {
   private readonly url: string;
   private readonly sdk: Promise<SDK>;
-  constructor(nodeUrl: string, lightClientUrl: string) {
+  /** Per-request deadline for light-client HTTP; see `common/http.ts`. */
+  private readonly requestTimeoutMs: number;
+  constructor(
+    nodeUrl: string,
+    lightClientUrl: string,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  ) {
     this.url = lightClientUrl ?? AVAIL_CLIENT_DEFAULT_URL;
     this.sdk = SDK.New(nodeUrl ?? AVAIL_NODE_DEFAULT_URL);
+    this.requestTimeoutMs = requestTimeoutMs;
   }
 
   async getStatus(): Promise<AvailStatus> {
-    const response = await fetch(`${this.url}/v2/status`);
+    const response = await fetchWithTimeout(
+      `${this.url}/v2/status`,
+      {},
+      "Avail v2/status",
+      this.requestTimeoutMs,
+    );
     if (!response.ok) {
       throw new Error(
         `Failed to get status from light client, status: ${response.status}`,
@@ -80,7 +93,12 @@ export class AvailClient {
       }
     }
 
-    const response = await fetch(`${this.url}/v2/blocks/${height}/header`);
+    const response = await fetchWithTimeout(
+      `${this.url}/v2/blocks/${height}/header`,
+      {},
+      `Avail v2/blocks/${height}/header`,
+      this.requestTimeoutMs,
+    );
     if (!response.ok) {
       throw new Error(
         `Failed to get block header from height ${height}, status: ${response.status}`,
@@ -103,7 +121,12 @@ export class AvailClient {
       return { block_number: height, data_transactions: [] }
     }
 
-    const response = await fetch(`${this.url}/v2/blocks/${height}/data`);
+    const response = await fetchWithTimeout(
+      `${this.url}/v2/blocks/${height}/data`,
+      {},
+      `Avail v2/blocks/${height}/data`,
+      this.requestTimeoutMs,
+    );
     if (!response.ok) {
       throw new Error(
         `Failed to get block data from height ${height}, status: ${response.status}`,

--- a/packages/node-sdk/sync/src/sync-protocols/avail/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/fetcher.ts
@@ -5,6 +5,7 @@ import {
 } from "@effectstream/config";
 import { BaseDataFetcher } from "../base/fetcher.ts";
 import type { DataFetched } from "../base/fetcher.ts";
+import { requestTimeoutOf } from "../common/http.ts";
 import type {
   LastPage,
   OutputAndCleanup,
@@ -38,6 +39,7 @@ export class AvailFetcher extends BaseDataFetcher<
     this.client = new AvailClient(
       config.syncProtocol.rpc,
       config.syncProtocol.lightClient,
+      requestTimeoutOf(config.syncProtocol),
     );
   }
 

--- a/packages/node-sdk/sync/src/sync-protocols/avail/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/state.ts
@@ -11,6 +11,7 @@ import { getPage } from "@effectstream/db";
 import { AvailClient } from "./AvailClient.ts";
 import { applyDelay } from "../common/utils.ts";
 import { bufferAtCap } from "../common/page-helpers.ts";
+import { requestTimeoutOf } from "../common/http.ts";
 
 export class AvailSyncState extends SyncState<
   Input,
@@ -138,6 +139,7 @@ export class AvailSyncState extends SyncState<
       new AvailClient(
         config.syncProtocol.rpc,
         config.syncProtocol.lightClient,
+        requestTimeoutOf(config.syncProtocol),
       ),
       dbConn,
     );

--- a/packages/node-sdk/sync/src/sync-protocols/base/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/base/state.ts
@@ -103,6 +103,27 @@ export abstract class SyncState<
    * stream). Surfaced on `/health`; a climbing count means a flapping upstream.
    */
   public producerRestarts: number = 0;
+  /**
+   * Producer failures, tracked separately from {@link consecutiveErrors}.
+   *
+   * That counter belongs to the fetch loop and is only cleared by a successful
+   * `readData`, so sharing it conflated two independent signals: an idle
+   * streaming chain would report `erroring` long after its producer recovered,
+   * and a successful poll would erase the record of a flapping producer.
+   */
+  public producerErrors: number = 0;
+  /** Wall-clock time of the last producer failure, or 0 if none. */
+  public lastProducerErrorMs: number = 0;
+
+  /**
+   * Resolved polling interval for this protocol, stamped by `startSync`.
+   *
+   * Single source of truth: `/health` derives its wedged threshold from this
+   * rather than reaching back into `fetcher.config.syncProtocol`, which it can
+   * only do through an unchecked cast that would fail silently to a default if
+   * the config shape ever moved.
+   */
+  public pollingIntervalMs: number = 0;
 
   // ── Backpressure observability (see common/page-helpers.ts + README) ──
   /** Resolved fetch cap (`maxBufferedPages`); set on each backpressure check, 0 until the first. */

--- a/packages/node-sdk/sync/src/sync-protocols/base/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/base/state.ts
@@ -69,6 +69,18 @@ export abstract class SyncState<
   public lastPage: undefined | LastPage<Page, RootPage>;
   /** Timestamp of the last successful fetch (readData completed without error). */
   public lastSuccessfulFetchMs: number = 0;
+  /**
+   * Wall-clock time of the last completed pass through the fetch loop, whatever
+   * its outcome (fetched, caught up, or errored).
+   *
+   * This — not `lastSuccessfulFetchMs` — is the hang detector. A chain that is
+   * caught up never calls `readData`, so its last-successful-fetch time is
+   * indistinguishable from that of a chain wedged inside a request that will
+   * never return. The loop still cycles in the first case and does not in the
+   * second, so a heartbeat that is stale by many polling intervals means the
+   * loop is stuck in `stateToInput`/`readData`.
+   */
+  public lastPollAtMs: number = 0;
   /** Number of consecutive errors since the last successful fetch. */
   public consecutiveErrors: number = 0;
   /** Timestamp of the most recent error, or 0 if no error has occurred. */

--- a/packages/node-sdk/sync/src/sync-protocols/base/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/base/state.ts
@@ -74,6 +74,24 @@ export abstract class SyncState<
   /** Timestamp of the most recent error, or 0 if no error has occurred. */
   public lastErrorTimestamp: number = 0;
 
+  // ── Streaming producer (see startAsync + orchestration/sync.ts) ──
+  /**
+   * Whether {@link SyncState#startAsync} runs a long-lived producer that this
+   * protocol depends on for its data (a subscription/stream), as opposed to the
+   * base-class no-op used by polled chains.
+   *
+   * `startSync` supervises and restarts the producer only when this is true.
+   * A polled chain must leave it false, or its no-op `startAsync` would be
+   * "restarted" forever.
+   */
+  public readonly hasAsyncProducer: boolean = false;
+  /**
+   * How many times the streaming producer has been restarted after dying —
+   * either by throwing or by returning (a producer that returns has ended its
+   * stream). Surfaced on `/health`; a climbing count means a flapping upstream.
+   */
+  public producerRestarts: number = 0;
+
   // ── Backpressure observability (see common/page-helpers.ts + README) ──
   /** Resolved fetch cap (`maxBufferedPages`); set on each backpressure check, 0 until the first. */
   public bufferCap: number = 0;

--- a/packages/node-sdk/sync/src/sync-protocols/bitcoin/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/bitcoin/fetcher.ts
@@ -27,6 +27,7 @@ import type {
   BitcoinTxId,
 } from "@effectstream/utils";
 import { blockNumberRelation } from "../common/utils.ts";
+import { DEFAULT_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "../common/http.ts";
 import type { ConfigType } from "./types.ts";
 
 const SATOSHIS_PER_BTC = 100_000_000;
@@ -457,6 +458,8 @@ type BitcoinRpcClientOptions = {
   url: string;
   username?: string | null;
   password?: string | null;
+  /** Per-request deadline; defaults to {@link DEFAULT_REQUEST_TIMEOUT_MS}. */
+  requestTimeoutMs?: number;
 };
 
 type BitcoinRpcRequest = {
@@ -515,16 +518,21 @@ export class BitcoinRpcClient {
   private async call<TResult>(
     request: BitcoinRpcRequest,
   ): Promise<TResult> {
-    const response = await fetch(this.options.url, {
-      method: "POST",
-      headers: this.buildHeaders(),
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: ++this.nextId,
-        method: request.method,
-        params: request.params ?? [],
-      }),
-    });
+    const response = await fetchWithTimeout(
+      this.options.url,
+      {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: ++this.nextId,
+          method: request.method,
+          params: request.params ?? [],
+        }),
+      },
+      `Bitcoin ${request.method}`,
+      this.options.requestTimeoutMs,
+    );
     if (!response.ok) {
       const body = await response.text();
       throw new Error(

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/CelestiaClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/CelestiaClient.ts
@@ -54,6 +54,11 @@ const CELESTIA_NODE_URL = ENV.getString(
   "http://localhost:26658",
 );
 const CELESTIA_AUTH_TOKEN = ENV.getString("CELESTIA_AUTH_TOKEN", "");
+/**
+ * Fallback per-request deadline, kept for compatibility with deployments that
+ * set it. The protocol config's `requestTimeoutMs` takes precedence — see the
+ * constructor.
+ */
 const CELESTIA_RPC_TIMEOUT_MS = parseInt(
   ENV.getString("CELESTIA_RPC_TIMEOUT_MS", "15000"),
 );
@@ -77,9 +82,18 @@ export function celestiaNamespaceToBase64(hex: string): string {
 
 export class CelestiaClient {
   private readonly rpcUrl: string;
+  /**
+   * Per-attempt deadline. Unlike the other clients this one retries internally
+   * (see `rpc` below), so this bounds each attempt rather than the whole call.
+   */
+  private readonly requestTimeoutMs: number;
 
-  constructor(rpcUrl: string = CELESTIA_NODE_URL) {
+  constructor(
+    rpcUrl: string = CELESTIA_NODE_URL,
+    requestTimeoutMs: number = CELESTIA_RPC_TIMEOUT_MS,
+  ) {
     this.rpcUrl = rpcUrl;
+    this.requestTimeoutMs = requestTimeoutMs;
   }
 
   private async rpc<T>(method: string, params: unknown[]): Promise<T | null> {
@@ -95,7 +109,7 @@ export class CelestiaClient {
           method: "POST",
           headers,
           body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-          signal: AbortSignal.timeout(CELESTIA_RPC_TIMEOUT_MS),
+          signal: AbortSignal.timeout(this.requestTimeoutMs),
         });
         const json = await res.json();
         if (json.error) {

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/fetcher.ts
@@ -2,6 +2,7 @@ import {
   ConfigSyncProtocolType,
   type PrimitiveEntry,
 } from "@effectstream/config";
+import { requestTimeoutOf } from "../common/http.ts";
 import { BaseDataFetcher } from "../base/fetcher.ts";
 import type { DataFetched } from "../base/fetcher.ts";
 import type {
@@ -37,7 +38,10 @@ export class CelestiaFetcher extends BaseDataFetcher<
     readonly config: ConfigType,
   ) {
     super(config.syncProtocol.name);
-    this.client = new CelestiaClient(config.network.rpcUrl);
+    this.client = new CelestiaClient(
+      config.network.rpcUrl,
+      requestTimeoutOf(config.syncProtocol),
+    );
   }
 
   @bound

--- a/packages/node-sdk/sync/src/sync-protocols/celestia/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/celestia/state.ts
@@ -10,6 +10,7 @@ import type { ConfigNetworkType, SyncProtocolWithNetwork } from "@effectstream/c
 import { getPage } from "@effectstream/db";
 import { CelestiaClient } from "./CelestiaClient.ts";
 import { applyDelay } from "../common/utils.ts";
+import { requestTimeoutOf } from "../common/http.ts";
 import { bufferAtCap } from "../common/page-helpers.ts";
 
 export class CelestiaSyncState extends SyncState<
@@ -135,7 +136,10 @@ export class CelestiaSyncState extends SyncState<
       page,
       config,
       fetcher,
-      new CelestiaClient(config.network.rpcUrl),
+      new CelestiaClient(
+        config.network.rpcUrl,
+        requestTimeoutOf(config.syncProtocol),
+      ),
       dbConn,
     );
   }

--- a/packages/node-sdk/sync/src/sync-protocols/common/http.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/common/http.ts
@@ -1,0 +1,77 @@
+/**
+ * Bounded HTTP for sync-protocol RPC clients.
+ *
+ * `fetch` has no default timeout. Against a blackholed endpoint — a load
+ * balancer that drops its backend, a socket left half-open by a NAT rebind —
+ * the connection is established and simply never answers, so the promise never
+ * settles. For a sync protocol that is the worst possible failure: `readData`
+ * never returns, so the fetch loop in `orchestration/sync.ts` never reaches its
+ * `catch`, `consecutiveErrors` stays 0, `lastSuccessfulFetchMs` freezes, and
+ * the merge blocks on that chain's page forever. The node stops producing
+ * blocks and reports nothing wrong.
+ *
+ * Deliberately timeout-only, with NO internal retry. The fetch loop already
+ * retries: it catches, counts the error, sleeps `pollingInterval` and re-runs
+ * the same page range (fetches are idempotent — `lastPage` only advances on a
+ * complete `DataFetched`). Retrying inside the client as well would double the
+ * backoff and, worse, hide failures from `consecutiveErrors`, which is what the
+ * health endpoint reports on.
+ *
+ * Regression test: `sync/test/rpc-timeout.test.ts` points each client at a
+ * blackhole and asserts it rejects rather than hanging.
+ */
+
+/** Used when a protocol config carries no `requestTimeoutMs`. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+/** Thrown when a request exceeds its budget, so callers can tell it apart. */
+export class RequestTimeoutError extends Error {
+  constructor(
+    readonly label: string,
+    readonly timeoutMs: number,
+  ) {
+    super(`[${label}] request timed out after ${timeoutMs}ms`);
+    this.name = "RequestTimeoutError";
+  }
+}
+
+/**
+ * `fetch` with a hard deadline.
+ *
+ * @param label   Prefix for the thrown error, e.g. `"Bitcoin getblockhash"`.
+ * @param timeoutMs Falls back to {@link DEFAULT_REQUEST_TIMEOUT_MS}.
+ * @param signal  Optional caller signal; aborting either one aborts the request.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  label: string,
+  timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const combined = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
+
+  try {
+    return await fetch(url, { ...init, signal: combined });
+  } catch (err) {
+    // Surface our own error for the timeout case; a caller-supplied abort and
+    // ordinary transport failures propagate unchanged.
+    if (timeoutSignal.aborted && !(signal?.aborted ?? false)) {
+      throw new RequestTimeoutError(label, timeoutMs);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Resolve the timeout for a protocol config. Optional in the schema, so this
+ * centralises the fallback instead of repeating `?? DEFAULT` at each client.
+ */
+export function requestTimeoutOf(
+  syncProtocol: { requestTimeoutMs?: number } | undefined,
+): number {
+  return syncProtocol?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+}

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/fetcher.ts
@@ -1,4 +1,5 @@
 import { BaseDataFetcher } from "../base/fetcher.ts";
+import { requestTimeoutOf } from "../common/http.ts";
 import type {
   Block,
   ConfigType,
@@ -59,6 +60,7 @@ export class MidnightFetcher extends BaseDataFetcher<
     this.client = new MidnightClient(
       indexerHttp,
       this.networkId,
+      requestTimeoutOf(config.syncProtocol),
     );
   }
 

--- a/packages/node-sdk/sync/src/sync-protocols/near/NearClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/near/NearClient.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "../common/http.ts";
+
 // ============================
 // NEAR JSON-RPC type responses
 // ============================
@@ -107,17 +109,25 @@ export function parseNep297Log(log: string): Nep297Event | null {
 
 export class NearClient {
   private readonly rpcUrl: string;
+  /** Per-request deadline; see `sync-protocols/common/http.ts`. */
+  private readonly requestTimeoutMs: number;
 
-  constructor(rpcUrl: string) {
+  constructor(rpcUrl: string, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
     this.rpcUrl = rpcUrl;
+    this.requestTimeoutMs = requestTimeoutMs;
   }
 
   private async rpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
-    const res = await fetch(this.rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-    });
+    const res = await fetchWithTimeout(
+      this.rpcUrl,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      },
+      `NEAR ${method}`,
+      this.requestTimeoutMs,
+    );
 
     const json = await res.json();
     if (json.error) {

--- a/packages/node-sdk/sync/src/sync-protocols/near/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/near/fetcher.ts
@@ -4,6 +4,7 @@ import {
 } from "@effectstream/config";
 import { BaseDataFetcher } from "../base/fetcher.ts";
 import type { DataFetched } from "../base/fetcher.ts";
+import { requestTimeoutOf } from "../common/http.ts";
 import type {
   LastPage,
   OutputAndCleanup,
@@ -39,7 +40,10 @@ export class NearFetcher extends BaseDataFetcher<
     readonly config: ConfigType,
   ) {
     super(config.syncProtocol.name);
-    this.client = new NearClient(config.network.rpcUrl);
+    this.client = new NearClient(
+      config.network.rpcUrl,
+      requestTimeoutOf(config.syncProtocol),
+    );
   }
 
   @bound

--- a/packages/node-sdk/sync/src/sync-protocols/near/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/near/state.ts
@@ -11,6 +11,7 @@ import { getPage } from "@effectstream/db";
 import { NearClient } from "./NearClient.ts";
 import { applyDelay } from "../common/utils.ts";
 import { bufferAtCap } from "../common/page-helpers.ts";
+import { requestTimeoutOf } from "../common/http.ts";
 
 export class NearSyncState extends SyncState<
   Input,
@@ -134,7 +135,10 @@ export class NearSyncState extends SyncState<
       page,
       config,
       fetcher,
-      new NearClient(config.network.rpcUrl),
+      new NearClient(
+        config.network.rpcUrl,
+        requestTimeoutOf(config.syncProtocol),
+      ),
       dbConn,
     );
   }

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
@@ -4,6 +4,25 @@ import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import type { AllSyncProtocols, ISyncProtocol } from "../types.ts";
 import { tryYield } from "@effectstream/utils";
 
+/**
+ * Used when a protocol config carries no `pollingInterval`.
+ *
+ * Every polling protocol declares one via `PollingSyncProtocol`, so this should
+ * be unreachable — it exists because the cost of getting it wrong is not a slow
+ * loop but a dead node. A pass through this loop that neither fetches nor
+ * sleeps never yields to the macrotask queue, which starves the entire process:
+ * no timers, no HTTP server, no other chain's fetch loop, and (for streaming
+ * chains) none of the stream callbacks that would let this loop make progress.
+ * See `sync/test/poll-loop-spin.test.ts`.
+ */
+const FALLBACK_POLLING_INTERVAL_MS = 1_000;
+
+/** This protocol's polling interval, or the fallback above. */
+function pollingIntervalOf(config: { syncProtocol: unknown }): number {
+  const syncProtocol = config.syncProtocol as { pollingInterval?: number };
+  return syncProtocol?.pollingInterval ?? FALLBACK_POLLING_INTERVAL_MS;
+}
+
 export function* startSync(
   state: AllSyncProtocols,
 ): Operation<void> {
@@ -27,18 +46,14 @@ export function* startSync(
           SeverityNumber.ERROR,
           (log) => log(inputResult.error),
         );
-        const { config } = state.fetcher;
-        if ("pollingInterval" in config.syncProtocol) {
-          yield* sleep(config.syncProtocol.pollingInterval);
-        }
+        yield* sleep(pollingIntervalOf(state.fetcher.config));
         continue;
       }
       const input = inputResult.data;
-      const { config } = state.fetcher;
       if (input == null) {
-        if ("pollingInterval" in config.syncProtocol) {
-          yield* sleep(config.syncProtocol.pollingInterval);
-        }
+        // Caught up. This is the ordinary steady state, and the pass that must
+        // never skip its sleep — see FALLBACK_POLLING_INTERVAL_MS.
+        yield* sleep(pollingIntervalOf(state.fetcher.config));
         continue;
       }
 
@@ -52,9 +67,7 @@ export function* startSync(
           SeverityNumber.ERROR,
           (l) => l(result.error),
         );
-        if ("pollingInterval" in config.syncProtocol) {
-          yield* sleep(config.syncProtocol.pollingInterval);
-        }
+        yield* sleep(pollingIntervalOf(state.fetcher.config));
         continue;
       }
       state.consecutiveErrors = 0;

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
@@ -32,6 +32,10 @@ export function* startSync(
 ): Operation<void> {
   const iState: ISyncProtocol = state as ISyncProtocol;
 
+  // Resolve once and publish it, so `/health` and anything else reads the same
+  // value this loop paces itself with instead of re-deriving it.
+  state.pollingIntervalMs = pollingIntervalOf(state.fetcher.config);
+
   yield* spawn(function* () {
     if (!iState.hasAsyncProducer) {
       // Polled chain: startAsync is the base-class no-op. Run it once, as
@@ -48,11 +52,18 @@ export function* startSync(
     // both. See `sync/test/start-async-supervision.test.ts`.
     let attempt = 0;
     while (true) {
+      const startedAt = Date.now();
       const result = yield* tryYield(iState.startAsync());
+      const ranForMs = Date.now() - startedAt;
 
       if (result.error != null) {
-        state.consecutiveErrors++;
-        state.lastErrorTimestamp = Date.now();
+        // Producer failures are tracked separately from `consecutiveErrors`.
+        // That counter belongs to the fetch loop and is only cleared by a
+        // successful `readData`, so bumping it here left an idle streaming chain
+        // reporting `erroring` until its next block arrived — and conversely, a
+        // successful poll would erase the record of a flapping producer.
+        state.producerErrors++;
+        state.lastProducerErrorMs = Date.now();
         log.remote(
           ComponentNames.EFFECTSTREAM_SYNC,
           [...state.getNamespace(), "startAsync"],
@@ -72,6 +83,17 @@ export function* startSync(
       }
 
       state.producerRestarts++;
+
+      // De-escalate after a producer that clearly worked. Without this `attempt`
+      // only ever grows, so a stream that ran healthily for a day between
+      // incidents would still be waiting the 30s cap on its next restart —
+      // penalising a healthy chain for ancient history. (It also keeps
+      // `2 ** attempt` from reaching Infinity after ~1024 restarts, which
+      // `Math.min` currently absorbs silently.)
+      if (ranForMs >= PRODUCER_MAX_BACKOFF_MS) {
+        attempt = 0;
+      }
+
       const backoff = Math.min(
         PRODUCER_MIN_BACKOFF_MS * 2 ** attempt,
         PRODUCER_MAX_BACKOFF_MS,
@@ -99,14 +121,14 @@ export function* startSync(
           SeverityNumber.ERROR,
           (log) => log(inputResult.error),
         );
-        yield* sleep(pollingIntervalOf(state.fetcher.config));
+        yield* sleep(state.pollingIntervalMs);
         continue;
       }
       const input = inputResult.data;
       if (input == null) {
         // Caught up. This is the ordinary steady state, and the pass that must
         // never skip its sleep — see FALLBACK_POLLING_INTERVAL_MS.
-        yield* sleep(pollingIntervalOf(state.fetcher.config));
+        yield* sleep(state.pollingIntervalMs);
         continue;
       }
 
@@ -120,7 +142,7 @@ export function* startSync(
           SeverityNumber.ERROR,
           (l) => l(result.error),
         );
-        yield* sleep(pollingIntervalOf(state.fetcher.config));
+        yield* sleep(state.pollingIntervalMs);
         continue;
       }
       state.consecutiveErrors = 0;

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
@@ -84,6 +84,11 @@ export function* startSync(
   // spawn polling task
   yield* spawn(function* () {
     while (true) {
+      // Liveness heartbeat: stamped every pass regardless of outcome, so a
+      // stale value means the loop is wedged inside a call that never returns
+      // rather than merely idle. See SyncState.lastPollAtMs.
+      state.lastPollAtMs = Date.now();
+
       const inputResult = yield* tryYield(iState.stateToInput());
       if (inputResult.error != null) {
         state.consecutiveErrors++;

--- a/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/orchestration/sync.ts
@@ -23,14 +23,62 @@ function pollingIntervalOf(config: { syncProtocol: unknown }): number {
   return syncProtocol?.pollingInterval ?? FALLBACK_POLLING_INTERVAL_MS;
 }
 
+/** Backoff bounds for restarting a dead streaming producer. */
+const PRODUCER_MIN_BACKOFF_MS = 1_000;
+const PRODUCER_MAX_BACKOFF_MS = 30_000;
+
 export function* startSync(
   state: AllSyncProtocols,
 ): Operation<void> {
   const iState: ISyncProtocol = state as ISyncProtocol;
 
-  // spawn async task
   yield* spawn(function* () {
-    yield* iState.startAsync();
+    if (!iState.hasAsyncProducer) {
+      // Polled chain: startAsync is the base-class no-op. Run it once, as
+      // before — supervising it would mean restarting a no-op forever.
+      yield* iState.startAsync();
+      return;
+    }
+
+    // Streaming chain: all of this protocol's data arrives through the
+    // producer, so if it dies the chain goes silent and the merge blocks on its
+    // page forever. Both of its exit modes used to be unhandled — a throw tore
+    // down the enclosing scope (in production, `start()`, taking every other
+    // chain with it), and a clean return went entirely unnoticed. Supervise
+    // both. See `sync/test/start-async-supervision.test.ts`.
+    let attempt = 0;
+    while (true) {
+      const result = yield* tryYield(iState.startAsync());
+
+      if (result.error != null) {
+        state.consecutiveErrors++;
+        state.lastErrorTimestamp = Date.now();
+        log.remote(
+          ComponentNames.EFFECTSTREAM_SYNC,
+          [...state.getNamespace(), "startAsync"],
+          SeverityNumber.ERROR,
+          (l) => l(result.error),
+        );
+      } else {
+        // Returning is a failure for a producer: its stream ended. Treated the
+        // same as a throw, because the observable effect is identical — no
+        // more data.
+        log.remote(
+          ComponentNames.EFFECTSTREAM_SYNC,
+          [...state.getNamespace(), "startAsync"],
+          SeverityNumber.WARN,
+          (l) => l("producer returned: stream ended, restarting"),
+        );
+      }
+
+      state.producerRestarts++;
+      const backoff = Math.min(
+        PRODUCER_MIN_BACKOFF_MS * 2 ** attempt,
+        PRODUCER_MAX_BACKOFF_MS,
+      );
+      attempt++;
+      yield* sleep(backoff);
+    }
   });
 
   // spawn polling task

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/WatchMultiplexer.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/WatchMultiplexer.ts
@@ -31,6 +31,21 @@ export class WatchMultiplexer {
   private highestConfirmedHeight: number | undefined = undefined;
   private lowestIncompleteHeight: number = 0;
   private slotOriginTimestamp: bigint | undefined = undefined;
+  /**
+   * Incremented by every {@link start} call so events from a previous
+   * generation's streams can be identified and dropped.
+   *
+   * `start` can now be called more than once: `startSync` supervises the
+   * producer and restarts it when the stream dies. All multiplexer state lives
+   * on this instance, and the gRPC streams of the previous generation are not
+   * cancellable from here — a `Promise.all` rejection from ONE watcher aborts
+   * `start` while its siblings keep streaming. Without this guard a restart
+   * would run two live streams per predicate into the same `pendingBlocks`,
+   * pushing each matched tx twice. Duplicate primitives in a block mean
+   * duplicate scheduled STF inputs, i.e. non-deterministic state — the exact
+   * failure the whole pipeline is built to avoid.
+   */
+  private generation = 0;
 
   constructor(
     private readonly clientOptions: ClientBuilderOptions,
@@ -88,14 +103,39 @@ export class WatchMultiplexer {
       }
     }
 
+    const generation = ++this.generation;
+
+    // Drop half-assembled work from the previous generation. A block is only
+    // completed once EVERY watcher has passed it, so at the moment a stream
+    // died some heights had been seen by some watchers and not others. The new
+    // stream re-delivers those heights from the resume point, and merging the
+    // two views would double their txs. Heights below `lowestIncompleteHeight`
+    // are already completed and are never revisited, so this discards exactly
+    // the in-flight window.
+    if (generation > 1) {
+      for (const [, watcher] of this.watchers) {
+        for (const [height] of watcher.pendingBlocks) {
+          if (height >= this.lowestIncompleteHeight) {
+            watcher.pendingBlocks.delete(height);
+          }
+        }
+        watcher.highestSeenHeight = Math.max(
+          this.lowestIncompleteHeight - 1,
+          0,
+        );
+      }
+    }
+
     const intersect = point ? [point] : [];
     const promises: Promise<void>[] = [];
     for (const [key, watcher] of this.watchers) {
       const watchClient = new CardanoWatchClient(this.clientOptions);
-      promises.push(this.runWatcher(key, watcher, watchClient, intersect));
+      promises.push(this.runWatcher(key, watcher, watchClient, intersect, generation));
     }
 
-    console.log(`[WatchMultiplexer] Started ${this.watchers.size} watcher(s)`);
+    console.log(
+      `[WatchMultiplexer] Started ${this.watchers.size} watcher(s) (generation ${generation})`,
+    );
     await Promise.all(promises);
   }
 
@@ -104,9 +144,19 @@ export class WatchMultiplexer {
     watcher: WatcherState,
     watchClient: CardanoWatchClient,
     intersect: ChainPoint[],
+    generation: number,
   ): Promise<void> {
     const stream = watchClient.watchTxByPredicate(watcher.sdkPredicate, intersect);
     for await (const event of stream) {
+      // A superseded generation must contribute nothing. Breaking here also
+      // closes the underlying stream via the async iterator's return path,
+      // which is the only way to stop it from this side.
+      if (generation !== this.generation) {
+        console.warn(
+          `[WatchMultiplexer] Watcher "${key}" from generation ${generation} superseded by ${this.generation}; closing`,
+        );
+        return;
+      }
       this.handleEvent(key, watcher, event);
     }
     console.warn(`[WatchMultiplexer] Watcher "${key}" stream ended unexpectedly`);

--- a/packages/node-sdk/sync/src/sync-protocols/utxorpc/state.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/utxorpc/state.ts
@@ -35,6 +35,9 @@ export class UtxoRpcSyncState extends SyncState<
     );
   }
 
+  /** All utxorpc data arrives via the watch stream in {@link startAsync}. */
+  public override readonly hasAsyncProducer = true;
+
   @bound
   override *startAsync(): Operation<void> {
     if (this.lastPage == null) {

--- a/packages/node-sdk/sync/src/syncProtocolFactory.ts
+++ b/packages/node-sdk/sync/src/syncProtocolFactory.ts
@@ -33,6 +33,7 @@ import { NearFetcher } from "./sync-protocols/near/fetcher.ts";
 import { NearSyncState } from "./sync-protocols/near/state.ts";
 import { TestFetcher } from "./sync-protocols/test/fetcher.ts";
 import { TestSyncState } from "./sync-protocols/test/state.ts";
+import { requestTimeoutOf } from "./sync-protocols/common/http.ts";
 
 export function* genSyncProtocols(
   dbConn: PoolClient,
@@ -123,6 +124,7 @@ export function* genSyncProtocols(
         url: entry.network.rpcUrl,
         username: entry.network.rpcAuth?.username ?? null,
         password: entry.network.rpcAuth?.password ?? null,
+        requestTimeoutMs: requestTimeoutOf(entry.syncProtocol),
       });
       const fetcher = new BitcoinFetcher(entry, rpcClient);
       const state = yield* BitcoinSyncState.restoreState(

--- a/packages/node-sdk/sync/src/syncProtocolFactory.ts
+++ b/packages/node-sdk/sync/src/syncProtocolFactory.ts
@@ -57,6 +57,7 @@ export function* genSyncProtocols(
         entry,
         createViemPublicClient(viemNetwork, {
           cacheTime: entry.syncProtocol.pollingInterval,
+          timeout: requestTimeoutOf(entry.syncProtocol),
         }),
       );
       const state = yield* EvmSyncState.restoreState(

--- a/packages/node-sdk/sync/test/poll-loop-spin.test.ts
+++ b/packages/node-sdk/sync/test/poll-loop-spin.test.ts
@@ -1,27 +1,27 @@
 /**
- * Repro for sync/CLAUDE.md Finding #3 (unpaced fetch loop).
+ * Regression guard for sync/CLAUDE.md Finding #3 (unpaced fetch loop).
  *
- * `orchestration/sync.ts` guards all three of its `sleep`s with
- * `if ("pollingInterval" in config.syncProtocol)`. A protocol whose config
- * lacks that key therefore never sleeps — not on error, and not in the ordinary
- * "caught up" pass where `stateToInput` returns `undefined`.
+ * `orchestration/sync.ts` used to guard all three of its `sleep`s with
+ * `if ("pollingInterval" in config.syncProtocol)`, so a protocol whose config
+ * lacked that key never slept — not on error, and not in the ordinary "caught
+ * up" pass where `stateToInput` returns `undefined`.
  *
- * The Cardano/utxorpc schema is exactly that case: it is the only sync protocol
- * that does not merge `PollingSyncProtocol`, so `pollingInterval` is neither
- * declared, typed, nor defaulted (asserted below). Every config in this repo
- * happens to pass it anyway as an undeclared extra field — which is the only
- * reason Cardano sync works today. Build a config strictly from the schema and
- * the node freezes.
+ * The Cardano/utxorpc schema was exactly that case: the only sync protocol that
+ * did not merge `PollingSyncProtocol`. Every config in this repo happened to
+ * pass `pollingInterval` anyway as an undeclared extra field, which is the only
+ * reason Cardano sync worked at all; a config built strictly from the schema
+ * produced a node that froze.
  *
- * "Freezes", not "spins": the probe below shows the loop starves the event
- * loop outright — a `setTimeout` scheduled for 500 ms had still not fired after
- * 4 s of looping. Nothing else in the process runs: not the HTTP server, not
- * the other chains' fetch loops, and not the gRPC stream callbacks that would
- * advance utxorpc's own tip and let the loop make progress.
+ * "Froze", not "span": the probe showed the loop starving the event loop
+ * outright — a `setTimeout` scheduled for 500ms had still not fired after 4s of
+ * looping. Nothing else in the process runs in that state: not the HTTP server,
+ * not the other chains' fetch loops, and not the stream callbacks that would
+ * advance utxorpc's own tip and let the loop escape.
  *
- * When the fix lands (declare `pollingInterval` on the utxorpc schema and/or
- * make the sleep unconditional in `startSync`), the KNOWN-BROKEN test should
- * report `reason: "window"` like its paced counterpart.
+ * Fixed on both sides: the utxorpc schema now merges `PollingSyncProtocol`, and
+ * `startSync` sleeps unconditionally with a fallback interval so no protocol
+ * can hot-loop regardless of what its schema declares. Both halves are asserted
+ * below — the second is what makes the first non-load-bearing.
  */
 import { expect, test } from "bun:test";
 import { join } from "node:path";
@@ -67,17 +67,18 @@ async function runProbe(spec: {
   return JSON.parse(line) as ProbeResult;
 }
 
-test("root cause: the utxorpc schema does not declare pollingInterval", () => {
+test("every polling protocol declares pollingInterval, utxorpc included", () => {
   const utxorpc = schemaKeys(ConfigSyncProtocolSchemaCardanoUtxoRpcParallel);
   const evm = schemaKeys(ConfigSyncProtocolSchemaEvmParallel);
 
-  // The runtime fetch loop keys off this exact property name.
-  expect(utxorpc).not.toContain("pollingInterval");
-  // Every other polling protocol declares it — utxorpc is the outlier.
+  // The runtime fetch loop keys its sleeps off this exact property name.
+  expect(utxorpc).toContain("pollingInterval");
   expect(evm).toContain("pollingInterval");
+  // Merged in from PollingSyncProtocol along with it.
+  expect(utxorpc).toContain("requestTimeoutMs");
 });
 
-test("CONTROL: with a pollingInterval the fetch loop is paced", async () => {
+test("with a pollingInterval the fetch loop is paced", async () => {
   const result = await runProbe({
     polling: 20,
     limit: 200_000,
@@ -92,21 +93,20 @@ test("CONTROL: with a pollingInterval the fetch loop is paced", async () => {
   expect(result.iterations).toBeLessThan(200);
 }, 30_000);
 
-test("KNOWN-BROKEN: without a pollingInterval the fetch loop starves the event loop", async () => {
-  const WINDOW_MS = 500;
+test("without a pollingInterval the fetch loop still paces itself", async () => {
+  const WINDOW_MS = 1_500;
   const result = await runProbe({
     polling: null,
     limit: 200_000,
-    // Same window as the control. If the loop were merely "fast" this timer
-    // would still fire; it does not.
+    // Comfortably longer than one FALLBACK_POLLING_INTERVAL_MS (1s) so the
+    // paced loop gets at least one pass in before the window closes.
     windowMs: WINDOW_MS,
     mode: "call",
   });
 
-  // The loop burned through the iteration cap instead of ever yielding to the
-  // timer — the discriminator between "spins hot" and "starves everything".
-  expect(result.reason).toBe("limit");
-  expect(result.iterations).toBe(200_000);
-  // The 500ms timer never ran despite the process being busy for far longer.
-  expect(result.elapsedMs).toBeGreaterThan(WINDOW_MS);
+  // Before the fix this reported `reason: "limit"` with 200k iterations and a
+  // 500ms timer that never fired at all.
+  expect(result.reason).toBe("window");
+  // One pass per fallback interval — single digits over this window.
+  expect(result.iterations).toBeLessThan(10);
 }, 30_000);

--- a/packages/node-sdk/sync/test/poll-loop-spin.test.ts
+++ b/packages/node-sdk/sync/test/poll-loop-spin.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Repro for sync/CLAUDE.md Finding #3 (unpaced fetch loop).
+ *
+ * `orchestration/sync.ts` guards all three of its `sleep`s with
+ * `if ("pollingInterval" in config.syncProtocol)`. A protocol whose config
+ * lacks that key therefore never sleeps — not on error, and not in the ordinary
+ * "caught up" pass where `stateToInput` returns `undefined`.
+ *
+ * The Cardano/utxorpc schema is exactly that case: it is the only sync protocol
+ * that does not merge `PollingSyncProtocol`, so `pollingInterval` is neither
+ * declared, typed, nor defaulted (asserted below). Every config in this repo
+ * happens to pass it anyway as an undeclared extra field — which is the only
+ * reason Cardano sync works today. Build a config strictly from the schema and
+ * the node freezes.
+ *
+ * "Freezes", not "spins": the probe below shows the loop starves the event
+ * loop outright — a `setTimeout` scheduled for 500 ms had still not fired after
+ * 4 s of looping. Nothing else in the process runs: not the HTTP server, not
+ * the other chains' fetch loops, and not the gRPC stream callbacks that would
+ * advance utxorpc's own tip and let the loop make progress.
+ *
+ * When the fix lands (declare `pollingInterval` on the utxorpc schema and/or
+ * make the sleep unconditional in `startSync`), the KNOWN-BROKEN test should
+ * report `reason: "window"` like its paced counterpart.
+ */
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+  ConfigSyncProtocolSchemaCardanoUtxoRpcParallel,
+  ConfigSyncProtocolSchemaEvmParallel,
+} from "@effectstream/config";
+
+const PROBE = join(import.meta.dir, "spin-probe.ts");
+
+/** Every property a protocol config may carry, required + optional. */
+function schemaKeys(schema: unknown): string[] {
+  const config = (schema as { config: { required: any; optional: any } }).config;
+  return [
+    ...Object.keys(config.required.properties ?? {}),
+    ...Object.keys(config.optional.properties ?? {}),
+  ];
+}
+
+type ProbeResult = {
+  reason: "limit" | "window";
+  iterations: number;
+  elapsedMs: number;
+};
+
+async function runProbe(spec: {
+  polling: number | null;
+  limit: number;
+  windowMs: number;
+  mode: "sync" | "call";
+}): Promise<ProbeResult> {
+  const proc = Bun.spawn(["bun", PROBE, JSON.stringify(spec)], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  const line = stdout.trim().split("\n").filter(Boolean).at(-1);
+  if (!line) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`probe produced no result\n${stderr}`);
+  }
+  return JSON.parse(line) as ProbeResult;
+}
+
+test("root cause: the utxorpc schema does not declare pollingInterval", () => {
+  const utxorpc = schemaKeys(ConfigSyncProtocolSchemaCardanoUtxoRpcParallel);
+  const evm = schemaKeys(ConfigSyncProtocolSchemaEvmParallel);
+
+  // The runtime fetch loop keys off this exact property name.
+  expect(utxorpc).not.toContain("pollingInterval");
+  // Every other polling protocol declares it — utxorpc is the outlier.
+  expect(evm).toContain("pollingInterval");
+});
+
+test("CONTROL: with a pollingInterval the fetch loop is paced", async () => {
+  const result = await runProbe({
+    polling: 20,
+    limit: 200_000,
+    windowMs: 500,
+    mode: "call",
+  });
+
+  // The window timer fired, so the event loop stayed responsive.
+  expect(result.reason).toBe("window");
+  // ~500ms / 20ms ≈ 25 passes. Generous bound; the point is it's tens, not tens
+  // of thousands.
+  expect(result.iterations).toBeLessThan(200);
+}, 30_000);
+
+test("KNOWN-BROKEN: without a pollingInterval the fetch loop starves the event loop", async () => {
+  const WINDOW_MS = 500;
+  const result = await runProbe({
+    polling: null,
+    limit: 200_000,
+    // Same window as the control. If the loop were merely "fast" this timer
+    // would still fire; it does not.
+    windowMs: WINDOW_MS,
+    mode: "call",
+  });
+
+  // The loop burned through the iteration cap instead of ever yielding to the
+  // timer — the discriminator between "spins hot" and "starves everything".
+  expect(result.reason).toBe("limit");
+  expect(result.iterations).toBe(200_000);
+  // The 500ms timer never ran despite the process being busy for far longer.
+  expect(result.elapsedMs).toBeGreaterThan(WINDOW_MS);
+}, 30_000);

--- a/packages/node-sdk/sync/test/rpc-timeout.test.ts
+++ b/packages/node-sdk/sync/test/rpc-timeout.test.ts
@@ -13,12 +13,15 @@
  * 0, `lastSuccessfulFetchMs` freezes, and the merge blocks on that chain's page
  * forever. The node stops producing blocks and reports nothing.
  *
- * These tests document CURRENT behaviour:
- *   - Bitcoin / NEAR / Avail  → hang forever            (the bug)
- *   - Midnight                → rejects after its timeout (the desired shape)
+ * Every client now bounds a single request with `AbortSignal.timeout` via
+ * `sync-protocols/common/http.ts:fetchWithTimeout`, configured per protocol by
+ * the optional `requestTimeoutMs` schema field. Retry is deliberately left to
+ * the fetch loop, which already re-runs the same page range and counts the
+ * failure in `consecutiveErrors` — retrying inside the client would hide the
+ * error from the health endpoint.
  *
- * When the fix lands, flip the three `expect(...).toBe("pending")` assertions
- * to `"rejected"` and drop the `KNOWN-BROKEN` markers.
+ * These tests are the permanent regression guard: each client must REJECT
+ * against a blackhole, never hang.
  */
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import net from "node:net";
@@ -80,45 +83,44 @@ async function settlementWithin(
   return winner === pending ? "pending" : outcome;
 }
 
-test("KNOWN-BROKEN: Bitcoin RPC hangs forever on a blackholed endpoint", async () => {
+test("Bitcoin RPC rejects on a blackholed endpoint", async () => {
   const client = new BitcoinRpcClient({
     url: `http://127.0.0.1:${port}`,
     username: null,
     password: null,
+    requestTimeoutMs: CLIENT_TIMEOUT_MS,
   });
 
   const settlement = await settlementWithin(client.getBlockCount(), OBSERVE_MS);
 
-  // BitcoinRpcClient.call() uses bare `fetch` with no AbortSignal
-  // (bitcoin/fetcher.ts). Nothing bounds this call.
-  expect(settlement).toBe("pending");
+  expect(settlement).toBe("rejected");
 }, OBSERVE_MS + 5_000);
 
-test("KNOWN-BROKEN: NEAR RPC hangs forever on a blackholed endpoint", async () => {
-  const client = new NearClient(`http://127.0.0.1:${port}`);
+test("NEAR RPC rejects on a blackholed endpoint", async () => {
+  const client = new NearClient(`http://127.0.0.1:${port}`, CLIENT_TIMEOUT_MS);
 
   const settlement = await settlementWithin(
     client.getBlock({ finality: "final" }),
     OBSERVE_MS,
   );
 
-  // NearClient.rpc() uses bare `fetch` with no AbortSignal (near/NearClient.ts).
-  expect(settlement).toBe("pending");
+  expect(settlement).toBe("rejected");
 }, OBSERVE_MS + 5_000);
 
-test("KNOWN-BROKEN: Avail light-client HTTP hangs forever on a blackholed endpoint", async () => {
+test("Avail light-client HTTP rejects on a blackholed endpoint", async () => {
   // Built without the constructor on purpose: `new AvailClient(...)` eagerly
   // calls `SDK.New(nodeUrl)`, whose websocket provider keeps reconnect timers
   // alive and would outlive the test process. `getStatus()` only touches the
   // light-client HTTP url, which is the code path under test.
   const client: AvailClient = Object.create(AvailClient.prototype);
-  Object.assign(client, { url: `http://127.0.0.1:${port}` });
+  Object.assign(client, {
+    url: `http://127.0.0.1:${port}`,
+    requestTimeoutMs: CLIENT_TIMEOUT_MS,
+  });
 
   const settlement = await settlementWithin(client.getStatus(), OBSERVE_MS);
 
-  // AvailClient.getStatus() uses bare `fetch` with no AbortSignal
-  // (avail/AvailClient.ts).
-  expect(settlement).toBe("pending");
+  expect(settlement).toBe("rejected");
 }, OBSERVE_MS + 5_000);
 
 test("CONTROL: Midnight rejects on a blackholed endpoint (has a request timeout)", async () => {

--- a/packages/node-sdk/sync/test/rpc-timeout.test.ts
+++ b/packages/node-sdk/sync/test/rpc-timeout.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Repro for sync/CLAUDE.md Finding #4 (missing RPC timeouts).
+ *
+ * Every per-chain client is pointed at a **blackhole**: a TCP server that
+ * completes the handshake and then never writes a byte. This is the realistic
+ * production failure (a load balancer that drops the backend, a half-open
+ * socket after a NAT rebind) — and the one plain `fetch` cannot see, because
+ * `fetch` has no default timeout in Bun/Node. The connection is *up*, so there
+ * is no ECONNREFUSED, no DNS error, nothing to catch.
+ *
+ * Consequence in production: `readData` never returns, so the fetch loop in
+ * `orchestration/sync.ts` never reaches its `catch` → `consecutiveErrors` stays
+ * 0, `lastSuccessfulFetchMs` freezes, and the merge blocks on that chain's page
+ * forever. The node stops producing blocks and reports nothing.
+ *
+ * These tests document CURRENT behaviour:
+ *   - Bitcoin / NEAR / Avail  → hang forever            (the bug)
+ *   - Midnight                → rejects after its timeout (the desired shape)
+ *
+ * When the fix lands, flip the three `expect(...).toBe("pending")` assertions
+ * to `"rejected"` and drop the `KNOWN-BROKEN` markers.
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import net from "node:net";
+import { BitcoinRpcClient } from "../src/sync-protocols/bitcoin/fetcher.ts";
+import { NearClient } from "../src/sync-protocols/near/NearClient.ts";
+import { AvailClient } from "../src/sync-protocols/avail/AvailClient.ts";
+import { MidnightClient } from "../src/sync-protocols/midnight/MidnightClient.ts";
+
+/** How long we watch a call before declaring it hung. */
+const OBSERVE_MS = 1_500;
+/** Timeout handed to clients that support one, kept well under OBSERVE_MS. */
+const CLIENT_TIMEOUT_MS = 300;
+
+let server: net.Server;
+let port: number;
+/** Held so the accepted sockets aren't garbage-collected mid-test. */
+const openSockets: net.Socket[] = [];
+
+beforeAll(async () => {
+  server = net.createServer((socket) => {
+    // Accept and go silent: the client sees a healthy connection and waits
+    // for a response that never comes.
+    openSockets.push(socket);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as net.AddressInfo).port;
+});
+
+afterAll(async () => {
+  for (const socket of openSockets) socket.destroy();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+type Settlement = "pending" | "resolved" | "rejected";
+
+/**
+ * Watch `p` for `ms` and report whether it settled. The promise is left with a
+ * no-op catch attached so a late rejection (after the test ends) can't surface
+ * as an unhandled rejection and fail an unrelated test.
+ */
+async function settlementWithin(
+  p: Promise<unknown>,
+  ms: number,
+): Promise<Settlement> {
+  const pending = Symbol("pending");
+  let outcome: Settlement = "pending";
+  const tracked = p.then(
+    () => {
+      outcome = "resolved";
+    },
+    () => {
+      outcome = "rejected";
+    },
+  );
+  const winner = await Promise.race([
+    tracked.then(() => "settled" as const),
+    new Promise<typeof pending>((resolve) => setTimeout(() => resolve(pending), ms)),
+  ]);
+  return winner === pending ? "pending" : outcome;
+}
+
+test("KNOWN-BROKEN: Bitcoin RPC hangs forever on a blackholed endpoint", async () => {
+  const client = new BitcoinRpcClient({
+    url: `http://127.0.0.1:${port}`,
+    username: null,
+    password: null,
+  });
+
+  const settlement = await settlementWithin(client.getBlockCount(), OBSERVE_MS);
+
+  // BitcoinRpcClient.call() uses bare `fetch` with no AbortSignal
+  // (bitcoin/fetcher.ts). Nothing bounds this call.
+  expect(settlement).toBe("pending");
+}, OBSERVE_MS + 5_000);
+
+test("KNOWN-BROKEN: NEAR RPC hangs forever on a blackholed endpoint", async () => {
+  const client = new NearClient(`http://127.0.0.1:${port}`);
+
+  const settlement = await settlementWithin(
+    client.getBlock({ finality: "final" }),
+    OBSERVE_MS,
+  );
+
+  // NearClient.rpc() uses bare `fetch` with no AbortSignal (near/NearClient.ts).
+  expect(settlement).toBe("pending");
+}, OBSERVE_MS + 5_000);
+
+test("KNOWN-BROKEN: Avail light-client HTTP hangs forever on a blackholed endpoint", async () => {
+  // Built without the constructor on purpose: `new AvailClient(...)` eagerly
+  // calls `SDK.New(nodeUrl)`, whose websocket provider keeps reconnect timers
+  // alive and would outlive the test process. `getStatus()` only touches the
+  // light-client HTTP url, which is the code path under test.
+  const client: AvailClient = Object.create(AvailClient.prototype);
+  Object.assign(client, { url: `http://127.0.0.1:${port}` });
+
+  const settlement = await settlementWithin(client.getStatus(), OBSERVE_MS);
+
+  // AvailClient.getStatus() uses bare `fetch` with no AbortSignal
+  // (avail/AvailClient.ts).
+  expect(settlement).toBe("pending");
+}, OBSERVE_MS + 5_000);
+
+test("CONTROL: Midnight rejects on a blackholed endpoint (has a request timeout)", async () => {
+  const client = new MidnightClient(
+    `http://127.0.0.1:${port}`,
+    undefined,
+    CLIENT_TIMEOUT_MS,
+  );
+
+  const settlement = await settlementWithin(
+    client.gqlQuery("query { __typename }"),
+    OBSERVE_MS,
+  );
+
+  // MidnightClient.gqlQuery() passes AbortSignal.timeout(requestTimeoutMs).
+  // This is the shape the three clients above are missing.
+  expect(settlement).toBe("rejected");
+}, OBSERVE_MS + 5_000);

--- a/packages/node-sdk/sync/test/spin-probe.ts
+++ b/packages/node-sdk/sync/test/spin-probe.ts
@@ -1,0 +1,102 @@
+/**
+ * Child process for `poll-loop-spin.test.ts` (sync/CLAUDE.md Finding #3).
+ *
+ * Drives the REAL `startSync` fetch loop with a fake `SyncState` that is always
+ * "caught up" (`stateToInput` → `undefined`) — the steady state of any protocol
+ * whose tip advances slowly. The only variable is whether the protocol config
+ * carries a `pollingInterval`, because `orchestration/sync.ts` guards all three
+ * of its `sleep`s with `if ("pollingInterval" in config.syncProtocol)`.
+ *
+ * Runs in its own process because a loop with no sleep can starve the event
+ * loop outright, which would hang the test runner rather than fail it. The two
+ * exit paths below discriminate the outcomes:
+ *
+ *   - `reason: "limit"`  — the loop reached `limit` iterations. Reported via
+ *                          `writeSync` + `process.exit`, which work even when
+ *                          the event loop is starved.
+ *   - `reason: "window"` — a `setTimeout` fired first, so the loop is paced and
+ *                          the event loop is healthy.
+ *
+ * Usage: bun spin-probe.ts '{"polling":20,"limit":50000,"windowMs":500,"mode":"call"}'
+ */
+import { writeSync } from "node:fs";
+import { call, type Operation, run } from "effection";
+import { startSync } from "../src/sync-protocols/orchestration/sync.ts";
+
+type ProbeSpec = {
+  /** `pollingInterval` for the fake protocol config; `null` omits the key entirely. */
+  polling: number | null;
+  /** Iteration count at which we declare the loop unpaced and bail out. */
+  limit: number;
+  /** Wall-clock budget; if this timer fires, the loop is paced. */
+  windowMs: number;
+  /**
+   * How `stateToInput` returns:
+   *  - "sync" — returns `undefined` with no suspension at all (worst case).
+   *  - "call" — `yield* call(() => <sync value>)` first, mirroring utxorpc's
+   *             `stateToInput`, which calls the in-memory `fetcher.lastHeight()`
+   *             before deciding it is caught up. This is the production shape.
+   */
+  mode: "sync" | "call";
+};
+
+const spec: ProbeSpec = JSON.parse(process.argv[2]);
+
+const startedAt = Date.now();
+let iterations = 0;
+
+function report(reason: "limit" | "window"): never {
+  writeSync(
+    1,
+    JSON.stringify({
+      reason,
+      iterations,
+      elapsedMs: Date.now() - startedAt,
+    }) + "\n",
+  );
+  process.exit(0);
+}
+
+// Fires only if the loop leaves room for macrotasks.
+setTimeout(() => report("window"), spec.windowMs);
+
+const syncProtocol: Record<string, unknown> = { name: "probe" };
+if (spec.polling != null) syncProtocol.pollingInterval = spec.polling;
+
+/**
+ * Minimal stand-in for a `SyncState`. Only the members `startSync` actually
+ * touches are implemented; it is cast at the call site the same way the real
+ * states are (`startSync` takes `AllSyncProtocols` and narrows to `ISyncProtocol`).
+ */
+const fakeState = {
+  name: "probe",
+  consecutiveErrors: 0,
+  lastErrorTimestamp: 0,
+  lastSuccessfulFetchMs: 0,
+  getNamespace: () => ["probe", "probe"],
+  *startAsync(): Operation<void> {},
+  *stateToInput(): Operation<undefined> {
+    iterations++;
+    if (iterations >= spec.limit) report("limit");
+    if (spec.mode === "call") {
+      // utxorpc reads an in-memory tip here — a `call` over a synchronous value.
+      yield* call(() => 0);
+    }
+    // "caught up": nothing to fetch this pass.
+    return undefined;
+  },
+  fetcher: {
+    config: { syncProtocol },
+    producerChannel: { *send(): Operation<void> {} },
+    *readData(): Operation<never> {
+      throw new Error("unreachable: stateToInput always returns undefined");
+    },
+  },
+  *updateState(): Operation<void> {},
+};
+
+await run(function* () {
+  yield* startSync(fakeState as never);
+  // Park forever; one of the two exit paths above ends the process.
+  yield* call(() => new Promise<void>(() => {}));
+});

--- a/packages/node-sdk/sync/test/start-async-supervision.test.ts
+++ b/packages/node-sdk/sync/test/start-async-supervision.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Repro for sync/CLAUDE.md Finding #5 (unsupervised `startAsync`).
+ *
+ * `orchestration/sync.ts` starts the streaming producer with a bare
+ * `yield* spawn(function* () { yield* iState.startAsync(); })`. There is no
+ * try/catch, no restart, and no liveness check. Streaming chains (utxorpc today,
+ * midnight if it moves to subscriptions) put ALL of their data on that path, so
+ * its two exit modes are both unhandled:
+ *
+ *   5a — the stream ENDS CLEANLY. `WatchMultiplexer.runWatcher` logs
+ *        "stream ended unexpectedly" and returns; `start()` resolves; the spawned
+ *        task completes normally. The chain now receives nothing, forever, while
+ *        the polling loop keeps running and every health counter stays clean.
+ *        The merge then blocks on that chain's page and the node stops producing
+ *        blocks — with nothing anywhere reporting an error.
+ *
+ *   5b — the stream THROWS. The error escapes the spawned task and tears down the
+ *        enclosing scope, which in production is `start()` — i.e. one flaky gRPC
+ *        connection takes the whole node down, including every unrelated chain.
+ *
+ * Both tests document CURRENT behaviour. After the fix (supervise + restart with
+ * backoff, and treat a returned producer as a failure), 5a should show the
+ * producer restarted and 5b should show the sibling loop still running.
+ */
+import { expect, test } from "bun:test";
+import { type Operation, run, sleep } from "effection";
+import { startSync } from "../src/sync-protocols/orchestration/sync.ts";
+
+const POLL_MS = 20;
+
+/**
+ * Minimal stand-in for a streaming `SyncState`. Only the members `startSync`
+ * touches are implemented. `stateToInput` always reports "caught up", which is
+ * what a streaming chain does while it waits for its producer to deliver.
+ */
+function makeStreamingState(startAsyncBody: () => Operation<void>) {
+  const counters = { startAsyncCalls: 0, pollPasses: 0 };
+  const state = {
+    name: "streamer",
+    consecutiveErrors: 0,
+    lastErrorTimestamp: 0,
+    lastSuccessfulFetchMs: 0,
+    getNamespace: () => ["streamer", "streamer"],
+    *startAsync(): Operation<void> {
+      counters.startAsyncCalls++;
+      yield* startAsyncBody();
+    },
+    *stateToInput(): Operation<undefined> {
+      counters.pollPasses++;
+      return undefined;
+    },
+    fetcher: {
+      config: { syncProtocol: { name: "streamer", pollingInterval: POLL_MS } },
+      producerChannel: { *send(): Operation<void> {} },
+      *readData(): Operation<never> {
+        throw new Error("unreachable: stateToInput always returns undefined");
+      },
+    },
+    *updateState(): Operation<void> {},
+  };
+  return { state, counters };
+}
+
+test("KNOWN-BROKEN 5a: a producer that ends cleanly is never restarted and reports nothing", async () => {
+  // The multiplexer's `for await (const event of stream)` falling through —
+  // the stream closed and `runWatcher` returned.
+  const { state, counters } = makeStreamingState(function* () {
+    // returns immediately
+  });
+
+  await run(function* () {
+    yield* startSync(state as never);
+    yield* sleep(300);
+  });
+
+  // The producer ran once and was never restarted...
+  expect(counters.startAsyncCalls).toBe(1);
+  // ...the polling loop carried on, oblivious...
+  expect(counters.pollPasses).toBeGreaterThan(1);
+  // ...and not one health counter moved. This is the silent stall: from the
+  // outside the protocol looks perfectly healthy while it is receiving nothing.
+  expect(state.consecutiveErrors).toBe(0);
+  expect(state.lastErrorTimestamp).toBe(0);
+}, 30_000);
+
+test("KNOWN-BROKEN 5b: a producer that throws tears down the whole scope", async () => {
+  const { state, counters } = makeStreamingState(function* () {
+    yield* sleep(50);
+    throw new Error("gRPC stream died");
+  });
+
+  let rejection: unknown;
+  await run(function* () {
+    yield* startSync(state as never);
+    yield* sleep(300);
+  }).catch((err) => {
+    rejection = err;
+  });
+
+  // The error escaped the spawned task and killed the enclosing scope. In
+  // production that scope is `start()` — every other chain dies with it.
+  expect(rejection).toBeInstanceOf(Error);
+  expect(String(rejection)).toContain("gRPC stream died");
+
+  // And the sibling polling loop is gone: its counter is frozen from here on.
+  const passesAtCrash = counters.pollPasses;
+  await new Promise((resolve) => setTimeout(resolve, 5 * POLL_MS));
+  expect(counters.pollPasses).toBe(passesAtCrash);
+}, 30_000);

--- a/packages/node-sdk/sync/test/start-async-supervision.test.ts
+++ b/packages/node-sdk/sync/test/start-async-supervision.test.ts
@@ -1,26 +1,28 @@
 /**
- * Repro for sync/CLAUDE.md Finding #5 (unsupervised `startAsync`).
+ * Regression guard for sync/CLAUDE.md Finding #5 (unsupervised `startAsync`).
  *
- * `orchestration/sync.ts` starts the streaming producer with a bare
- * `yield* spawn(function* () { yield* iState.startAsync(); })`. There is no
- * try/catch, no restart, and no liveness check. Streaming chains (utxorpc today,
- * midnight if it moves to subscriptions) put ALL of their data on that path, so
- * its two exit modes are both unhandled:
+ * `orchestration/sync.ts` used to start the streaming producer with a bare
+ * `yield* spawn(function* () { yield* iState.startAsync(); })` — no try/catch,
+ * no restart, no liveness check. Streaming chains (utxorpc today, midnight if
+ * it moves to subscriptions) put ALL of their data on that path, so both of its
+ * exit modes were unhandled:
  *
  *   5a — the stream ENDS CLEANLY. `WatchMultiplexer.runWatcher` logs
- *        "stream ended unexpectedly" and returns; `start()` resolves; the spawned
- *        task completes normally. The chain now receives nothing, forever, while
- *        the polling loop keeps running and every health counter stays clean.
- *        The merge then blocks on that chain's page and the node stops producing
- *        blocks — with nothing anywhere reporting an error.
+ *        "stream ended unexpectedly" and returns; the spawned task completed
+ *        normally. The chain then received nothing forever while every health
+ *        counter stayed clean, and the merge blocked on its page — a total stall
+ *        with nothing reporting an error.
  *
- *   5b — the stream THROWS. The error escapes the spawned task and tears down the
- *        enclosing scope, which in production is `start()` — i.e. one flaky gRPC
- *        connection takes the whole node down, including every unrelated chain.
+ *   5b — the stream THROWS. The error escaped the spawned task and tore down the
+ *        enclosing scope, which in production is `start()`: one flaky gRPC
+ *        connection took down every unrelated chain with it.
  *
- * Both tests document CURRENT behaviour. After the fix (supervise + restart with
- * backoff, and treat a returned producer as a failure), 5a should show the
- * producer restarted and 5b should show the sibling loop still running.
+ * Now supervised — both modes are treated as failure and restarted with capped
+ * exponential backoff, counted in `producerRestarts`. A returning producer
+ * counts as failure because the observable effect is identical: no more data.
+ *
+ * Supervision is gated on `hasAsyncProducer` so polled chains, whose
+ * `startAsync` is the base-class no-op, are still run exactly once (5c).
  */
 import { expect, test } from "bun:test";
 import { type Operation, run, sleep } from "effection";
@@ -33,13 +35,18 @@ const POLL_MS = 20;
  * touches are implemented. `stateToInput` always reports "caught up", which is
  * what a streaming chain does while it waits for its producer to deliver.
  */
-function makeStreamingState(startAsyncBody: () => Operation<void>) {
+function makeStreamingState(
+  startAsyncBody: () => Operation<void>,
+  hasAsyncProducer = true,
+) {
   const counters = { startAsyncCalls: 0, pollPasses: 0 };
   const state = {
     name: "streamer",
     consecutiveErrors: 0,
     lastErrorTimestamp: 0,
     lastSuccessfulFetchMs: 0,
+    hasAsyncProducer,
+    producerRestarts: 0,
     getNamespace: () => ["streamer", "streamer"],
     *startAsync(): Operation<void> {
       counters.startAsyncCalls++;
@@ -61,7 +68,7 @@ function makeStreamingState(startAsyncBody: () => Operation<void>) {
   return { state, counters };
 }
 
-test("KNOWN-BROKEN 5a: a producer that ends cleanly is never restarted and reports nothing", async () => {
+test("5a: a producer that ends cleanly is restarted and counted", async () => {
   // The multiplexer's `for await (const event of stream)` falling through —
   // the stream closed and `runWatcher` returned.
   const { state, counters } = makeStreamingState(function* () {
@@ -70,20 +77,19 @@ test("KNOWN-BROKEN 5a: a producer that ends cleanly is never restarted and repor
 
   await run(function* () {
     yield* startSync(state as never);
-    yield* sleep(300);
+    // Long enough for the first restart (1s backoff) plus room to spare.
+    yield* sleep(1_500);
   });
 
-  // The producer ran once and was never restarted...
-  expect(counters.startAsyncCalls).toBe(1);
-  // ...the polling loop carried on, oblivious...
+  // Restarted rather than abandoned...
+  expect(counters.startAsyncCalls).toBeGreaterThan(1);
+  // ...and the restart is visible to health instead of being silent.
+  expect(state.producerRestarts).toBeGreaterThan(0);
+  // The sibling polling loop is unaffected.
   expect(counters.pollPasses).toBeGreaterThan(1);
-  // ...and not one health counter moved. This is the silent stall: from the
-  // outside the protocol looks perfectly healthy while it is receiving nothing.
-  expect(state.consecutiveErrors).toBe(0);
-  expect(state.lastErrorTimestamp).toBe(0);
 }, 30_000);
 
-test("KNOWN-BROKEN 5b: a producer that throws tears down the whole scope", async () => {
+test("5b: a producer that throws is restarted and does not kill the scope", async () => {
   const { state, counters } = makeStreamingState(function* () {
     yield* sleep(50);
     throw new Error("gRPC stream died");
@@ -92,18 +98,32 @@ test("KNOWN-BROKEN 5b: a producer that throws tears down the whole scope", async
   let rejection: unknown;
   await run(function* () {
     yield* startSync(state as never);
-    yield* sleep(300);
+    yield* sleep(1_500);
   }).catch((err) => {
     rejection = err;
   });
 
-  // The error escaped the spawned task and killed the enclosing scope. In
-  // production that scope is `start()` — every other chain dies with it.
-  expect(rejection).toBeInstanceOf(Error);
-  expect(String(rejection)).toContain("gRPC stream died");
+  // The scope survived: no error escaped to tear down `start()`.
+  expect(rejection).toBeUndefined();
+  // The throw was caught, counted as an error, and the producer restarted.
+  expect(counters.startAsyncCalls).toBeGreaterThan(1);
+  expect(state.producerRestarts).toBeGreaterThan(0);
+  expect(state.consecutiveErrors).toBeGreaterThan(0);
+  expect(state.lastErrorTimestamp).toBeGreaterThan(0);
+  // And the sibling polling loop kept running throughout.
+  expect(counters.pollPasses).toBeGreaterThan(1);
+}, 30_000);
 
-  // And the sibling polling loop is gone: its counter is frozen from here on.
-  const passesAtCrash = counters.pollPasses;
-  await new Promise((resolve) => setTimeout(resolve, 5 * POLL_MS));
-  expect(counters.pollPasses).toBe(passesAtCrash);
+test("5c: a polled chain's no-op producer is run once, not supervised", async () => {
+  const { state, counters } = makeStreamingState(function* () {}, false);
+
+  await run(function* () {
+    yield* startSync(state as never);
+    yield* sleep(1_500);
+  });
+
+  // Without this gate, every polled chain would "restart" its no-op forever.
+  expect(counters.startAsyncCalls).toBe(1);
+  expect(state.producerRestarts).toBe(0);
+  expect(counters.pollPasses).toBeGreaterThan(1);
 }, 30_000);

--- a/packages/node-sdk/sync/test/start-async-supervision.test.ts
+++ b/packages/node-sdk/sync/test/start-async-supervision.test.ts
@@ -47,6 +47,9 @@ function makeStreamingState(
     lastSuccessfulFetchMs: 0,
     hasAsyncProducer,
     producerRestarts: 0,
+    producerErrors: 0,
+    lastProducerErrorMs: 0,
+    pollingIntervalMs: POLL_MS,
     getNamespace: () => ["streamer", "streamer"],
     *startAsync(): Operation<void> {
       counters.startAsyncCalls++;
@@ -85,6 +88,8 @@ test("5a: a producer that ends cleanly is restarted and counted", async () => {
   expect(counters.startAsyncCalls).toBeGreaterThan(1);
   // ...and the restart is visible to health instead of being silent.
   expect(state.producerRestarts).toBeGreaterThan(0);
+  // A clean return is not an *error*, so only the restart counter moves.
+  expect(state.producerErrors).toBe(0);
   // The sibling polling loop is unaffected.
   expect(counters.pollPasses).toBeGreaterThan(1);
 }, 30_000);
@@ -105,11 +110,16 @@ test("5b: a producer that throws is restarted and does not kill the scope", asyn
 
   // The scope survived: no error escaped to tear down `start()`.
   expect(rejection).toBeUndefined();
-  // The throw was caught, counted as an error, and the producer restarted.
+  // The throw was caught, counted, and the producer restarted.
   expect(counters.startAsyncCalls).toBeGreaterThan(1);
   expect(state.producerRestarts).toBeGreaterThan(0);
-  expect(state.consecutiveErrors).toBeGreaterThan(0);
-  expect(state.lastErrorTimestamp).toBeGreaterThan(0);
+  expect(state.producerErrors).toBeGreaterThan(0);
+  expect(state.lastProducerErrorMs).toBeGreaterThan(0);
+  // Counted on the PRODUCER's own tally, not the fetch loop's. Sharing
+  // `consecutiveErrors` conflated two signals: only a successful `readData`
+  // clears it, so an idle streaming chain stayed `erroring` long after its
+  // producer recovered, and a successful poll erased the record of a flap.
+  expect(state.consecutiveErrors).toBe(0);
   // And the sibling polling loop kept running throughout.
   expect(counters.pollPasses).toBeGreaterThan(1);
 }, 30_000);


### PR DESCRIPTION
## What

Hardens the sync service against **external** failures — unreachable RPCs and
dead streams. The internal failure paths were already solid (transient-pg retry,
block-accurate resume, backpressure); the external ones were uneven, and their
dominant failure mode was *hang*, not *error*, which the existing error handling
could not see.

Every fix here landed only after a test proved the bug first. Those repros are
kept as permanent regression guards.

> **Reorg detection was split out into #813**, stacked on this branch. It
> was by far the most complex piece (new migration, new table, incident
> reporting) and deserves its own review.

## Why

All three of these end identically in production: the merge blocks on one
chain's page, block production stops, and **nothing reports a problem** — the
database stays perfectly healthy, so `/health` kept answering
`200 {"status":"ok"}`.

| # | Issue | Before |
|---|---|---|
| 1 | No RPC timeout on Bitcoin / NEAR / Avail | `readData` hangs forever; `consecutiveErrors` stays 0 |
| 2 | utxorpc had no `pollingInterval` | fetch loop starves the entire event loop |
| 3 | `startAsync` unsupervised | clean stream end = silent permanent stall; a throw kills the node |
| 4 | `/health` reported only DB reachability | all of the above invisible |

## Notable findings

**Cardano was one config field away from freezing.** The utxorpc schema was the
only sync protocol not merging `PollingSyncProtocol`, so `pollingInterval` was
undeclared, untyped and undefaulted — while the fetch loop keys its pacing off
exactly that property name. It works today only because every config in the repo
passes it anyway as an undeclared extra field. Built strictly from the schema,
the node froze: 200k loop iterations in ~4s while a 500ms `setTimeout` never
fired once. Not a slow node — a dead one, with no HTTP server, no other chain's
fetch loop, and (for a streaming chain) none of the callbacks that would let it
escape.

**A producer that returns cleanly was the worst failure found.**
`WatchMultiplexer.runWatcher` logs "stream ended unexpectedly" and returns; the
spawned task then completed *normally*. The chain received nothing forever while
every health counter stayed clean.

**`lastSuccessfulFetchMs` cannot detect a hang.** A caught-up chain never calls
`readData`, so its last-successful-fetch time is indistinguishable from that of a
chain wedged inside a request that will never return. `/health` keys off a new
`lastPollAtMs` heartbeat instead — the loop still cycles in the first case and
does not in the second.

## Testing

```bash
bun run e2e/sync-repro/run-tests.ts --docker
```

26 tests green (11 runtime reproductions + 15 sync-service). A new lightweight
`Dockerfile.sync-repro` gives the suite its own network namespace, so it can run
while other suites hold the PGLite gateway / API ports. It deliberately does not
reuse `.github/Dockerfile` (foundry + compact + solc + Playwright) — this suite
starts no chains and uses in-process PGLite.

## New config

| Field / env | Default | Purpose |
|---|---|---|
| `requestTimeoutMs` (per protocol) | 15s | bounds one RPC request |
| `pollingInterval` on utxorpc | — | now declared like every other protocol |

## Behaviour changes to review

- **`/health` can now return 503** — for `db-unreachable`, `stalled`, or
  `starting`. A chain erroring while blocks still flow is `degraded` + 200, so an
  orchestrator does not kill a node that is recovering on its own. Anything
  probing `/health` for liveness should be checked against this.
- **`pollingInterval` is now required on utxorpc configs.** Every config in this
  repo already passes it, so this is a no-op in practice — but it fails loudly at
  validation instead of freezing at runtime.

## Not included (pre-existing, flagged separately)

- `migrations/assets.ts` is stale: the bundled copy of `system-up-v-0.0.0` still
  contains `CREATE EXTENSION IF NOT EXISTS pg_ivm`, removed from the source in
  5d12bbcc. Migrations load from the bundle, so fresh databases still run it.
- `db-emulator` imports `@effectstream/sm` without declaring it, so its tests
  cannot load.

Both verified present at `d665de80`, before any of this work.

## Test status

`bun test ./packages` has 4 failures, all pre-existing and unrelated: 2
pool-error-tracker tests that pass in isolation and fail on cross-test
interference, plus the db-emulator import error. Verified not mine by swapping in
the base version of the one db file this branch touches — they persist unchanged.
