### PR TITLE
fix(e2e): mark suite FAILED when a crash escapes the assertion accounting

### DIFF
--- a/e2e/avail/run-tests.ts
+++ b/e2e/avail/run-tests.ts
@@ -12,6 +12,7 @@ import {
   assert,
   assertSQL,
   printSummary,
+  recordCrash,
   startInfrastructure,
   stopInfrastructure,
   waitForOrchestrator,
@@ -128,6 +129,7 @@ async function test() {
     // 6. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/bitcoin/run-tests.ts
+++ b/e2e/bitcoin/run-tests.ts
@@ -11,6 +11,7 @@
 import {
   anyError,
   printSummary,
+  recordCrash,
   startInfrastructure,
   stopInfrastructure,
   waitForOrchestrator,
@@ -383,6 +384,7 @@ async function test() {
     // 8. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/cardano/run-tests.ts
+++ b/e2e/cardano/run-tests.ts
@@ -10,6 +10,7 @@
 import {
   anyError,
   printSummary,
+  recordCrash,
   assert,
   assertSQL,
   assertChainReady,
@@ -169,6 +170,7 @@ async function test() {
     // 7. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/celestia/run-tests.ts
+++ b/e2e/celestia/run-tests.ts
@@ -12,6 +12,7 @@ import {
   assert,
   assertSQL,
   printSummary,
+  recordCrash,
   startInfrastructure,
   stopInfrastructure,
   waitForOrchestrator,
@@ -174,6 +175,7 @@ async function test() {
     // 6. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/evm/run-tests.ts
+++ b/e2e/evm/run-tests.ts
@@ -11,6 +11,7 @@ import {
   anyError,
   newSharedState,
   printSummary,
+  recordCrash,
   waitForBlock,
   type SharedState,
 } from "@e2e/engine";
@@ -199,6 +200,7 @@ async function test() {
     // 6. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/features/run-tests.ts
+++ b/e2e/features/run-tests.ts
@@ -6,6 +6,7 @@
 import {
   anyError,
   printSummary,
+  recordCrash,
   newSharedState,
   startInfrastructure,
   stopInfrastructure,
@@ -76,6 +77,7 @@ async function test() {
 
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/midnight/run-tests.ts
+++ b/e2e/midnight/run-tests.ts
@@ -12,6 +12,7 @@ import {
   assert,
   assertSQL,
   printSummary,
+  recordCrash,
   startInfrastructure,
   stopInfrastructure,
   waitForOrchestrator,
@@ -573,6 +574,7 @@ async function test() {
     // 7. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/near/run-tests.ts
+++ b/e2e/near/run-tests.ts
@@ -20,6 +20,7 @@ import {
   anyError,
   assertSQL,
   printSummary,
+  recordCrash,
   startInfrastructure,
   stopInfrastructure,
   waitForOrchestrator,
@@ -96,6 +97,7 @@ async function test() {
     // 6. Summary
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {

--- a/e2e/shared/engine/assert.ts
+++ b/e2e/shared/engine/assert.ts
@@ -15,15 +15,36 @@ const testResults = {
   skipped: 0,
 };
 
+let suiteCrashed = false;
+
+/**
+ * Call from a suite's top-level catch. An exception thrown OUTSIDE an
+ * assertion (infrastructure that died mid-run, a phase that threw between
+ * asserts) is never counted in testResults, so without this flag anyError()
+ * stays false whenever the tests that did run all passed — and the suite
+ * would exit 0 despite having crashed.
+ */
+export function recordCrash(): void {
+  suiteCrashed = true;
+}
+
 export function printSummary() {
   console.log(`\n\n[Summary]`);
   console.log(`  ${testResults.passed} tests passed`);
   console.log(`  ${testResults.failed} tests failed`);
   console.log(`  ${testResults.skipped} tests skipped`);
+  if (isRunning) {
+    console.log(`  1 test crashed before completing`);
+  }
+  if (suiteCrashed) {
+    console.log(`  [CRASH] suite aborted by an uncaught error`);
+  }
 }
 
 export function anyError(): boolean {
-  return testResults.count === 0 || testResults.failed > 0;
+  // isRunning: a test called startTest() but crashed before recording a
+  // result (e.g. the DB connection died inside assertSQL) — count it as failed.
+  return suiteCrashed || isRunning || testResults.count === 0 || testResults.failed > 0;
 }
 
 export function hasPassedTests(): boolean {

--- a/e2e/solana/run-tests.ts
+++ b/e2e/solana/run-tests.ts
@@ -11,6 +11,7 @@ import {
   anyError,
   assertSQL,
   printSummary,
+  recordCrash,
   startInfrastructure,
   stopInfrastructure,
   waitForOrchestrator,
@@ -50,12 +51,6 @@ async function runSyncTests(db: Client): Promise<void> {
 
 async function test() {
   let db: Client | null = null;
-  // An exception thrown OUTSIDE an assertion (infrastructure that never came
-  // up, a phase that threw before asserting) leaves anyError() false whenever an
-  // earlier phase passed — `anyError()` is `count === 0 || failed > 0`. Without
-  // this flag the suite would exit 0 having silently skipped, say, the entire
-  // batcher phase.
-  let infraError = false;
   try {
     await startInfrastructure(LAUNCHER_PATH);
     await waitForOrchestrator();
@@ -80,13 +75,13 @@ async function test() {
 
     printSummary();
   } catch (e) {
-    infraError = true;
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {
     if (db) await db.end();
     await stopInfrastructure();
-    if (anyError() || infraError) process.exit(1);
+    if (anyError()) process.exit(1);
     process.exit(0);
   }
 }

--- a/e2e/wallets-ui/run-tests.ts
+++ b/e2e/wallets-ui/run-tests.ts
@@ -15,7 +15,7 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
-import { assert, printSummary, anyError } from "@e2e/engine";
+import { assert, printSummary, anyError, recordCrash } from "@e2e/engine";
 
 const __dirname = import.meta.dirname!;
 const PORT = 4201;
@@ -182,6 +182,7 @@ async function main(): Promise<void> {
     await browserTests();
     printSummary();
   } catch (e) {
+    recordCrash();
     printSummary();
     console.error(e);
   } finally {


### PR DESCRIPTION
## Problem

The e2e runner reported a suite as **PASSED (exit 0)** even when the test script crashed mid-run. Observed in `e2e/midnight`: infrastructure was killed externally partway through, `runSyncTests` threw `ConnectionRefused`, yet the output printed `[Summary] 4 tests passed / 0 tests failed` followed by `[PASS] midnight` and exit code 0.

## Root cause

`runner.ts` correctly trusts the child suite's exit code — the bug is in how suites compute it:

1. `assertSQL` calls `safeQuery` outside any try/catch, after `startTest()` incremented the counter but before `testPassed()`/`testFailed()` ran. A `ConnectionRefused` there propagates out **without incrementing `failed`**.
2. Each suite's top-level `catch` swallows the exception, prints the summary (which only counts tests that *completed*), and `finally` gates the exit code on `anyError()` = `count === 0 || failed > 0` → false → `process.exit(0)`.

The solana suite had already patched this locally with an `infraError` flag; the fix never reached the other nine suites.

## Fix (centralized in `e2e/shared/engine/assert.ts`)

- **`recordCrash()`**: suites call it as the first line of their top-level `catch`, so a crash *between* assertions marks the suite failed.
- **`anyError()`** also returns true while a test is still in-flight (`startTest()` ran but no result was recorded — the exact `assertSQL`/`safeQuery` crash path), as a safety net even if a future suite forgets `recordCrash()`.
- **`printSummary()`** now prints `1 test crashed before completing` / `[CRASH] suite aborted by an uncaught error` so logs no longer read as a clean pass.

All ten suites (evm, bitcoin, cardano, midnight, avail, celestia, near, solana, features, wallets-ui) now call `recordCrash()`; solana's local `infraError` flag is replaced by the shared mechanism. `sync-repro` already propagates child exit codes and needed no change.

## Verification

Reproduced the incident's crash path in a standalone script: two passing asserts, then an `assertSQL` whose `db_acquire_lock` fetch hits `ConnectionRefused`, in the same catch/finally shape the suites use:

```
[Summary]
  2 tests passed
  0 tests failed
  0 tests skipped
  1 test crashed before completing
  [CRASH] suite aborted by an uncaught error
EXIT CODE: 1
```

Under the old logic this exact scenario exited 0. All edited files syntax-checked with `bun build`.

Note: midnight's "non-fatal" batcher phase still tolerates ordinary errors, but a DB-connection crash mid-assertion there now fails the suite — consistent with "a crash anywhere marks the suite FAILED" (plain assertion failures in that phase already failed the exit code before this change).