### PR TITLE
fix(binaries): force arch@3 so arm64 assets are actually selectable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1098,6 +1098,7 @@
   "overrides": {
     "@effect/platform": "0.96.1",
     "@midnight-ntwrk/ledger-v8": "8.0.3",
+    "arch": "3.0.0",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
@@ -2518,7 +2519,7 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
-    "arch": ["arch@2.2.0", "", {}, "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="],
+    "arch": ["arch@3.0.0", "", {}, "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q=="],
 
     "archive-type": ["archive-type@4.0.0", "", { "dependencies": { "file-type": "^4.2.0" } }, "sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA=="],
 
@@ -4485,8 +4486,6 @@
     "@xhmikosr/decompress-unzip/yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
 
     "@xhmikosr/downloader/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
-
-    "@xhmikosr/os-filter-obj/arch": ["arch@3.0.0", "", {}, "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q=="],
 
     "algosdk/js-sha3": ["js-sha3@0.8.0", "", {}, "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "overrides": {
     "@effect/platform": "0.96.1",
-    "@midnight-ntwrk/ledger-v8": "8.0.3"
+    "@midnight-ntwrk/ledger-v8": "8.0.3",
+    "arch": "3.0.0"
   },
   "devDependencies": {
     "@effectstream/db": "workspace:*",

--- a/packages/binaries/bitcoin-core/index.js
+++ b/packages/binaries/bitcoin-core/index.js
@@ -1,7 +1,7 @@
 import BinWrapper from '@xhmikosr/bin-wrapper';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 
@@ -37,8 +37,45 @@ port=18334
 fallbackfee=0.00001
 `;
 
+/**
+ * Apple Silicon refuses to exec an arm64 Mach-O that carries no code signature
+ * at all — the process is SIGKILLed before `main`, with no diagnostic beyond
+ * exit 137. bitcoin.org ships `bitcoin-*-arm64-apple-darwin.tar.gz` unsigned
+ * (`codesign -dv` → "code object is not signed at all"), so an ad-hoc signature
+ * has to be applied locally before first use. Every other binary in
+ * packages/binaries/ already ships signed; this is bitcoin-core only.
+ *
+ * Not a security downgrade: an ad-hoc signature asserts nothing about origin,
+ * it just satisfies the kernel's exec requirement. The x86_64 build is equally
+ * unsigned and runs only because Rosetta is exempt from the rule.
+ */
+function adhocSignIfNeeded(binaryPath) {
+  if (process.platform !== 'darwin' || process.arch !== 'arm64') return;
+  try {
+    const check = spawnSync('codesign', ['-dv', binaryPath], { encoding: 'utf8' });
+    // "not signed at all" appears on stderr; anything already signed is left alone.
+    if (!/not signed at all/.test(check.stderr ?? '')) return;
+    const res = spawnSync('codesign', ['-s', '-', '-f', binaryPath], { encoding: 'utf8' });
+    if (res.status !== 0) {
+      console.warn(
+        `[bitcoin-core] ad-hoc signing failed (${res.stderr?.trim()}); ` +
+        `bitcoind will likely be killed on launch.`,
+      );
+    }
+  } catch (error) {
+    console.warn(`[bitcoin-core] could not ad-hoc sign bitcoind: ${error.message}`);
+  }
+}
+
 export async function run(options = {}) {
   const { config, dataDir, verbose = false } = options;
+
+  // Download first, sign second, THEN let bin.run() exec it — `bin.run()` alone
+  // would try to execute the unsigned binary and be killed.
+  if (!fs.existsSync(bin.path())) {
+    await bin.download();
+  }
+  adhocSignIfNeeded(bin.path());
 
   await bin.run(['--version']);
 


### PR DESCRIPTION
`bin-wrapper@5` filters download candidates through `os-filter-obj@2` → `arch@^2`, and **`arch@2.x` has no concept of `arm64`** — the string does not appear anywhere in its source:

```
$ grep -c "arm64" arch@2.2.0/index.js
0
```

Every return path yields `'x64'` or `'x86'`. `darwin` is hardcoded to `'x64'` (it predates Apple Silicon); `linux` shells out to `getconf LONG_BIT`, which reports *word size*, not ISA, so arm64 Linux also answers `'x64'`.

**Consequence: every `.src(..., 'arm64')` entry in `packages/binaries/` has been unreachable dead code.** x86_64 Linux resolves correctly, which is why CI (`ubuntu-22.04`) has never surfaced it.

## Measured on Apple Silicon

| Package | Before | After |
|---|---|---|
| bitcoin-core | `x86_64-apple-darwin` | `arm64-apple-darwin` |
| celestia (appd) | `macos-amd64` | `macos-arm64` |
| celestia (node) | `macos-amd64` | `macos-arm64` |
| ord | `x86_64-apple-darwin` | `aarch64-apple-darwin` |
| near-sandbox | **NO MATCH — `download()` threw** | `Darwin-arm64` |
| grafana-alloy / loki | already correct | unchanged |

`near-sandbox` was the worst case: it builds its URL from `process.arch` and passes that as the filter key, so on Apple Silicon it declared `darwin/arm64` while `arch()` said `x64` — nothing matched and the download failed outright with *"No binary found matching your system."* Its source already carried a comment diagnosing this ("misreports arm64 as x64 under Bun"); the workaround fixed the URL but not the filter key.

The grafana pair escapes because `bin-wrapper@13` depends on `@xhmikosr/os-filter-obj@3` → `arch@^3.0.0`.

## Verification

Every affected package was downloaded from a clean `vendor/`, checked with `file`, and **executed** on an M-series Mac:

```
bitcoind          Mach-O 64-bit executable arm64
ord               Mach-O 64-bit executable arm64   ord 0.23.3
near-sandbox      Mach-O 64-bit executable arm64   neard (release 2.10.7)
celestia-appd     Mach-O 64-bit executable arm64   6.4.10
celestia          Mach-O 64-bit executable arm64   0.28.4
```

All six declared darwin/arm64 asset URLs return HTTP 200, so nothing regresses to a missing-asset error on macOS.

## bitcoin-core needed a second fix

Switching to the arm64 build initially **broke** it: `exit 137` — SIGKILL before `main`, no diagnostic.

Apple Silicon refuses to exec an arm64 Mach-O carrying no code signature at all, and bitcoin.org ships its arm64 build unsigned (`codesign -dv` → *"code object is not signed at all"*). The x86_64 build is *equally* unsigned but runs anyway, because Rosetta is exempt from that rule. So bitcoin-core was the one case where the "wrong" binary was the only working one — which is why this is a two-part change rather than a one-line override.

`run()` now applies an ad-hoc signature (`codesign -s - -f`) after download and before first exec, guarded to darwin/arm64 and skipped when a signature already exists. That asserts nothing about provenance; it only satisfies the kernel's exec requirement. Verified from a clean `vendor/`: downloads → signs → boots.

## Known limitation (not a regression)

celestia, ord and solana-node declare no linux/arm64 asset. On arm64 Linux they now fail at download instead of fetching an x86_64 Linux binary that could never exec there — a clearer failure, not a new one. `.github/Dockerfile` has no `--platform` pin, so this is reachable via `docker build` on an Apple Silicon host.

## CI

`bun install --frozen-lockfile` passes against the updated lockfile. CI runs x86_64 Linux, where selection is unchanged, so the e2e suites should be unaffected — this PR exists to prove that.
