### PR TITLE
feat(solana): add the SOLANA:TokenAccount primitive (closes #815 gap 6)

### DIFF
--- a/.claude/skills/create-effectstream-app/references/chains/solana.md
+++ b/.claude/skills/create-effectstream-app/references/chains/solana.md
@@ -36,6 +36,7 @@ Sync protocol: `SOLANA_RPC_PARALLEL`. Polls slot by slot; **skipped slots are no
 |---|---|---|
 | `PrimitiveTypeSolanaProgramLog` | `programId` (+ optional `eventType` substring) | `{ programId, slot, logMessages }` |
 | `PrimitiveTypeSolanaAccountBalance` | `address` | `{ address, lamports, slot }` |
+| `PrimitiveTypeSolanaTokenAccount` | at least one of `mint` / `owner` / `tokenAccount` (+ optional `tokenProgramId`) | `{ tokenAccount, mint, owner, amount, decimals, slot }` |
 
 Program-log attribution keys off the log stream's `invoke`/`success` framing, not `accountKeys` — a program merely referenced as an account is not treated as invoked, and only its own log lines are forwarded. Reverted transactions are skipped.
 

--- a/bun.lock
+++ b/bun.lock
@@ -445,6 +445,7 @@
         "@effectstream/sm": "workspace:*",
         "@effectstream/utils": "workspace:*",
         "@sinclair/typebox": "^0.34.30",
+        "@solana/spl-token": "^0.4.9",
         "@solana/web3.js": "^1.95.0",
         "bs58": "^6.0.0",
         "effection": "^3.5.0",
@@ -509,7 +510,7 @@
     },
     "packages/batcher": {
       "name": "@effectstream/batcher-sdk",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/event-client": "workspace:*",
@@ -554,7 +555,7 @@
     },
     "packages/binaries/avail-light-client": {
       "name": "@effectstream/npm-avail-light-client",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-avail-light-client": "index.js",
       },
@@ -565,7 +566,7 @@
     },
     "packages/binaries/avail-node": {
       "name": "@effectstream/npm-avail-node",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-avail-node": "index.js",
       },
@@ -576,7 +577,7 @@
     },
     "packages/binaries/bitcoin-core": {
       "name": "@effectstream/bitcoin-core",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "bitcoin-core": "./index.js",
       },
@@ -586,7 +587,7 @@
     },
     "packages/binaries/celestia": {
       "name": "@effectstream/celestia",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "celestia": "./index.js",
       },
@@ -596,7 +597,7 @@
     },
     "packages/binaries/grafana-alloy": {
       "name": "@effectstream/grafana-alloy",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "grafana-alloy": "index.js",
       },
@@ -606,7 +607,7 @@
     },
     "packages/binaries/grafana-loki": {
       "name": "@effectstream/grafana-loki",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "grafana-loki": "index.js",
       },
@@ -616,7 +617,7 @@
     },
     "packages/binaries/midnight-indexer": {
       "name": "@effectstream/npm-midnight-indexer",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-midnight-indexer": "index.js",
       },
@@ -629,7 +630,7 @@
     },
     "packages/binaries/midnight-node": {
       "name": "@effectstream/npm-midnight-node",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-midnight-node": "index.js",
       },
@@ -641,7 +642,7 @@
     },
     "packages/binaries/midnight-proof-server": {
       "name": "@effectstream/npm-midnight-proof-server",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-midnight-proof-server": "index.js",
       },
@@ -652,7 +653,7 @@
     },
     "packages/binaries/near-sandbox": {
       "name": "@effectstream/near-sandbox",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "near-sandbox": "./index.js",
       },
@@ -662,7 +663,7 @@
     },
     "packages/binaries/ord": {
       "name": "@effectstream/ord",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "ord": "./index.js",
       },
@@ -672,7 +673,7 @@
     },
     "packages/binaries/solana-node": {
       "name": "@effectstream/solana-node",
-      "version": "0.100.18",
+      "version": "0.102.0",
       "bin": {
         "solana-node": "./index.js",
       },
@@ -707,7 +708,7 @@
     },
     "packages/build-tools/orchestrator": {
       "name": "@effectstream/orchestrator",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "orchestrator": "src/cli.ts",
       },
@@ -717,11 +718,11 @@
     },
     "packages/chains/avail-contracts": {
       "name": "@effectstream/avail-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
     },
     "packages/chains/bitcoin-contracts": {
       "name": "@effectstream/bitcoin-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "bitcoinjs-lib": "^7.0.0",
         "ecpair": "^3.0.0",
@@ -730,11 +731,11 @@
     },
     "packages/chains/cardano-contracts": {
       "name": "@effectstream/cardano-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
     },
     "packages/chains/evm-contracts": {
       "name": "@effectstream/evm-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@nomicfoundation/hardhat-ignition": "3.0.2",
         "@nomicfoundation/hardhat-ignition-viem": "3.0.2",
@@ -749,7 +750,7 @@
     },
     "packages/chains/evm-hardhat": {
       "name": "@effectstream/evm-hardhat",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -767,7 +768,7 @@
     },
     "packages/chains/midnight-contracts": {
       "name": "@effectstream/midnight-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@midnight-ntwrk/compact-js": "2.5.1",
@@ -796,14 +797,14 @@
     },
     "packages/effectstream-sdk/chain-types": {
       "name": "@effectstream/chain-types",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/concise": {
       "name": "@effectstream/concise",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -814,7 +815,7 @@
     },
     "packages/effectstream-sdk/config": {
       "name": "@effectstream/config",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@dcspark/carp-client": "^3.3.0",
         "@dcspark/cip34-js": "3.0.1",
@@ -831,7 +832,7 @@
     },
     "packages/effectstream-sdk/coroutine": {
       "name": "@effectstream/coroutine",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@pgtyped/parser": "2.4.2",
@@ -843,7 +844,7 @@
     },
     "packages/effectstream-sdk/crypto": {
       "name": "@effectstream/crypto",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
         "@effectstream/utils": "workspace:*",
@@ -872,7 +873,7 @@
     },
     "packages/effectstream-sdk/events": {
       "name": "@effectstream/event-client",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -886,7 +887,7 @@
     },
     "packages/effectstream-sdk/log": {
       "name": "@effectstream/log",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
@@ -908,14 +909,14 @@
     },
     "packages/effectstream-sdk/precompile": {
       "name": "@effectstream/precompile",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/utils": {
       "name": "@effectstream/utils",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@foxglove/crc": "^1.0.1",
@@ -936,7 +937,7 @@
     },
     "packages/effectstream-sdk/wallets": {
       "name": "@effectstream/wallets",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@aurowallet/mina-provider": "^1.0.12",
         "@effectstream/concise": "workspace:*",
@@ -995,14 +996,14 @@
     },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/wallets": "workspace:*",
       },
     },
     "packages/node-sdk/db": {
       "name": "@effectstream/db",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/coroutine": "workspace:*",
         "@effectstream/log": "workspace:*",
@@ -1025,7 +1026,7 @@
     },
     "packages/node-sdk/db-emulator": {
       "name": "@effectstream/db-emulator",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@pgtyped/runtime": "2.4.2",
         "effection": "^3.5.0",
@@ -1034,7 +1035,7 @@
     },
     "packages/node-sdk/events": {
       "name": "@effectstream/event-server",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -1042,7 +1043,7 @@
     },
     "packages/node-sdk/node": {
       "name": "@effectstream/node-sdk",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/chain-types": "workspace:*",
         "@effectstream/concise": "workspace:*",
@@ -1060,7 +1061,7 @@
     },
     "packages/node-sdk/runtime": {
       "name": "@effectstream/runtime",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1092,7 +1093,7 @@
     },
     "packages/node-sdk/sm": {
       "name": "@effectstream/sm",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1113,7 +1114,7 @@
     },
     "packages/node-sdk/sync": {
       "name": "@effectstream/sync",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@cardano-sdk/core": "^0.46.11",
         "@cardano-sdk/util": "^0.17.1",
@@ -2198,15 +2199,17 @@
 
     "@solana/buffer-layout": ["@solana/buffer-layout@4.0.1", "", { "dependencies": { "buffer": "~6.0.3" } }, "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA=="],
 
-    "@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+    "@solana/buffer-layout-utils": ["@solana/buffer-layout-utils@0.3.0", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/web3.js": "^1.32.0", "bigint-buffer": "^1.1.5", "bignumber.js": "^9.0.1" } }, "sha512-MuQOCC1j0np1xH9yAv0ZWWfwvr7Bt7Sz4LId11Wi4wDdAmJ+lobE+vHg/mZmGcihF0BIkqVBNxGmlv8QE5DrtA=="],
+
+    "@solana/codecs": ["@solana/codecs@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-data-structures": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/codecs-strings": "2.0.0-rc.1", "@solana/options": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ=="],
 
     "@solana/codecs-core": ["@solana/codecs-core@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw=="],
 
-    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog=="],
 
     "@solana/codecs-numbers": ["@solana/codecs-numbers@2.3.0", "", { "dependencies": { "@solana/codecs-core": "2.3.0", "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg=="],
 
-    "@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+    "@solana/codecs-strings": ["@solana/codecs-strings@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5" } }, "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g=="],
 
     "@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
 
@@ -2226,7 +2229,7 @@
 
     "@solana/offchain-messages": ["@solana/offchain-messages@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw=="],
 
-    "@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+    "@solana/options": ["@solana/options@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/codecs-data-structures": "2.0.0-rc.1", "@solana/codecs-numbers": "2.0.0-rc.1", "@solana/codecs-strings": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA=="],
 
     "@solana/plugin-core": ["@solana/plugin-core@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A=="],
 
@@ -2259,6 +2262,12 @@
     "@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
 
     "@solana/signers": ["@solana/signers@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/offchain-messages": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ=="],
+
+    "@solana/spl-token": ["@solana/spl-token@0.4.15", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.3.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-3Lof3mNov8NVQ3PalIWb1Jgr/TZ6lYM+/sexv2TLqdhNFVth2OfWmH3d7QucgMjSbokkjNiNlRr6I8Fd269uaw=="],
+
+    "@solana/spl-token-group": ["@solana/spl-token-group@0.0.7", "", { "dependencies": { "@solana/codecs": "2.0.0-rc.1" }, "peerDependencies": { "@solana/web3.js": "^1.95.3" } }, "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug=="],
+
+    "@solana/spl-token-metadata": ["@solana/spl-token-metadata@0.1.6", "", { "dependencies": { "@solana/codecs": "2.0.0-rc.1" }, "peerDependencies": { "@solana/web3.js": "^1.95.3" } }, "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA=="],
 
     "@solana/subscribable": ["@solana/subscribable@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ=="],
 
@@ -2642,6 +2651,8 @@
 
     "big.js": ["big.js@6.2.2", "", {}, "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="],
 
+    "bigint-buffer": ["bigint-buffer@1.1.5", "", { "dependencies": { "bindings": "^1.3.0" } }, "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA=="],
+
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "bin-check": ["bin-check@4.1.0", "", { "dependencies": { "execa": "^0.7.0", "executable": "^4.1.0" } }, "sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA=="],
@@ -2651,6 +2662,8 @@
     "bin-version-check": ["bin-version-check@5.1.0", "", { "dependencies": { "bin-version": "^6.0.0", "semver": "^7.5.3", "semver-truncate": "^3.0.0" } }, "sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "bip174": ["bip174@2.1.1", "", {}, "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ=="],
 
@@ -3028,6 +3041,8 @@
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
+    "fastestsmallesttextencoderdecoder": ["fastestsmallesttextencoderdecoder@1.0.22", "", {}, "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="],
+
     "fastify": ["fastify@5.8.5", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q=="],
 
     "fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
@@ -3045,6 +3060,8 @@
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "file-type": ["file-type@12.4.2", "", {}, "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
 
@@ -4432,29 +4449,33 @@
 
     "@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
+    "@solana/accounts/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
     "@solana/accounts/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/addresses/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
     "@solana/addresses/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/assertions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
 
-    "@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
 
-    "@solana/codecs-data-structures/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/codecs-data-structures/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
 
-    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
 
-    "@solana/codecs-data-structures/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/codecs-data-structures/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
-    "@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
 
-    "@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
 
-    "@solana/codecs-strings/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/codecs-strings/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
     "@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -4468,27 +4489,37 @@
 
     "@solana/keys/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
+    "@solana/keys/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
     "@solana/keys/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/kit/@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
 
     "@solana/kit/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/offchain-messages/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
+    "@solana/offchain-messages/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
     "@solana/offchain-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/offchain-messages/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
     "@solana/offchain-messages/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
-    "@solana/options/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+    "@solana/options/@solana/codecs-core": ["@solana/codecs-core@2.0.0-rc.1", "", { "dependencies": { "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ=="],
 
-    "@solana/options/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+    "@solana/options/@solana/codecs-numbers": ["@solana/codecs-numbers@2.0.0-rc.1", "", { "dependencies": { "@solana/codecs-core": "2.0.0-rc.1", "@solana/errors": "2.0.0-rc.1" }, "peerDependencies": { "typescript": ">=5" } }, "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ=="],
 
-    "@solana/options/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/options/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
     "@solana/programs/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/rpc/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/rpc-api/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
     "@solana/rpc-api/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
@@ -4510,6 +4541,8 @@
 
     "@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
+    "@solana/rpc-types/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
     "@solana/rpc-types/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/signers/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
@@ -4518,11 +4551,17 @@
 
     "@solana/subscribable/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
+    "@solana/sysvars/@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+
     "@solana/sysvars/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/transaction-confirmation/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
     "@solana/transaction-confirmation/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
     "@solana/transaction-messages/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/transaction-messages/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
 
     "@solana/transaction-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
@@ -4530,7 +4569,11 @@
 
     "@solana/transactions/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
+    "@solana/transactions/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
     "@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/transactions/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
     "@solana/transactions/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
 
@@ -5204,9 +5247,13 @@
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
+    "@solana/accounts/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
     "@solana/accounts/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@solana/accounts/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/addresses/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
     "@solana/addresses/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -5218,15 +5265,15 @@
 
     "@solana/codecs-data-structures/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/codecs-data-structures/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/codecs-data-structures/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "@solana/codecs-strings/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/codecs-strings/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/codecs-strings/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
-    "@solana/codecs/@solana/codecs-core/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/codecs/@solana/codecs-core/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
-    "@solana/codecs/@solana/codecs-numbers/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors": ["@solana/errors@2.0.0-rc.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.1.0" }, "peerDependencies": { "typescript": ">=5" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ=="],
 
     "@solana/instruction-plans/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -5236,9 +5283,21 @@
 
     "@solana/instructions/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/keys/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
     "@solana/keys/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@solana/keys/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/kit/@solana/codecs/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/kit/@solana/codecs/@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
 
     "@solana/kit/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -5250,11 +5309,13 @@
 
     "@solana/options/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/options/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/options/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "@solana/programs/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@solana/programs/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-api/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
     "@solana/rpc-api/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -5300,9 +5361,23 @@
 
     "@solana/subscribable/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "@solana/sysvars/@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+
     "@solana/sysvars/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@solana/sysvars/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/transaction-confirmation/@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/transaction-confirmation/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
 
     "@solana/transaction-confirmation/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -5634,11 +5709,11 @@
 
     "@solana/codecs/@solana/codecs-core/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/codecs/@solana/codecs-core/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/codecs/@solana/codecs-core/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "@solana/codecs/@solana/codecs-numbers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@solana/codecs/@solana/codecs-numbers/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "@walletconnect/browser-utils/@walletconnect/window-metadata/@walletconnect/window-getters/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/docs/site/docs/home/100-components/118-primitives.md
+++ b/docs/site/docs/home/100-components/118-primitives.md
@@ -72,6 +72,7 @@ A primitive that maintains a table for you **still triggers your state machine**
 | **`PrimitiveTypeNEARAccountWatch`** | NEAR | Monitors all transactions targeting a specific NEAR account. |
 | **`PrimitiveTypeSolanaProgramLog`** | Solana | Captures the log lines a watched program emitted, scoped by the `invoke`/`success` framing so only genuine invocations fire. |
 | **`PrimitiveTypeSolanaAccountBalance`** | Solana | Tracks a watched address's lamport balance from each transaction's `postBalances`, resolving lookup-table addresses. |
+| **`PrimitiveTypeSolanaTokenAccount`** | Solana | Tracks an SPL token balance from each transaction's `postTokenBalances`, filtered by mint, owner and/or token account. |
 
 ## Custom Primitives
 

--- a/docs/site/docs/home/200-chains/211-solana.md
+++ b/docs/site/docs/home/200-chains/211-solana.md
@@ -45,12 +45,13 @@ Block ordering uses `blockTime`, which Solana guarantees is monotonically non-de
 
 ### Primitives
 
-Two built-in primitives cover the Solana surface.
+Three built-in primitives cover the Solana surface.
 
 ```ts
 import {
   PrimitiveTypeSolanaProgramLog,
   PrimitiveTypeSolanaAccountBalance,
+  PrimitiveTypeSolanaTokenAccount,
 } from "@effectstream/sm/builtin";
 ```
 
@@ -108,8 +109,40 @@ Tracks a watched address's lamport balance as of each transaction that touches i
 
 Payload: `{ address, lamports, slot }`. Lookup-table addresses are resolved, so an address pulled in via an ALT is still matched.
 
+#### Token Account (`PrimitiveTypeSolanaTokenAccount`)
+
+Tracks an SPL token balance as of each transaction that touches it, read from the transaction's `meta.postTokenBalances`.
+
+```ts
+.buildPrimitives(builder =>
+  builder.addPrimitive(
+    (sp) => sp.parallelSolanaRPC,
+    () => ({
+      name: "PlayerTokens",
+      type: PrimitiveTypeSolanaTokenAccount,
+      startBlockHeight: 0,
+      mint: "2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1",
+      owner: "J2xccRtuG43drESLYznHhLhQkLTdfepcKYbiQ9BsJVaf",
+      stateMachinePrefix: "solana-token-account",
+    }),
+  )
+)
+```
+
+Payload: `{ tokenAccount, mint, owner, amount, decimals, slot }`.
+
+At least one of `mint`, `owner` or `tokenAccount` is required — without a filter the primitive would match every token balance on chain, so the constructor rejects it. Combine them to narrow further. `tokenProgramId` optionally pins the primitive to classic SPL Token or to Token-2022; omit it to accept both.
+
+`amount` is the raw u64 in base units, carried as a **string**. A u64 does not survive a JavaScript number, and at the top of its range it also exceeds PostgreSQL's signed `BIGINT` — store it as `TEXT` and pair it with `decimals` to render a display value.
+
+Balance records carry an `accountIndex` into the same resolved account list as `postBalances`, so a token account reached through an address lookup table is matched correctly here too.
+
+:::caution Closing a token account produces no event
+This reports post-state balances only, matching Account Balance. A token account that is **closed** appears in `preTokenBalances` and is absent from `postTokenBalances`, so closure emits nothing rather than a zero balance. If your state machine needs to observe accounts going away, track it from the owning program's logs instead.
+:::
+
 :::note Reverted transactions are skipped
-Neither primitive emits for a transaction whose `meta.err` is set. A failed transaction's logs describe work that was rolled back and its `postBalances` are the pre-state, so neither is a fact about chain state.
+No primitive emits for a transaction whose `meta.err` is set. A failed transaction's logs describe work that was rolled back and its `postBalances` are the pre-state, so neither is a fact about chain state.
 :::
 
 ## 2. Batcher (Write)

--- a/e2e/solana/config.ts
+++ b/e2e/solana/config.ts
@@ -6,6 +6,7 @@ import {
 import {
   PrimitiveTypeSolanaAccountBalance,
   PrimitiveTypeSolanaProgramLog,
+  PrimitiveTypeSolanaTokenAccount,
 } from "@effectstream/sm/builtin";
 import {
   EVENT_PREFIX,
@@ -19,6 +20,29 @@ import {
  */
 export const WATCHED_BALANCE_ADDRESS =
   "GmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB";
+
+/**
+ * The SPL mint the TokenAccount primitive watches, and the wallet that holds it.
+ *
+ * A static config cannot name a mint generated at runtime, so both are derived from
+ * fixed seeds the same way WATCHED_BALANCE_ADDRESS is:
+ *   mint  = Keypair.fromSeed(Uint8Array(32).fill(8))
+ *   owner = Keypair.fromSeed(Uint8Array(32).fill(9))
+ * `token-account.test.ts` recreates the same keypairs and asserts these match, so a
+ * changed seed fails loudly instead of silently watching the wrong mint.
+ *
+ * Localnet only, and they hold nothing but worthless test SOL — but the seeds are
+ * public, so never reuse them anywhere real.
+ */
+export const WATCHED_MINT = "2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1";
+export const WATCHED_TOKEN_OWNER =
+  "J2xccRtuG43drESLYznHhLhQkLTdfepcKYbiQ9BsJVaf";
+/** Associated token account for (WATCHED_TOKEN_OWNER, WATCHED_MINT). */
+export const WATCHED_TOKEN_ACCOUNT =
+  "8taZEqZDH5zq6hbgwFdBhbNpHNVvCzgKJi4LtnrRDNhR";
+/** Decimals the mint is created with, and the amount minted to the owner. */
+export const WATCHED_MINT_DECIMALS = 6;
+export const MINTED_AMOUNT = "2500000";
 
 export const config = new ConfigBuilder()
   .setNamespace(
@@ -102,6 +126,20 @@ export const config = new ConfigBuilder()
           programId: TEST_EVENT_PROGRAM_ID,
           eventType: EVENT_PREFIX,
           stateMachinePrefix: "solana-program-log",
+        }),
+      )
+      // Watch the SPL token balance of one wallet's ATA for one mint. Narrowed by
+      // both mint and owner so an unrelated token account for the same mint (the
+      // mint authority's own, say) does not land in the same table.
+      .addPrimitive(
+        (syncProtocols) => (syncProtocols as any).parallelSolanaRPC,
+        (network, deployments, syncProtocol) => ({
+          name: "SolanaTokenAccount",
+          type: PrimitiveTypeSolanaTokenAccount,
+          startBlockHeight: 0,
+          mint: WATCHED_MINT,
+          owner: WATCHED_TOKEN_OWNER,
+          stateMachinePrefix: "solana-token-account",
         }),
       )
       // Watch the SPL Memo program so the sync captures txs the fee-payer

--- a/e2e/solana/database/migrations/create-user-tables.sql
+++ b/e2e/solana/database/migrations/create-user-tables.sql
@@ -6,6 +6,20 @@ CREATE TABLE IF NOT EXISTS solana_balance_events (
   created_at TIMESTAMP DEFAULT NOW()
 );
 
+-- `amount` is a raw SPL u64 in base units. TEXT, not BIGINT: a u64 exceeds
+-- PostgreSQL's signed bigint at the top of its range, and the grammar carries it as
+-- a string for the same reason.
+CREATE TABLE IF NOT EXISTS solana_token_events (
+  id SERIAL PRIMARY KEY,
+  slot INTEGER NOT NULL,
+  token_account TEXT NOT NULL,
+  mint TEXT NOT NULL,
+  owner TEXT NOT NULL,
+  amount TEXT NOT NULL,
+  decimals INTEGER NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS solana_log_events (
   id SERIAL PRIMARY KEY,
   slot INTEGER NOT NULL,

--- a/e2e/solana/grammar.ts
+++ b/e2e/solana/grammar.ts
@@ -4,4 +4,5 @@ import { builtinGrammars } from "@effectstream/sm/grammar";
 export const grammar = {
   "solana-program-log": builtinGrammars.solanaProgramLog,
   "solana-account-balance": builtinGrammars.solanaAccountBalance,
+  "solana-token-account": builtinGrammars.solanaTokenAccount,
 } as const satisfies GrammarDefinition;

--- a/e2e/solana/node.ts
+++ b/e2e/solana/node.ts
@@ -42,6 +42,18 @@ stm.addStateTransition("solana-account-balance", function* (data) {
   ));
 });
 
+stm.addStateTransition("solana-token-account", function* (data) {
+  const { slot, tokenAccount, mint, owner, amount, decimals } = data.parsedInput;
+  console.log(
+    `[STM] solana-token-account: slot=${slot} account=${tokenAccount} mint=${mint} owner=${owner} amount=${amount}`,
+  );
+
+  yield* World.promise(pool.query(
+    "INSERT INTO solana_token_events (slot, token_account, mint, owner, amount, decimals) VALUES ($1, $2, $3, $4, $5, $6)",
+    [slot, tokenAccount, mint, owner, amount, decimals],
+  ));
+});
+
 const gameStateTransitions: StartConfigGameStateTransitions = function* (
   blockHeight: number,
   input: BaseStfInput,

--- a/e2e/solana/package.json
+++ b/e2e/solana/package.json
@@ -20,6 +20,7 @@
     "@effectstream/sm": "workspace:*",
     "@effectstream/batcher-sdk": "workspace:*",
     "@effectstream/utils": "workspace:*",
+    "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.0",
     "bs58": "^6.0.0",
     "@sinclair/typebox": "^0.34.30",

--- a/e2e/solana/run-tests.ts
+++ b/e2e/solana/run-tests.ts
@@ -28,6 +28,10 @@ import { runWalletTransferTest } from "./sync/wallet-transfer.test.ts";
 import { runAccountBalanceTest } from "./sync/account-balance.test.ts";
 import { runProgramLogTest } from "./sync/program-logs.test.ts";
 import { runProgramEventTests } from "./sync/program-events.test.ts";
+import {
+  runTokenAccountSetup,
+  runTokenAccountTest,
+} from "./sync/token-account.test.ts";
 import { runBatcherTest } from "./sync/batcher.test.ts";
 
 const LAUNCHER_PATH = path.resolve(import.meta.dirname!, "./launcher.cli.ts");
@@ -46,6 +50,7 @@ async function runSyncTests(db: Client): Promise<void> {
   await runAccountBalanceTest(db);
   await runProgramLogTest(db);
   await runProgramEventTests(db);
+  await runTokenAccountTest(db);
 }
 
 async function test() {
@@ -65,6 +70,9 @@ async function test() {
 
     await runToolingTests();
     await runWalletTransferTest();
+    // Must run before the sync assertions: it produces the on-chain token activity
+    // the SOLANA:TokenAccount primitive reads, and the validator is already up.
+    await runTokenAccountSetup();
 
     await waitForProcess("sync");
     await waitForHealth();

--- a/e2e/solana/sync/token-account.test.ts
+++ b/e2e/solana/sync/token-account.test.ts
@@ -1,0 +1,150 @@
+import { assert, assertSQL } from "@e2e/engine";
+import type { Client } from "pg";
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  createAssociatedTokenAccount,
+  createMint,
+  getAccount,
+  getAssociatedTokenAddress,
+  mintTo,
+} from "@solana/spl-token";
+import {
+  MINTED_AMOUNT,
+  WATCHED_MINT,
+  WATCHED_MINT_DECIMALS,
+  WATCHED_TOKEN_ACCOUNT,
+  WATCHED_TOKEN_OWNER,
+} from "../config.ts";
+
+const RPC = "http://localhost:8899";
+
+/**
+ * Phase 1 on-chain setup for the SOLANA:TokenAccount primitive: create the mint the
+ * config watches, open the owner's associated token account, and mint into it.
+ *
+ * The mint and owner come from fixed seeds because the config is static and cannot
+ * name a runtime-generated address. The first assertion re-derives them and checks
+ * they match `config.ts`, so changing a seed fails here rather than silently leaving
+ * the primitive watching a mint nothing ever touches.
+ */
+export async function runTokenAccountSetup(): Promise<void> {
+  const connection = new Connection(RPC, "confirmed");
+  const mintKeypair = Keypair.fromSeed(new Uint8Array(32).fill(8));
+  const ownerKeypair = Keypair.fromSeed(new Uint8Array(32).fill(9));
+  // Pays rent and fees for the setup. Not the owner, so the owner's ATA balance
+  // reflects only the mint.
+  const payer = Keypair.generate();
+
+  await assert(
+    "Solana: fixed seeds still derive the mint and owner the config watches",
+    async () => {
+      return mintKeypair.publicKey.toBase58() === WATCHED_MINT &&
+        ownerKeypair.publicKey.toBase58() === WATCHED_TOKEN_OWNER;
+    },
+  );
+
+  await assert("Solana: airdrop funds the token setup payer", async () => {
+    const sig = await connection.requestAirdrop(
+      payer.publicKey,
+      2 * LAMPORTS_PER_SOL,
+    );
+    await connection.confirmTransaction(sig, "confirmed");
+    return (await connection.getBalance(payer.publicKey, "confirmed")) > 0;
+  });
+
+  await assert("Solana: creates the watched SPL mint", async () => {
+    const mint = await createMint(
+      connection,
+      payer,
+      // Payer is the mint authority; the owner only ever receives.
+      payer.publicKey,
+      null,
+      WATCHED_MINT_DECIMALS,
+      mintKeypair,
+    );
+    return mint.toBase58() === WATCHED_MINT;
+  });
+
+  await assert("Solana: opens the owner's associated token account", async () => {
+    const ata = await createAssociatedTokenAccount(
+      connection,
+      payer,
+      mintKeypair.publicKey,
+      ownerKeypair.publicKey,
+    );
+    // Cross-check against the independently derived address, so a change in how
+    // the ATA is derived surfaces here rather than as a missing row later.
+    const derived = await getAssociatedTokenAddress(
+      mintKeypair.publicKey,
+      ownerKeypair.publicKey,
+    );
+    return ata.toBase58() === WATCHED_TOKEN_ACCOUNT &&
+      derived.toBase58() === WATCHED_TOKEN_ACCOUNT;
+  });
+
+  await assert("Solana: mints the watched amount to the owner's ATA", async () => {
+    const ata = await getAssociatedTokenAddress(
+      mintKeypair.publicKey,
+      ownerKeypair.publicKey,
+    );
+    await mintTo(
+      connection,
+      payer,
+      mintKeypair.publicKey,
+      ata,
+      payer,
+      BigInt(MINTED_AMOUNT),
+    );
+    const account = await getAccount(connection, ata);
+    return account.amount === BigInt(MINTED_AMOUNT) &&
+      account.mint.toBase58() === WATCHED_MINT &&
+      account.owner.toBase58() === WATCHED_TOKEN_OWNER;
+  });
+
+  console.log("Solana token account setup passed.\n");
+}
+
+/**
+ * Real sync-pipeline assertion for SOLANA:TokenAccount: the mintTo above appears in
+ * the block's `meta.postTokenBalances`, the primitive resolves its `accountIndex`
+ * against the resolved account list, and the state machine writes it to
+ * `solana_token_events`.
+ *
+ * Asserts on the state-machine table rather than `primitive_accounting`, so a
+ * primitive that produced accounting rows but never reached the STM still fails.
+ */
+export async function runTokenAccountTest(db: Client): Promise<void> {
+  await assertSQL<{
+    count: number;
+    amount: string | null;
+    owner: string | null;
+    decimals: number | null;
+  }>(
+    "Solana: sync captured the watched SPL balance into solana_token_events",
+    db,
+    `SELECT COUNT(*)::int AS count, MAX(amount) AS amount, MAX(owner) AS owner, MAX(decimals) AS decimals
+FROM solana_token_events WHERE token_account = '${WATCHED_TOKEN_ACCOUNT}' AND mint = '${WATCHED_MINT}';`,
+    (res) => (res.rows[0]?.count ?? 0) >= 1,
+    (res) =>
+      (res.rows[0]?.count ?? 0) >= 1 &&
+      res.rows[0]?.amount === MINTED_AMOUNT &&
+      res.rows[0]?.owner === WATCHED_TOKEN_OWNER &&
+      Number(res.rows[0]?.decimals) === WATCHED_MINT_DECIMALS,
+  );
+
+  // The mint authority's own account touches the same mint during setup, and the
+  // primitive is narrowed by owner — so nothing but the watched owner may appear.
+  await assertSQL<{ count: number }>(
+    "Solana: no token events for an owner the primitive does not watch",
+    db,
+    `SELECT COUNT(*)::int AS count FROM solana_token_events WHERE owner <> '${WATCHED_TOKEN_OWNER}';`,
+    (res) => res.rows.length >= 1,
+    (res) => (res.rows[0]?.count ?? 0) === 0,
+  );
+
+  console.log("Solana token account sync test passed.\n");
+}

--- a/packages/effectstream-sdk/config/src/schema/primitive/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/primitive/types.ts
@@ -90,9 +90,21 @@ type SolanaAccountBalancePayload = {
   slot: number;
 };
 
+type SolanaTokenBalancePayload = {
+  tokenAccount: string;
+  mint: string;
+  /** Empty string when the RPC's balance record omitted the owner. */
+  owner: string;
+  /** Raw u64 in base units — a u64 does not survive a JS number. */
+  amount: string;
+  decimals: number;
+  slot: number;
+};
+
 type SolanaPrimitivePayload =
   | SolanaProgramLogPayload
-  | SolanaAccountBalancePayload;
+  | SolanaAccountBalancePayload
+  | SolanaTokenBalancePayload;
 
 interface ProtocolPayloadMap {
   [ConfigSyncProtocolType.NTP_MAIN]: NtpPrimitivePayload;

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
@@ -150,6 +150,19 @@ type NearPrimitive = BasePrimitive & {
 
 type NtpMainPrimitive = BasePrimitive & {};
 
+/**
+ * The `type` discriminators for the built-in Solana primitives.
+ *
+ * These live here rather than in `@effectstream/sm/builtin` (which re-exports them
+ * under their `PrimitiveType*` names, so every existing import site is unchanged)
+ * because `SolanaFetcher.readPrimitives` needs them to dispatch, and
+ * `@effectstream/sync` does not depend on `@effectstream/sm`. Keeping one copy next
+ * to the `SolanaPrimitive` type they discriminate is what stops the two from drifting.
+ */
+export const SOLANA_PRIMITIVE_PROGRAM_LOG = "SOLANA:ProgramLog" as const;
+export const SOLANA_PRIMITIVE_ACCOUNT_BALANCE = "SOLANA:AccountBalance" as const;
+export const SOLANA_PRIMITIVE_TOKEN_ACCOUNT = "SOLANA:TokenAccount" as const;
+
 type SolanaPrimitive = BasePrimitive & {
   /** Program ID to watch for logs (SOLANA:ProgramLog primitive). */
   programId?: string;
@@ -157,6 +170,23 @@ type SolanaPrimitive = BasePrimitive & {
   eventType?: string;
   /** Account address to watch for balance changes (SOLANA:AccountBalance primitive). */
   address?: string;
+  /**
+   * SPL mint to watch token balances for (SOLANA:TokenAccount primitive).
+   *
+   * At least one of `mint`, `owner` or `tokenAccount` must be set, otherwise the
+   * primitive would match every token balance in every transaction. The fetcher
+   * treats an entry with none of the three as a misconfiguration and warns.
+   */
+  mint?: string;
+  /** Narrow SOLANA:TokenAccount to balances owned by this wallet address. */
+  owner?: string;
+  /** Narrow SOLANA:TokenAccount to one specific token account (usually an ATA). */
+  tokenAccount?: string;
+  /**
+   * Narrow SOLANA:TokenAccount to a single token program, i.e. classic SPL Token
+   * vs Token-2022. Omit to accept both.
+   */
+  tokenProgramId?: string;
 }
 
 type TestMainPrimitive = BasePrimitive & {};

--- a/packages/node-sdk/sm/primitives/src/builtin.ts
+++ b/packages/node-sdk/sm/primitives/src/builtin.ts
@@ -1,5 +1,11 @@
 // list of built-in primitives
 // this list is exposed to the effectstream-sdk modules via the @effectstream/sm/builtin module
+import {
+  SOLANA_PRIMITIVE_ACCOUNT_BALANCE,
+  SOLANA_PRIMITIVE_PROGRAM_LOG,
+  SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+} from "@effectstream/config";
+
 export const PrimitiveTypeMidnightGeneric = "Midnight:Generic" as const;
 export const PrimitiveTypeMidnightNullifier = "Midnight:Nullifier" as const;
 export const PrimitiveTypeMidnightUnshieldedSpend = "Midnight:UnshieldedSpend" as const;
@@ -33,8 +39,17 @@ export const PrimitiveTypeNEARIntent = "NEAR:Intent" as const;
 export const PrimitiveTypeNEARGeneric = "NEAR:Generic" as const;
 export const PrimitiveTypeNEARAccountWatch = "NEAR:AccountWatch" as const;
 
-export const PrimitiveTypeSolanaProgramLog = "SOLANA:ProgramLog" as const;
-export const PrimitiveTypeSolanaAccountBalance = "SOLANA:AccountBalance" as const;
+// Solana's discriminators are defined in @effectstream/config, beside the
+// `SolanaPrimitive` type they discriminate, because the sync fetcher dispatches on
+// them and @effectstream/sync does not depend on @effectstream/sm. Re-exported here
+// under the PrimitiveType* names so consumers keep importing them from
+// @effectstream/sm/builtin like every other primitive.
+// Aliased through local consts rather than `export { X as Y } from`, because the
+// `BuiltInPrimitives` union below needs `typeof PrimitiveTypeSolana*` in scope and a
+// bare re-export does not bind the name locally.
+export const PrimitiveTypeSolanaProgramLog = SOLANA_PRIMITIVE_PROGRAM_LOG;
+export const PrimitiveTypeSolanaAccountBalance = SOLANA_PRIMITIVE_ACCOUNT_BALANCE;
+export const PrimitiveTypeSolanaTokenAccount = SOLANA_PRIMITIVE_TOKEN_ACCOUNT;
 
 type BuiltInPrimitives =
     typeof PrimitiveTypeMidnightGeneric |
@@ -63,7 +78,8 @@ type BuiltInPrimitives =
     typeof PrimitiveTypeNEARGeneric |
     typeof PrimitiveTypeNEARAccountWatch |
     typeof PrimitiveTypeSolanaProgramLog |
-    typeof PrimitiveTypeSolanaAccountBalance // |
+    typeof PrimitiveTypeSolanaAccountBalance |
+    typeof PrimitiveTypeSolanaTokenAccount // |
     // typeof PrimitiveTypeEVMGeneric
 ;
 

--- a/packages/node-sdk/sm/primitives/src/grammar.ts
+++ b/packages/node-sdk/sm/primitives/src/grammar.ts
@@ -17,6 +17,7 @@ import { nearGenericGrammar } from "./near-generic/near-generic-grammar.ts";
 import { nearAccountWatchGrammar } from "./near-account-watch/near-account-watch-grammar.ts";
 import { solanaProgramLogGrammar } from "./solana-program-log/solana-program-log-grammar.ts";
 import { solanaAccountBalanceGrammar } from "./solana-account-balance/solana-account-balance-grammar.ts";
+import { solanaTokenAccountGrammar } from "./solana-token-account/solana-token-account-grammar.ts";
 import { mintBurnGrammar } from "./cardano-mint-burn/mint-burn-grammar.ts";
 import { transferGrammar } from "./cardano-transfer/transfer-grammar.ts";
 import { poolDelegationGrammar } from "./cardano-pool-delegation/pool-delegation-grammar.ts";
@@ -42,6 +43,7 @@ export const builtinGrammars = {
   nearAccountWatch: nearAccountWatchGrammar,
   solanaProgramLog: solanaProgramLogGrammar,
   solanaAccountBalance: solanaAccountBalanceGrammar,
+  solanaTokenAccount: solanaTokenAccountGrammar,
   cardanoMintBurn: mintBurnGrammar,
   cardanoTransfer: transferGrammar,
   cardanoPoolDelegation: poolDelegationGrammar,

--- a/packages/node-sdk/sm/primitives/src/mod.ts
+++ b/packages/node-sdk/sm/primitives/src/mod.ts
@@ -21,6 +21,7 @@ import {
   PrimitiveTypeNEARAccountWatch,
   PrimitiveTypeSolanaProgramLog,
   PrimitiveTypeSolanaAccountBalance,
+  PrimitiveTypeSolanaTokenAccount,
   PrimitiveTypeCardanoMintBurn,
   PrimitiveTypeCardanoTransfer,
   PrimitiveTypeCardanoPoolDelegation,
@@ -51,6 +52,7 @@ import { NearGenericPrimitive } from "./near-generic/near-generic-primitive.ts";
 import { NearAccountWatchPrimitive } from "./near-account-watch/near-account-watch-primitive.ts";
 import { SolanaProgramLogPrimitive } from "./solana-program-log/solana-program-log-primitive.ts";
 import { SolanaAccountBalancePrimitive } from "./solana-account-balance/solana-account-balance-primitive.ts";
+import { SolanaTokenAccountPrimitive } from "./solana-token-account/solana-token-account-primitive.ts";
 import { CardanoMintBurnPrimitive } from "./cardano-mint-burn/mint-burn-primitive.ts";
 import { CardanoTransferPrimitive } from "./cardano-transfer/transfer-primitive.ts";
 import { CardanoPoolDelegationPrimitive } from "./cardano-pool-delegation/pool-delegation-primitive.ts";
@@ -81,6 +83,7 @@ const builtInPrimitivesMap = {
   [PrimitiveTypeNEARAccountWatch]: NearAccountWatchPrimitive,
   [PrimitiveTypeSolanaProgramLog]: SolanaProgramLogPrimitive,
   [PrimitiveTypeSolanaAccountBalance]: SolanaAccountBalancePrimitive,
+  [PrimitiveTypeSolanaTokenAccount]: SolanaTokenAccountPrimitive,
   [PrimitiveTypeCardanoMintBurn]: CardanoMintBurnPrimitive,
   [PrimitiveTypeCardanoTransfer]: CardanoTransferPrimitive,
   [PrimitiveTypeCardanoPoolDelegation]: CardanoPoolDelegationPrimitive,
@@ -116,6 +119,7 @@ export {
   NearAccountWatchPrimitive,
   SolanaProgramLogPrimitive,
   SolanaAccountBalancePrimitive,
+  SolanaTokenAccountPrimitive,
   CardanoMintBurnPrimitive,
   CardanoTransferPrimitive,
   CardanoPoolDelegationPrimitive,

--- a/packages/node-sdk/sm/primitives/src/solana-token-account/solana-token-account-grammar.ts
+++ b/packages/node-sdk/sm/primitives/src/solana-token-account/solana-token-account-grammar.ts
@@ -1,0 +1,13 @@
+import { Type } from "@sinclair/typebox";
+
+export const solanaTokenAccountGrammar = [
+  ["tokenAccount", Type.String()],
+  ["mint", Type.String()],
+  ["owner", Type.String()],
+  // SPL amounts are u64 and do not survive a JS number. Carried as the raw base
+  // unit string, matching nep141Grammar's `amount` and erc20Grammar's `value`;
+  // `decimals` is what turns it into a display value.
+  ["amount", Type.String()],
+  ["decimals", Type.Number()],
+  ["slot", Type.Number()],
+] as const;

--- a/packages/node-sdk/sm/primitives/src/solana-token-account/solana-token-account-primitive.test.ts
+++ b/packages/node-sdk/sm/primitives/src/solana-token-account/solana-token-account-primitive.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+// Via the barrel, not the file directly: mod.ts registers every primitive class, so
+// importing the file first hits a TDZ error on the map entry. Same as
+// solana-program-log-primitive.test.ts.
+import { SolanaTokenAccountPrimitive } from "./../mod.ts";
+import { PrimitiveRegistry } from "../../PrimitiveRegistry.ts";
+
+/**
+ * Unit coverage for the primitive half of SOLANA:TokenAccount — the config guard and
+ * the payload the state machine actually receives. The fetcher half (which balance
+ * records match, and lookup-table resolution) is covered in
+ * `sync/src/sync-protocols/solana/read-primitives.test.ts`.
+ *
+ * `getPayload` is a generator that never yields, so one `.next()` drives it to done.
+ */
+
+const MINT = "Mint111111111111111111111111111111111111111";
+const OWNER = "0wner11111111111111111111111111111111111111";
+const TOKEN_ACCOUNT = "Tok111111111111111111111111111111111111111";
+
+function makePrimitive(overrides: Record<string, unknown> = {}) {
+  // The Primitive constructor self-registers and PrimitiveRegistry.addPrimitive
+  // throws on a duplicate instanceName, so the singleton has to be cleared between
+  // constructions.
+  PrimitiveRegistry.primitives = {};
+  return new SolanaTokenAccountPrimitive({
+    instanceName: "WatchedToken",
+    startBlockHeight: 0,
+    mint: MINT,
+    stateMachinePrefix: "solana-token-account",
+    ...overrides,
+  } as any);
+}
+
+function payloadOf(primitive: SolanaTokenAccountPrimitive, payload: unknown) {
+  const it = primitive.getPayload(0 as any, { output: { payload } } as any) as any;
+  const step = it.next();
+  expect(step.done).toBe(true);
+  return step.value;
+}
+
+const balancePayload = {
+  tokenAccount: TOKEN_ACCOUNT,
+  mint: MINT,
+  owner: OWNER,
+  amount: "1500000000",
+  decimals: 9,
+  slot: 11,
+};
+
+test("rejects a config with no mint, owner or tokenAccount", () => {
+  // Without a filter it would match every token balance on chain, which is never
+  // what was meant — so this fails at construction rather than flooding the STM.
+  expect(() =>
+    makePrimitive({ mint: undefined })
+  ).toThrow(/needs at least one of/);
+});
+
+test("accepts a config filtered by owner alone", () => {
+  expect(() => makePrimitive({ mint: undefined, owner: OWNER })).not.toThrow();
+});
+
+test("accepts a config filtered by tokenAccount alone", () => {
+  expect(() =>
+    makePrimitive({ mint: undefined, tokenAccount: TOKEN_ACCOUNT })
+  ).not.toThrow();
+});
+
+test("carries the raw u64 amount through as a string", () => {
+  // 2^63 - 1: a value that silently loses precision as a JS number, which is why
+  // the grammar types `amount` as a string.
+  const huge = "9223372036854775807";
+  const out = payloadOf(makePrimitive(), { ...balancePayload, amount: huge });
+  expect(out.data[0].accountingPayload.amount).toBe(huge);
+  expect(out.data[0].accountingPayload.decimals).toBe(9);
+});
+
+test("attributes the event to the owner", () => {
+  const out = payloadOf(makePrimitive(), balancePayload);
+  expect(out.data[0].fromAddressAndType.address).toBe(OWNER);
+});
+
+test("falls back to the token account when the RPC omitted the owner", () => {
+  // `owner` is optional in the RPC's token balance record. The balance is still
+  // valid state, so it is reported against the token account rather than dropped.
+  const out = payloadOf(makePrimitive(), { ...balancePayload, owner: undefined });
+  expect(out.data[0].fromAddressAndType.address).toBe(TOKEN_ACCOUNT);
+  expect(out.data[0].accountingPayload.owner).toBe("");
+});
+
+test("builds a state machine payload prefixed by stateMachinePrefix", () => {
+  const out = payloadOf(makePrimitive(), balancePayload);
+  expect(out.data[0].stateMachinePayload).not.toBeNull();
+  expect(out.data[0].stateMachinePayload[0]).toBe("solana-token-account");
+});
+
+test("emits no state machine payload when no prefix is configured", () => {
+  // The accounting row is still written; only STM delivery is skipped. This is the
+  // documented meaning of omitting the prefix.
+  const out = payloadOf(
+    makePrimitive({ stateMachinePrefix: undefined }),
+    balancePayload,
+  );
+  expect(out.data[0].stateMachinePayload).toBeNull();
+  expect(out.data[0].accountingPayload.mint).toBe(MINT);
+});
+
+test("getConfig round-trips the state machine prefix under both names", () => {
+  // Every other builtin emits only `scheduledPrefix`, which the Primitive
+  // constructor does not read — so a config round-tripped through getConfig() loses
+  // its STM routing. Emitting both makes this primitive survive that trip.
+  const config = makePrimitive().getConfig() as Record<string, unknown>;
+  expect(config.stateMachinePrefix).toBe("solana-token-account");
+  expect(config.scheduledPrefix).toBe("solana-token-account");
+  expect(config.type).toBe("SOLANA:TokenAccount");
+  expect(config.mint).toBe(MINT);
+});

--- a/packages/node-sdk/sm/primitives/src/solana-token-account/solana-token-account-primitive.ts
+++ b/packages/node-sdk/sm/primitives/src/solana-token-account/solana-token-account-primitive.ts
@@ -1,0 +1,156 @@
+import type { StaticDecode } from "@sinclair/typebox";
+import type {
+  ConfigSyncProtocolType,
+  FlattenSyncProtocolIOFor,
+  ProtocolPrimitiveMap,
+} from "@effectstream/config";
+import {
+  type AddressAndType,
+  AddressType,
+  type EffectstreamBlockNumber,
+} from "@effectstream/utils";
+import { type JsonObject, Primitive } from "@effectstream/sm";
+import {
+  type CommandTuple,
+  generateRawStmInput,
+  type ParamToData,
+} from "@effectstream/concise";
+import type { StateUpdateStream } from "@effectstream/coroutine";
+import { solanaTokenAccountGrammar } from "./solana-token-account-grammar.ts";
+import { PrimitiveTypeSolanaTokenAccount } from "../builtin.ts";
+
+/**
+ * Built-in primitive: tracks the SPL token balance of a watched token account per
+ * slot, derived from a transaction's `meta.postTokenBalances` by
+ * `SolanaFetcher.readPrimitives`.
+ *
+ * Narrowed by any combination of `mint`, `owner` and `tokenAccount`; at least one
+ * must be set. `tokenProgramId` optionally pins it to classic SPL Token or to
+ * Token-2022 rather than accepting both.
+ *
+ * KNOWN LIMITATION — this reports post-state balances only, matching
+ * SOLANA:AccountBalance. A token account that is *closed* appears in
+ * `preTokenBalances` and is absent from `postTokenBalances`, so closure produces no
+ * event rather than a zero one. Emitting a pre/post delta would cover it and is a
+ * deliberate non-goal here; see the Solana chain docs.
+ */
+export class SolanaTokenAccountPrimitive extends Primitive<
+  ConfigSyncProtocolType.SOLANA_RPC_PARALLEL,
+  typeof solanaTokenAccountGrammar
+> {
+  readonly internalTypeName = PrimitiveTypeSolanaTokenAccount;
+  override grammar = solanaTokenAccountGrammar;
+  readonly mint: string | undefined;
+  readonly owner: string | undefined;
+  readonly tokenAccount: string | undefined;
+  readonly tokenProgramId: string | undefined;
+
+  constructor(config: {
+    instanceName: string;
+    startBlockHeight: number;
+    mint?: string;
+    owner?: string;
+    tokenAccount?: string;
+    tokenProgramId?: string;
+    stateMachinePrefix: string | undefined;
+  }) {
+    super(config);
+    // Rejected here rather than in the fetcher because this is the earliest point
+    // it can be caught: an entry with no filter at all would match every token
+    // balance in every transaction, which is never what was meant.
+    if (
+      config.mint == null && config.owner == null && config.tokenAccount == null
+    ) {
+      throw new Error(
+        `[${PrimitiveTypeSolanaTokenAccount}] "${config.instanceName}" needs at least one of ` +
+          `mint, owner or tokenAccount. Without a filter it would match every token balance on chain.`,
+      );
+    }
+    this.mint = config.mint;
+    this.owner = config.owner;
+    this.tokenAccount = config.tokenAccount;
+    this.tokenProgramId = config.tokenProgramId;
+  }
+
+  override *getPayload(
+    _: EffectstreamBlockNumber,
+    primitiveTransactionData: FlattenSyncProtocolIOFor<
+      ConfigSyncProtocolType.SOLANA_RPC_PARALLEL
+    >,
+  ): StateUpdateStream<{
+    isBatched: boolean;
+    data: {
+      fromAddressAndType: AddressAndType;
+      stateMachinePayload:
+        | StaticDecode<CommandTuple<string, typeof solanaTokenAccountGrammar>>
+        | null;
+      accountingPayload: JsonObject;
+    }[];
+  }> {
+    const payload = primitiveTransactionData.output.payload as {
+      tokenAccount?: string;
+      mint?: string;
+      owner?: string;
+      amount?: string;
+      decimals?: number;
+      slot?: number;
+    };
+
+    const accountingPayload: ParamToData<typeof solanaTokenAccountGrammar> = {
+      tokenAccount: String(payload.tokenAccount ?? ""),
+      mint: String(payload.mint ?? this.mint ?? ""),
+      // `owner` is optional in the RPC's token balance record, so it can genuinely
+      // be absent. Empty string rather than a thrown error: the balance itself is
+      // still valid state, and the grammar requires a string.
+      owner: String(payload.owner ?? this.owner ?? ""),
+      amount: String(payload.amount ?? "0"),
+      decimals: Number(payload.decimals ?? 0),
+      slot: Number(payload.slot ?? 0),
+    };
+
+    const stateMachinePayload = this.stateMachinePrefix
+      ? generateRawStmInput(
+        this.grammar,
+        this.stateMachinePrefix,
+        accountingPayload,
+      )
+      : null;
+
+    return {
+      isBatched: false,
+      data: [
+        {
+          // The owner is the party whose holdings changed, so it is the meaningful
+          // actor. Falls back to the token account when the RPC omitted the owner.
+          fromAddressAndType: {
+            type: AddressType.SOLANA,
+            address: accountingPayload.owner || accountingPayload.tokenAccount,
+          },
+          accountingPayload,
+          stateMachinePayload,
+        },
+      ],
+    };
+  }
+
+  override getConfig(): ProtocolPrimitiveMap[
+    ConfigSyncProtocolType.SOLANA_RPC_PARALLEL
+  ] {
+    return {
+      name: this.instanceName,
+      type: this.internalTypeName,
+      startBlockHeight: this.startBlockHeight,
+      mint: this.mint,
+      owner: this.owner,
+      tokenAccount: this.tokenAccount,
+      tokenProgramId: this.tokenProgramId,
+      // Both names on purpose. Every other builtin emits only `scheduledPrefix`,
+      // which the `Primitive` constructor does not read — so a config round-tripped
+      // through getConfig() silently loses its state-machine routing. Emitting
+      // `stateMachinePrefix` too makes this primitive survive that trip, and
+      // `scheduledPrefix` stays for anything still reading the deprecated name.
+      stateMachinePrefix: this.stateMachinePrefix,
+      scheduledPrefix: this.stateMachinePrefix,
+    } as ProtocolPrimitiveMap[ConfigSyncProtocolType.SOLANA_RPC_PARALLEL];
+  }
+}

--- a/packages/node-sdk/sync/src/sync-protocols/solana/SolanaClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/solana/SolanaClient.ts
@@ -43,7 +43,37 @@ export type SolanaTransaction = {
       writable: string[];
       readonly: string[];
     } | null;
+    /**
+     * SPL token balances after the transaction, one record per (token account,
+     * mint) pair it touched. Returned by `getBlock` with
+     * `transactionDetails: "full"`; absent on transactions that touched no token
+     * account, and on validators old enough not to report them.
+     *
+     * `accountIndex` indexes the SAME resolved list as `pre`/`postBalances` — see
+     * {@link resolveAccountKeys} — so a token account reached through a lookup
+     * table is only findable after resolution.
+     */
+    postTokenBalances?: SolanaTokenBalance[] | null;
+    /** Pre-state counterpart of {@link postTokenBalances}. */
+    preTokenBalances?: SolanaTokenBalance[] | null;
   } | null;
+};
+
+export type SolanaTokenBalance = {
+  /** Index into the resolved account list, NOT into `message.accountKeys` alone. */
+  accountIndex: number;
+  mint: string;
+  /** Optional: older validators omit it. */
+  owner?: string;
+  /** The owning token program, i.e. SPL Token or Token-2022. Optional for the same reason. */
+  programId?: string;
+  uiTokenAmount: {
+    /** Raw u64 in base units, as a string. */
+    amount: string;
+    decimals: number;
+    uiAmount: number | null;
+    uiAmountString?: string;
+  };
 };
 
 /**

--- a/packages/node-sdk/sync/src/sync-protocols/solana/fetcher.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/solana/fetcher.ts
@@ -1,6 +1,9 @@
 import {
   ConfigSyncProtocolType,
   type PrimitiveEntry,
+  SOLANA_PRIMITIVE_ACCOUNT_BALANCE,
+  SOLANA_PRIMITIVE_PROGRAM_LOG,
+  SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
 } from "@effectstream/config";
 import { BaseDataFetcher } from "../base/fetcher.ts";
 import type { DataFetched } from "../base/fetcher.ts";
@@ -17,7 +20,11 @@ import type {
   Page,
   PrimitiveType,
 } from "./types.ts";
-import { resolveAccountKeys, SolanaClient } from "./SolanaClient.ts";
+import {
+  resolveAccountKeys,
+  SolanaClient,
+  type SolanaTokenBalance,
+} from "./SolanaClient.ts";
 import { requestTimeoutOf } from "../common/http.ts";
 import { extractProgramLogs } from "./program-logs.ts";
 import { call, sleep, type Operation } from "effection";
@@ -47,6 +54,19 @@ export class SolanaFetcher extends BaseDataFetcher<
    * very first block ever fetched has no fallback.
    */
   private lastKnownBlockTime: number | undefined;
+
+  /**
+   * Messages already logged by `warnOnce`. `readPrimitives` runs per transaction,
+   * so a misconfigured primitive would otherwise emit an identical line thousands
+   * of times during catch-up and bury everything else.
+   */
+  private readonly warnedOnce = new Set<string>();
+
+  private warnOnce(message: string): void {
+    if (this.warnedOnce.has(message)) return;
+    this.warnedOnce.add(message);
+    console.warn(message);
+  }
 
   constructor(
     readonly config: ConfigType,
@@ -252,6 +272,7 @@ export class SolanaFetcher extends BaseDataFetcher<
             writable: string[];
             readonly: string[];
           } | null;
+          postTokenBalances?: SolanaTokenBalance[] | null;
         } | null;
       }[];
     },
@@ -290,65 +311,142 @@ export class SolanaFetcher extends BaseDataFetcher<
       for (const entry of primitiveEntries) {
         const prim = entry.primitive;
 
-        // ── SOLANA:AccountBalance — watch an address's lamport balance ──
-        if (prim.address) {
-          const idx = accountKeys.indexOf(prim.address);
-          if (idx === -1) continue;
-          allPrimitives.push({
-            syncProtocol: {
-              name: entry.syncProtocol,
-              blockNumber: slot,
-              transactionHash: txHash,
-              contractAddress: prim.address,
-              logIndex: txIndex,
-            },
-            primitive: prim.name,
-            output: {
-              payloadType: "solana:balance",
-              payload: {
-                address: prim.address,
-                lamports: postBalances[idx] ?? 0,
-                slot,
+        // Dispatch on `prim.type`, NOT on which optional fields happen to be set.
+        // `SolanaPrimitive` is a flat bag of optionals, so field-truthy dispatch
+        // fails two ways once a third primitive exists: a TokenAccount entry
+        // matches no field branch and silently emits nothing, and any field it
+        // shares with an earlier branch (`address` being the natural name for a
+        // token account) routes it into that branch instead. Neither is a type
+        // error. `type` is always populated at runtime because
+        // `Primitive.getConfig()` sets it and runtime/src/main.ts replaces the
+        // config entry with its output.
+        switch (prim.type) {
+          // ── SOLANA:AccountBalance — watch an address's lamport balance ──
+          case SOLANA_PRIMITIVE_ACCOUNT_BALANCE: {
+            if (!prim.address) continue;
+            const idx = accountKeys.indexOf(prim.address);
+            if (idx === -1) continue;
+            allPrimitives.push({
+              syncProtocol: {
+                name: entry.syncProtocol,
+                blockNumber: slot,
+                transactionHash: txHash,
+                contractAddress: prim.address,
+                logIndex: txIndex,
               },
-            },
-          });
-          continue;
-        }
-
-        // ── SOLANA:ProgramLog — logs the watched programId actually emitted ──
-        if (prim.programId) {
-          // Source of truth is the log stream's invoke/success framing, NOT
-          // accountKeys: naming a program as an account doesn't invoke it, and
-          // a program reached through a lookup table isn't in accountKeys at
-          // all. See program-logs.ts.
-          const programLogs = extractProgramLogs(logs, prim.programId);
-          if (programLogs == null) continue;
-          // Filter by eventType if specified — against this program's own lines
-          // only, so another program can't trigger it by echoing the string.
-          if (prim.eventType) {
-            const hasMatchingLog = programLogs.some((log) =>
-              log.includes(prim.eventType!)
-            );
-            if (!hasMatchingLog) continue;
+              primitive: prim.name,
+              output: {
+                payloadType: "solana:balance",
+                payload: {
+                  address: prim.address,
+                  lamports: postBalances[idx] ?? 0,
+                  slot,
+                },
+              },
+            });
+            continue;
           }
-          allPrimitives.push({
-            syncProtocol: {
-              name: entry.syncProtocol,
-              blockNumber: slot,
-              transactionHash: txHash,
-              contractAddress: prim.programId,
-              logIndex: txIndex,
-            },
-            primitive: prim.name,
-            output: {
-              payloadType: "solana:transaction",
-              payload: {
-                programId: prim.programId,
-                slot,
-                logMessages: programLogs,
+
+          // ── SOLANA:ProgramLog — logs the watched programId actually emitted ──
+          case SOLANA_PRIMITIVE_PROGRAM_LOG: {
+            if (!prim.programId) continue;
+            // Source of truth is the log stream's invoke/success framing, NOT
+            // accountKeys: naming a program as an account doesn't invoke it, and
+            // a program reached through a lookup table isn't in accountKeys at
+            // all. See program-logs.ts.
+            const programLogs = extractProgramLogs(logs, prim.programId);
+            if (programLogs == null) continue;
+            // Filter by eventType if specified — against this program's own lines
+            // only, so another program can't trigger it by echoing the string.
+            if (prim.eventType) {
+              const hasMatchingLog = programLogs.some((log) =>
+                log.includes(prim.eventType!)
+              );
+              if (!hasMatchingLog) continue;
+            }
+            allPrimitives.push({
+              syncProtocol: {
+                name: entry.syncProtocol,
+                blockNumber: slot,
+                transactionHash: txHash,
+                contractAddress: prim.programId,
+                logIndex: txIndex,
               },
-            },
-          });
+              primitive: prim.name,
+              output: {
+                payloadType: "solana:transaction",
+                payload: {
+                  programId: prim.programId,
+                  slot,
+                  logMessages: programLogs,
+                },
+              },
+            });
+            continue;
+          }
+
+          // ── SOLANA:TokenAccount — SPL balance of a watched token account ──
+          case SOLANA_PRIMITIVE_TOKEN_ACCOUNT: {
+            // An entry with no filter would match every token balance on chain.
+            // The primitive constructor rejects that, so reaching here means a
+            // hand-built config bypassed it.
+            if (!prim.mint && !prim.owner && !prim.tokenAccount) {
+              this.warnOnce(
+                `[Solana] primitive "${prim.name}" is ${SOLANA_PRIMITIVE_TOKEN_ACCOUNT} with no ` +
+                  `mint, owner or tokenAccount — it would match every token balance, so it is skipped.`,
+              );
+              continue;
+            }
+            for (const bal of tx.meta.postTokenBalances ?? []) {
+              if (prim.mint && bal.mint !== prim.mint) continue;
+              if (prim.owner && bal.owner !== prim.owner) continue;
+              if (prim.tokenProgramId && bal.programId !== prim.tokenProgramId) {
+                continue;
+              }
+              // `accountIndex` indexes the RESOLVED list, same as postBalances, so
+              // a token account pulled in via a lookup table is only findable here
+              // (security fix B3 applied to token balances).
+              const tokenAccount = accountKeys[bal.accountIndex];
+              if (tokenAccount == null) continue;
+              if (prim.tokenAccount && tokenAccount !== prim.tokenAccount) {
+                continue;
+              }
+              allPrimitives.push({
+                syncProtocol: {
+                  name: entry.syncProtocol,
+                  blockNumber: slot,
+                  transactionHash: txHash,
+                  contractAddress: bal.mint,
+                  logIndex: txIndex,
+                },
+                primitive: prim.name,
+                output: {
+                  payloadType: "solana:token-balance",
+                  payload: {
+                    tokenAccount,
+                    mint: bal.mint,
+                    owner: bal.owner ?? "",
+                    amount: bal.uiTokenAmount.amount,
+                    decimals: bal.uiTokenAmount.decimals,
+                    slot,
+                  },
+                },
+              });
+            }
+            continue;
+          }
+
+          default:
+            // A Solana sync protocol carrying a primitive type this fetcher does
+            // not implement produced nothing and said nothing before. Warn once
+            // per type rather than per transaction, which would be thousands of
+            // identical lines during catch-up.
+            this.warnOnce(
+              `[Solana] primitive "${prim.name}" has unsupported type "${prim.type}" — ignored. ` +
+                `Supported: ${SOLANA_PRIMITIVE_ACCOUNT_BALANCE}, ${SOLANA_PRIMITIVE_PROGRAM_LOG}, ` +
+                `${SOLANA_PRIMITIVE_TOKEN_ACCOUNT}.`,
+            );
+            continue;
         }
       }
     }

--- a/packages/node-sdk/sync/src/sync-protocols/solana/read-primitives.test.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/solana/read-primitives.test.ts
@@ -1,4 +1,9 @@
 import { expect, test } from "bun:test";
+import {
+  SOLANA_PRIMITIVE_ACCOUNT_BALANCE,
+  SOLANA_PRIMITIVE_PROGRAM_LOG,
+  SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+} from "@effectstream/config";
 import { SolanaFetcher } from "./fetcher.ts";
 import type { ConfigType } from "./types.ts";
 
@@ -33,13 +38,25 @@ function run(fetcher: SolanaFetcher, slot: number, block: any, entries: any[]) {
   return step.value as any[];
 }
 
+// `type` is what readPrimitives dispatches on. These fixtures used to omit it,
+// which the old field-truthy dispatch tolerated — real configs always carry it,
+// because `Primitive.getConfig()` sets it and runtime/src/main.ts substitutes its
+// output for the raw config entry.
 const programLogEntry = {
   syncProtocol: "parallelSolanaRPC",
-  primitive: { name: "WatchedLog", programId: WATCHED_PROGRAM },
+  primitive: {
+    name: "WatchedLog",
+    type: SOLANA_PRIMITIVE_PROGRAM_LOG,
+    programId: WATCHED_PROGRAM,
+  },
 };
 const balanceEntry = {
   syncProtocol: "parallelSolanaRPC",
-  primitive: { name: "WatchedBalance", address: WATCHED_ADDRESS },
+  primitive: {
+    name: "WatchedBalance",
+    type: SOLANA_PRIMITIVE_ACCOUNT_BALANCE,
+    address: WATCHED_ADDRESS,
+  },
 };
 
 /** A transaction that genuinely invoked the watched program. */
@@ -136,7 +153,12 @@ test("eventType filters against the program's OWN lines only", () => {
   });
   const entry = {
     syncProtocol: "parallelSolanaRPC",
-    primitive: { name: "WatchedLog", programId: WATCHED_PROGRAM, eventType: "MARKER" },
+    primitive: {
+      name: "WatchedLog",
+      type: SOLANA_PRIMITIVE_PROGRAM_LOG,
+      programId: WATCHED_PROGRAM,
+      eventType: "MARKER",
+    },
   };
   expect(run(makeFetcher(), 42, { transactions: [tx] }, [entry])).toEqual([]);
 });
@@ -185,4 +207,229 @@ test("dispatches both primitive kinds from one transaction", () => {
 
 test("returns nothing when no primitives are configured", () => {
   expect(run(makeFetcher(), 42, { transactions: [invokingTx()] }, [])).toEqual([]);
+});
+
+// ───────────────────────── SOLANA:TokenAccount ─────────────────────────
+
+const MINT = "Mint111111111111111111111111111111111111111";
+const OTHER_MINT = "0therMint11111111111111111111111111111111";
+const TOKEN_ACCOUNT = "Tok111111111111111111111111111111111111111";
+const OWNER = "0wner11111111111111111111111111111111111111";
+const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+const tokenEntry = {
+  syncProtocol: "parallelSolanaRPC",
+  primitive: {
+    name: "WatchedToken",
+    type: SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+    mint: MINT,
+  },
+};
+
+/** `meta.postTokenBalances` record shape, per the JSON-RPC `getBlock` response. */
+function tokenBalance(overrides: Record<string, unknown> = {}) {
+  return {
+    accountIndex: 0,
+    mint: MINT,
+    owner: OWNER,
+    programId: TOKEN_PROGRAM,
+    uiTokenAmount: {
+      amount: "1500000000",
+      decimals: 9,
+      uiAmount: 1.5,
+      uiAmountString: "1.5",
+    },
+    ...overrides,
+  };
+}
+
+/** A successful transaction carrying token balances. */
+function tokenTx(
+  balances: Record<string, unknown>[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    transaction: {
+      message: { accountKeys: [TOKEN_ACCOUNT, WATCHED_PROGRAM] },
+      signatures: ["sig-tok"],
+    },
+    meta: {
+      err: null,
+      logMessages: [],
+      postBalances: [0, 0],
+      postTokenBalances: balances,
+      ...overrides,
+    },
+  };
+}
+
+test("TokenAccount emits the post balance for a watched mint", () => {
+  const out = run(makeFetcher(), 11, { transactions: [tokenTx([tokenBalance()])] }, [
+    tokenEntry,
+  ]);
+  expect(out.length).toBe(1);
+  expect(out[0].primitive).toBe("WatchedToken");
+  expect(out[0].output.payloadType).toBe("solana:token-balance");
+  expect(out[0].output.payload).toEqual({
+    tokenAccount: TOKEN_ACCOUNT,
+    mint: MINT,
+    owner: OWNER,
+    // Raw u64 as a string: 1.5 tokens at 9 decimals does not survive a JS number
+    // once amounts get large, so the grammar carries the base units.
+    amount: "1500000000",
+    decimals: 9,
+    slot: 11,
+  });
+});
+
+test("TokenAccount resolves lookup-table token accounts (security fix B3)", () => {
+  // `accountIndex` indexes the resolved list — static keys, then ALT writable, then
+  // ALT readonly — so a token account reached through an ALT is at an index past
+  // the end of message.accountKeys. Without resolution this reads undefined and
+  // drops the balance silently.
+  // Two static keys (indices 0-1), then ALT writable (2), then ALT readonly (3),
+  // so the watched token account sits at index 3 — past the end of accountKeys.
+  const tx = tokenTx([tokenBalance({ accountIndex: 3 })], {
+    loadedAddresses: {
+      writable: ["W1111111111111111111111111111111111111111111"],
+      readonly: [TOKEN_ACCOUNT],
+    },
+  });
+  tx.transaction.message.accountKeys = [OTHER_PROGRAM, WATCHED_PROGRAM];
+  const out = run(makeFetcher(), 12, { transactions: [tx] }, [tokenEntry]);
+  expect(out.length).toBe(1);
+  expect(out[0].output.payload.tokenAccount).toBe(TOKEN_ACCOUNT);
+});
+
+test("TokenAccount SKIPS a reverted transaction (security fix B2)", () => {
+  const tx = tokenTx([tokenBalance()], { err: { InstructionError: [0, "Custom"] } });
+  expect(run(makeFetcher(), 13, { transactions: [tx] }, [tokenEntry])).toEqual([]);
+});
+
+test("TokenAccount ignores balances for a different mint", () => {
+  const tx = tokenTx([tokenBalance({ mint: OTHER_MINT })]);
+  expect(run(makeFetcher(), 14, { transactions: [tx] }, [tokenEntry])).toEqual([]);
+});
+
+test("TokenAccount narrows by owner", () => {
+  const entry = {
+    syncProtocol: "parallelSolanaRPC",
+    primitive: {
+      name: "WatchedToken",
+      type: SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+      mint: MINT,
+      owner: OWNER,
+    },
+  };
+  expect(
+    run(makeFetcher(), 15, { transactions: [tokenTx([tokenBalance()])] }, [entry]),
+  ).toHaveLength(1);
+  expect(
+    run(
+      makeFetcher(),
+      15,
+      { transactions: [tokenTx([tokenBalance({ owner: "someone-else" })])] },
+      [entry],
+    ),
+  ).toEqual([]);
+});
+
+test("TokenAccount narrows by tokenProgramId, separating Token-2022", () => {
+  const entry = {
+    syncProtocol: "parallelSolanaRPC",
+    primitive: {
+      name: "WatchedToken",
+      type: SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+      mint: MINT,
+      tokenProgramId: TOKEN_2022_PROGRAM,
+    },
+  };
+  // Same mint, classic SPL Token program — must not match a Token-2022 filter.
+  expect(
+    run(makeFetcher(), 16, { transactions: [tokenTx([tokenBalance()])] }, [entry]),
+  ).toEqual([]);
+  expect(
+    run(
+      makeFetcher(),
+      16,
+      { transactions: [tokenTx([tokenBalance({ programId: TOKEN_2022_PROGRAM })])] },
+      [entry],
+    ),
+  ).toHaveLength(1);
+});
+
+test("TokenAccount narrows by tokenAccount", () => {
+  const entry = {
+    syncProtocol: "parallelSolanaRPC",
+    primitive: {
+      name: "WatchedToken",
+      type: SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+      tokenAccount: TOKEN_ACCOUNT,
+    },
+  };
+  expect(
+    run(makeFetcher(), 17, { transactions: [tokenTx([tokenBalance()])] }, [entry]),
+  ).toHaveLength(1);
+  // accountIndex 1 resolves to WATCHED_PROGRAM, not the watched token account.
+  expect(
+    run(
+      makeFetcher(),
+      17,
+      { transactions: [tokenTx([tokenBalance({ accountIndex: 1 })])] },
+      [entry],
+    ),
+  ).toEqual([]);
+});
+
+test("TokenAccount emits one primitive per matching balance record", () => {
+  const tx = tokenTx([
+    tokenBalance(),
+    tokenBalance({ accountIndex: 1, owner: "second-owner" }),
+    tokenBalance({ mint: OTHER_MINT, accountIndex: 1 }),
+  ]);
+  const out = run(makeFetcher(), 18, { transactions: [tx] }, [tokenEntry]);
+  expect(out.length).toBe(2);
+  expect(out.map((p) => p.output.payload.owner)).toEqual([OWNER, "second-owner"]);
+});
+
+test("TokenAccount tolerates a transaction with no token balances", () => {
+  expect(run(makeFetcher(), 19, { transactions: [invokingTx()] }, [tokenEntry]))
+    .toEqual([]);
+});
+
+test("a TokenAccount entry is never treated as an AccountBalance", () => {
+  // The regression the type dispatch exists for. `SolanaPrimitive` is a flat bag of
+  // optionals, so a config can set `address` on a TokenAccount entry — under the old
+  // field-truthy dispatch (`if (prim.address)` first) that emitted a lamport-balance
+  // event under the token primitive's name.
+  const entry = {
+    syncProtocol: "parallelSolanaRPC",
+    primitive: {
+      name: "WatchedToken",
+      type: SOLANA_PRIMITIVE_TOKEN_ACCOUNT,
+      mint: MINT,
+      address: TOKEN_ACCOUNT,
+    },
+  };
+  const out = run(makeFetcher(), 20, { transactions: [tokenTx([tokenBalance()])] }, [
+    entry,
+  ]);
+  expect(out.length).toBe(1);
+  expect(out[0].output.payloadType).toBe("solana:token-balance");
+  expect(out[0].output.payload).not.toHaveProperty("lamports");
+});
+
+test("an unsupported primitive type is ignored rather than misrouted", () => {
+  const entry = {
+    syncProtocol: "parallelSolanaRPC",
+    primitive: {
+      name: "FromTheFuture",
+      type: "SOLANA:NotImplementedYet",
+      address: WATCHED_ADDRESS,
+      programId: WATCHED_PROGRAM,
+    },
+  };
+  expect(run(makeFetcher(), 21, { transactions: [invokingTx()] }, [entry]))
+    .toEqual([]);
 });


### PR DESCRIPTION
Closes known gap 6 from #815. Complements #820, which closes gap 1. No file overlap with it.

#815's description named a third Solana primitive, `SolanaTokenAccount`, that was never written. @acedward went looking for it and came up empty, and I confirmed the same across every ref I could reach: `feat/solana-support`, `feat/solana-sync-primitives-batcher`, `solana-clean` and `feat/solana-starter-ci-enable` all carry exactly `solana-account-balance` and `solana-program-log`. So this is written fresh rather than ported.

## What it does

Reads `meta.postTokenBalances`. Narrowed by any combination of `mint`, `owner` and `tokenAccount`, with at least one required. `tokenProgramId` optionally pins it to classic SPL Token or to Token-2022, and omitting it accepts both.

Payload: `{ tokenAccount, mint, owner, amount, decimals, slot }`.

Two properties carried across from #815's security review, both with tests confirmed to fail when the guard is removed:

| | |
|---|---|
| **B3** | `accountIndex` indexes the **resolved** account list, not `message.accountKeys`, so a token account reached through an address lookup table is only findable after `resolveAccountKeys`. |
| **B2** | Reverted transactions are skipped by the existing per transaction guard, so a rolled back mint drives nothing. |

An entry with no filter at all is rejected at construction. Without one it would match every token balance on chain, which is never the intent, and the constructor is the earliest place to catch it.

## The dispatch change was a prerequisite, and not for the reason I first thought

`readPrimitives` dispatched on field truthiness rather than on primitive type:

```ts
if (prim.address)   { /* AccountBalance */ continue; }
if (prim.programId) { /* ProgramLog */ }
```

I originally expected a token primitive to be misrouted into the AccountBalance branch. Reading the actual code, the plain failure is quieter than that: a `TokenAccount` entry matches **no** branch and silently emits nothing. Misrouting only happens if it carries `address`, which `SolanaPrimitive` permits because it is a flat bag of optionals. Neither case is a type error, and both are fixed by dispatching on `prim.type`. That is the first half of #815's known gap 7.

Worth flagging two things about it:

1. **This introduces a pattern rather than following one.** The NEAR fetcher dispatches the same field truthy way (`near/fetcher.ts:178` and `:220`). Three Solana primitives make the field approach ambiguous, so Solana moves first. NEAR is worth converting separately.
2. **`@effectstream/sync` does not depend on `@effectstream/sm`**, so the fetcher could not import `PrimitiveTypeSolana*` from where they lived. The three literals moved into `@effectstream/config`, beside the `SolanaPrimitive` type they discriminate, and `sm/primitives/src/builtin.ts` re-exports them under their existing `PrimitiveType*` names. Every current import site is unchanged, and there is no new dependency and no cycle.

An unrecognised type now warns once per primitive rather than being silently dropped, and once rather than per transaction so catch up does not bury the log.

## Two deliberate choices

**`amount` is a string.** SPL amounts are u64. They do not survive a JS number, and at the top of the range they also exceed PostgreSQL's signed `BIGINT`, so the grammar carries the raw base units as a string and the e2e table uses `TEXT`. This matches `nep141Grammar` and `erc20Grammar`.

**`getConfig()` emits both `stateMachinePrefix` and `scheduledPrefix`.** Every other builtin emits only the latter, which the `Primitive` constructor does not read, so a config round tripped through `getConfig()` silently loses its state machine routing. Emitting both makes this primitive survive that trip and follows the deprecation direction @acedward set in #815.

## Documented limitation

Post state balances only, matching AccountBalance. A token account that is **closed** appears in `preTokenBalances` and is absent from `postTokenBalances`, so closure emits nothing rather than a zero balance. A pre/post delta would cover it and is a deliberate non goal here. It is called out in the primitive docblock and in the chain docs rather than left implicit.

## Verified

| | |
|---|---|
| `bun test packages/node-sdk/sync/src/sync-protocols/solana/` | **42 pass**, up from 31 |
| `bun test packages/node-sdk/sm/primitives/src/solana-token-account/` | **9 pass** |
| `bun test ./packages` | **261 pass**, up from 241. Failure set byte identical to clean `v-next` |
| `bun run e2e/runner.ts solana` | **31 passed, 0 failed**, up from 24 |
| `docs/site` build | clean, only the pre existing blog `#whats-next` anchors |

**No regressions.** I compared the full unit suite against clean `v-next` by stashing, and the 13 failures plus 6 errors are identical in both. They are all pre existing and unrelated: a missing `@midnightntwrk/wallet-sdk-hd`, and runtime reproduction tests that need Postgres and free ports. The pass count moved by exactly the 20 tests added here.

**The e2e assertions are not vacuous.** I re ran the suite capturing the log specifically to check, because a green summary can hide a sync node that never did the work. The state machine fired with real data:

```
[STM] solana-token-account: slot=7 account=8taZEqZ... mint=2KW2XRd9... owner=J2xccRtu... amount=0
[STM] solana-token-account: slot=8 account=8taZEqZ... mint=2KW2XRd9... owner=J2xccRtu... amount=2500000
```

Slot 7 is the ATA opening and slot 8 is the mint, both landing in `solana_token_events` through the full path: `postTokenBalances` to `resolveAccountKeys` to primitive to grammar to STM to Postgres.

**Revert and confirm it fails**, on each new guard, since a guard whose test still passes without it is not a guard:

* drop the `resolveAccountKeys` call, and the lookup table test fails
* simulate the old field truthy dispatch, and both the misroute test and the unsupported type test fail

## Notes

* `@solana/spl-token` is new in `e2e/solana`. The test validator carries SPL Token and the ATA program in genesis, which I verified against the pinned Agave 3.0.14 specifically rather than assuming, since #815 pinned away from 1.18.26.
* The e2e mint and owner come from fixed seeds, using the same idiom as the existing `WATCHED_BALANCE_ADDRESS`, because a static config cannot name a runtime generated address. The first e2e assertion re derives both and checks they match `config.ts`, so a changed seed fails loudly instead of leaving the primitive watching a mint nothing ever touches. Localnet only, and the seeds are public, so they should never be reused anywhere real.
* Gap 3 is deliberately untouched. #820 owns `templates/solana-starter`, so wiring `RateLimitStore` waits for it to merge.
* One local environment note for anyone reproducing this. My `packages/binaries/solana-node/vendor/` still held solana-labs 1.18.26 from before the Agave pin, and the checksum guard from `60c873b5` rejects it, correctly. It fails closed rather than re downloading, so a stale vendor directory has to be cleared by hand.
