### PR TITLE
Remove unused indexerWS field from Midnight sync-protocol config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -509,7 +509,7 @@
     },
     "packages/batcher": {
       "name": "@effectstream/batcher-sdk",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/event-client": "workspace:*",
@@ -554,7 +554,7 @@
     },
     "packages/binaries/avail-light-client": {
       "name": "@effectstream/npm-avail-light-client",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-avail-light-client": "index.js",
       },
@@ -565,7 +565,7 @@
     },
     "packages/binaries/avail-node": {
       "name": "@effectstream/npm-avail-node",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-avail-node": "index.js",
       },
@@ -576,7 +576,7 @@
     },
     "packages/binaries/bitcoin-core": {
       "name": "@effectstream/bitcoin-core",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "bitcoin-core": "./index.js",
       },
@@ -586,7 +586,7 @@
     },
     "packages/binaries/celestia": {
       "name": "@effectstream/celestia",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "celestia": "./index.js",
       },
@@ -596,7 +596,7 @@
     },
     "packages/binaries/grafana-alloy": {
       "name": "@effectstream/grafana-alloy",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "grafana-alloy": "index.js",
       },
@@ -606,7 +606,7 @@
     },
     "packages/binaries/grafana-loki": {
       "name": "@effectstream/grafana-loki",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "grafana-loki": "index.js",
       },
@@ -616,7 +616,7 @@
     },
     "packages/binaries/midnight-indexer": {
       "name": "@effectstream/npm-midnight-indexer",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-midnight-indexer": "index.js",
       },
@@ -629,7 +629,7 @@
     },
     "packages/binaries/midnight-node": {
       "name": "@effectstream/npm-midnight-node",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-midnight-node": "index.js",
       },
@@ -641,7 +641,7 @@
     },
     "packages/binaries/midnight-proof-server": {
       "name": "@effectstream/npm-midnight-proof-server",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "npm-midnight-proof-server": "index.js",
       },
@@ -652,7 +652,7 @@
     },
     "packages/binaries/near-sandbox": {
       "name": "@effectstream/near-sandbox",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "near-sandbox": "./index.js",
       },
@@ -662,7 +662,7 @@
     },
     "packages/binaries/ord": {
       "name": "@effectstream/ord",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "ord": "./index.js",
       },
@@ -672,7 +672,7 @@
     },
     "packages/binaries/solana-node": {
       "name": "@effectstream/solana-node",
-      "version": "0.100.18",
+      "version": "0.102.0",
       "bin": {
         "solana-node": "./index.js",
       },
@@ -707,7 +707,7 @@
     },
     "packages/build-tools/orchestrator": {
       "name": "@effectstream/orchestrator",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "bin": {
         "orchestrator": "src/cli.ts",
       },
@@ -717,11 +717,11 @@
     },
     "packages/chains/avail-contracts": {
       "name": "@effectstream/avail-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
     },
     "packages/chains/bitcoin-contracts": {
       "name": "@effectstream/bitcoin-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "bitcoinjs-lib": "^7.0.0",
         "ecpair": "^3.0.0",
@@ -730,11 +730,11 @@
     },
     "packages/chains/cardano-contracts": {
       "name": "@effectstream/cardano-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
     },
     "packages/chains/evm-contracts": {
       "name": "@effectstream/evm-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@nomicfoundation/hardhat-ignition": "3.0.2",
         "@nomicfoundation/hardhat-ignition-viem": "3.0.2",
@@ -749,7 +749,7 @@
     },
     "packages/chains/evm-hardhat": {
       "name": "@effectstream/evm-hardhat",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -767,7 +767,7 @@
     },
     "packages/chains/midnight-contracts": {
       "name": "@effectstream/midnight-contracts",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@midnight-ntwrk/compact-js": "2.5.1",
@@ -796,14 +796,14 @@
     },
     "packages/effectstream-sdk/chain-types": {
       "name": "@effectstream/chain-types",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/concise": {
       "name": "@effectstream/concise",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/crypto": "workspace:*",
         "@effectstream/utils": "workspace:*",
@@ -814,7 +814,7 @@
     },
     "packages/effectstream-sdk/config": {
       "name": "@effectstream/config",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@dcspark/carp-client": "^3.3.0",
         "@dcspark/cip34-js": "3.0.1",
@@ -831,7 +831,7 @@
     },
     "packages/effectstream-sdk/coroutine": {
       "name": "@effectstream/coroutine",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@pgtyped/parser": "2.4.2",
@@ -843,7 +843,7 @@
     },
     "packages/effectstream-sdk/crypto": {
       "name": "@effectstream/crypto",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@cardano-foundation/cardano-verify-datasignature": "1.0.11",
         "@effectstream/utils": "workspace:*",
@@ -872,7 +872,7 @@
     },
     "packages/effectstream-sdk/events": {
       "name": "@effectstream/event-client",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -886,7 +886,7 @@
     },
     "packages/effectstream-sdk/log": {
       "name": "@effectstream/log",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
@@ -908,14 +908,14 @@
     },
     "packages/effectstream-sdk/precompile": {
       "name": "@effectstream/precompile",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "js-sha3": "^0.9.3",
       },
     },
     "packages/effectstream-sdk/utils": {
       "name": "@effectstream/utils",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@coderspirit/nominal": "^4.1.1",
         "@foxglove/crc": "^1.0.1",
@@ -936,7 +936,7 @@
     },
     "packages/effectstream-sdk/wallets": {
       "name": "@effectstream/wallets",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@aurowallet/mina-provider": "^1.0.12",
         "@effectstream/concise": "workspace:*",
@@ -995,14 +995,14 @@
     },
     "packages/frontend": {
       "name": "@effectstream/frontend-sdk",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/wallets": "workspace:*",
       },
     },
     "packages/node-sdk/db": {
       "name": "@effectstream/db",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/coroutine": "workspace:*",
         "@effectstream/log": "workspace:*",
@@ -1025,7 +1025,7 @@
     },
     "packages/node-sdk/db-emulator": {
       "name": "@effectstream/db-emulator",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@pgtyped/runtime": "2.4.2",
         "effection": "^3.5.0",
@@ -1034,7 +1034,7 @@
     },
     "packages/node-sdk/events": {
       "name": "@effectstream/event-server",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/utils": "workspace:*",
         "@seriousme/opifex": "^1.11.2",
@@ -1042,7 +1042,7 @@
     },
     "packages/node-sdk/node": {
       "name": "@effectstream/node-sdk",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/chain-types": "workspace:*",
         "@effectstream/concise": "workspace:*",
@@ -1060,7 +1060,7 @@
     },
     "packages/node-sdk/runtime": {
       "name": "@effectstream/runtime",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1092,7 +1092,7 @@
     },
     "packages/node-sdk/sm": {
       "name": "@effectstream/sm",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@effectstream/concise": "workspace:*",
         "@effectstream/config": "workspace:*",
@@ -1113,7 +1113,7 @@
     },
     "packages/node-sdk/sync": {
       "name": "@effectstream/sync",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "dependencies": {
         "@cardano-sdk/core": "^0.46.11",
         "@cardano-sdk/util": "^0.17.1",

--- a/docs/site/docs/home/1200-templates/1205-intent-swap.md
+++ b/docs/site/docs/home/1200-templates/1205-intent-swap.md
@@ -148,7 +148,6 @@ This block configures the connection to the local Midnight node, the Indexer syn
     type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
     pollingInterval: 1000,
     indexer: "http://127.0.0.1:8088/api/v1/graphql",
-    indexerWs: "ws://127.0.0.1:8088/api/v1/graphql/ws",
   })
 )
 

--- a/docs/site/docs/home/200-chains/202-midnight.md
+++ b/docs/site/docs/home/200-chains/202-midnight.md
@@ -75,7 +75,6 @@ The protocol type `MIDNIGHT_PARALLEL` connects to the Midnight Indexer (GraphQL)
     startBlockHeight: 1,
     pollingInterval: 1000,
     indexer: "http://127.0.0.1:8088/api/v1/graphql",
-    indexerWs: "ws://127.0.0.1:8088/api/v1/graphql/ws",
   })
 )
 ```

--- a/e2e/midnight/config.ts
+++ b/e2e/midnight/config.ts
@@ -99,7 +99,6 @@ export const config = new ConfigBuilder()
           pollingInterval: 1000,
           delayMs: 18000,
           indexer: midnightNetworkConfig.indexer,
-          indexerWs: midnightNetworkConfig.indexerWS,
         }),
       )
   )

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/midnight/graphql.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/midnight/graphql.ts
@@ -30,7 +30,6 @@ export const ConfigSyncProtocolSchemaMidnightBase = NameField.cloneMerge(
     // note: node URL and proof server are not needed for read-only use
   }),
   optional: Type.Object({
-    indexerWS: TypeboxHelpers.Nullable(Type.String(), { default: null }),
     stepSize: Type.Number({ default: 10 }),
     paginationLimit: Type.Number({ default: 50 }),
   }),

--- a/templates/evm-midnight-v2/packages/node/config.dev.ts
+++ b/templates/evm-midnight-v2/packages/node/config.dev.ts
@@ -96,7 +96,6 @@ export const config = new ConfigBuilder()
           startBlockHeight: 1,
           pollingInterval: 1000,
           indexer: midnightNetworkConfig.indexer,
-          indexerWs: midnightNetworkConfig.indexerWS,
         }),
       )
   )

--- a/templates/evm-midnight-v2/packages/node/config.mainnet.ts
+++ b/templates/evm-midnight-v2/packages/node/config.mainnet.ts
@@ -137,7 +137,6 @@ export const config = new ConfigBuilder()
           delayMs: 60000,
           stepSize: 2,
           indexer: midnightNetworkConfig.indexer,
-          indexerWs: midnightNetworkConfig.indexerWS,
         }),
       )
   )

--- a/templates/night-bitcoin-v2/packages/node/config.dev.ts
+++ b/templates/night-bitcoin-v2/packages/node/config.dev.ts
@@ -90,7 +90,6 @@ export const config = new ConfigBuilder()
           pollingInterval: 1000,
           delayMs: 18000,
           indexer: midnightNetworkConfig.indexer,
-          indexerWS: midnightNetworkConfig.indexerWS,
         }),
       )
       .addParallel(

--- a/templates/night-bitcoin-v2/packages/node/config.mainnet.ts
+++ b/templates/night-bitcoin-v2/packages/node/config.mainnet.ts
@@ -130,7 +130,6 @@ export const config = new ConfigBuilder()
           delayMs: 60000,
           stepSize: 2,
           indexer: midnightNetworkConfig.indexer,
-          indexerWs: midnightNetworkConfig.indexerWS,
         }),
       )
       .addParallel(

--- a/templates/zk-cardano/packages/node/config.dev.ts
+++ b/templates/zk-cardano/packages/node/config.dev.ts
@@ -106,7 +106,6 @@ export const config = new ConfigBuilder()
           startBlockHeight: 1,
           pollingInterval: 1000,
           indexer: midnightNetworkConfig.indexer,
-          indexerWs: midnightNetworkConfig.indexerWS,
         }),
       )
   )


### PR DESCRIPTION
## Summary

A docs/code audit flagged a spelling mismatch: the Midnight GraphQL sync-protocol schema declared `indexerWS` (capital WS), while templates and the e2e config wrote `indexerWs` (lowercase s) — so the value silently fell back to the `null` default.

Investigation showed the mismatch is harmless in a deeper way: **nothing consumes the field under either spelling**. `MidnightFetcher`/`MidnightClient` are HTTP-only and read only `syncProtocol.indexer` (the `graphql-ws` import is type-only). Templates weren't even self-consistent — night-bitcoin-v2's dev config used the capital spelling, its mainnet config lowercase.

Rather than fix the spelling of a field that goes nowhere, this removes it:

- **Schema**: drop `indexerWS` from `packages/effectstream-sdk/config/src/schema/sync-protocols/midnight/graphql.ts`
- **Templates**: remove the line from evm-midnight-v2, night-bitcoin-v2 (dev + mainnet configs), and zk-cardano
- **E2E**: remove it from `e2e/midnight/config.ts`
- **Docs**: remove it from the sync-protocol examples in `202-midnight.md` and `1205-intent-swap.md`

## Deliberately untouched

- All other `indexerWS` usages (wallets, batcher adapters, faucet, `midnight-env.ts`, and related docs) — those belong to `NetworkUrls`/adapter configs where the websocket URL **is** genuinely used.
- The legacy `multi-chain-token-transfer` template (still on `@paimaexample/*` 0.3.x, not migrated).

If sync ever adopts the indexer's websocket endpoint (push-based subscriptions), the field can be reintroduced alongside code that reads it.

## Testing

`bun test packages/effectstream-sdk/config packages/node-sdk/sync` — 55 pass, 0 fail.