### PR TITLE
ci: bump actions/checkout to v7 (Node20 runner deprecation)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
       templates: ${{ steps.classify.outputs.templates }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Build testing image
         run: docker build -t testing_image:${{ github.sha }} -f .github/Dockerfile .
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Build testing image
         run: docker build -t testing_image:${{ github.sha }} -f .github/Dockerfile .
@@ -93,7 +93,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout v-next
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: v-next
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

GitHub is [deprecating Node20 on the Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Since **June 16, 2026** the runners default to Node24, and the back-compat path that still force-runs older JS actions on Node20 is removed later this fall.

## What changed

Five `actions/checkout` pins, across the only two workflow files in the repo:

| Location | Before | Runtime | After |
|---|---|---|---|
| `main.yaml:21` (`changes`) | `@v4` | node20 | `@v7` |
| `main.yaml:50` (`e2e`) | `@v3` | **node16** | `@v7` |
| `main.yaml:68` (`template-tests`) | `@v3` | **node16** | `@v7` |
| `main.yaml:96` (`frontend-build`) | `@v4` | node20 | `@v7` |
| `release.yaml:20` (`publish`) | `@v4` | node20 | `@v7` |

The two `e2e` / `template-tests` steps were on **node16**, not node20 — already two deprecation cycles behind.

`oven-sh/setup-bun@v2` already declares `using: "node24"` in its `action.yml`, so it needed no change. A repo-wide grep confirms these two files contain every `uses:` line; there are no nested `.github/` directories under `templates/` or `packages/`.

## Why v7 and not v5

`checkout` is node24 from v5 onward, but v7.0.1 is current. v7's only behavioural change — blocking fork-PR checkout for `pull_request_target` and `workflow_run` — does not apply, since these workflows trigger on `push` and `release` only.

## Reviewer note

checkout **v6** moved persisted git credentials into a separate config file included via `includeIf`. `release.yaml` checks out with a `token` and then runs `git push origin v-next` at the end of the publish job, which depends on those credentials. The same-workspace case is exactly what that mechanism supports, so this should be fine — but that path only runs on a real GitHub Release, so it is **not** exercised by the push-triggered CI on this branch. Worth a glance from someone who knows the release flow.

Also note: checkout v5+ requires runner v2.327.1 or newer. GitHub-hosted `ubuntu-22.04` is well past that; it would only matter if self-hosted runners get added.