### PR TITLE
Export NEAR batcher adapters from package root

### DIFF
--- a/docs/site/docs/home/200-chains/210-near.md
+++ b/docs/site/docs/home/200-chains/210-near.md
@@ -198,7 +198,7 @@ Two adapters ship for NEAR. Both sign locally with an Ed25519 private key (no `n
 Batches application inputs and submits them as `FunctionCall` actions to a target contract method.
 
 ```ts
-import { NearAdapter } from "@effectstream/batcher-sdk/adapters";
+import { NearAdapter } from "@effectstream/batcher-sdk";
 
 const adapter = new NearAdapter({
   rpcUrl: "https://rpc.mainnet.near.org",
@@ -219,7 +219,7 @@ const adapter = new NearAdapter({
 Submits DIP-4 cross-chain intent messages to the NEAR Intents protocol.
 
 ```ts
-import { NearIntentAdapter } from "@effectstream/batcher-sdk/adapters";
+import { NearIntentAdapter } from "@effectstream/batcher-sdk";
 
 const intentAdapter = new NearIntentAdapter({
   rpcUrl: "https://rpc.mainnet.near.org",

--- a/e2e/near/run-tests.ts
+++ b/e2e/near/run-tests.ts
@@ -39,6 +39,7 @@ import { runAccountWatchTest } from "./sync/account-watch.test.ts";
 import { runNep141Test } from "./sync/nep141.test.ts";
 import { runNep171Test } from "./sync/nep171.test.ts";
 import { runNep245Test } from "./sync/nep245.test.ts";
+import { runBatcherTest } from "./sync/batcher.test.ts";
 
 const LAUNCHER_PATH = path.resolve(import.meta.dirname!, "./launcher.cli.ts");
 
@@ -82,6 +83,9 @@ async function test() {
 
     // 3. Run tooling tests
     await runToolingTests();
+
+    // 3b. Batcher adapter tests (offline logic; no batcher service needed)
+    await runBatcherTest();
 
     // 4. Wait for sync node to be healthy
     await waitForProcess("sync");

--- a/e2e/near/sync/batcher.test.ts
+++ b/e2e/near/sync/batcher.test.ts
@@ -1,9 +1,15 @@
 /**
  * NEAR batcher adapter test.
  *
- * STATUS: STUB — requires batcher service integration
+ * STATUS: PARTIAL — offline adapter logic only
  *
- * Should verify:
+ * Constructs `NearAdapter` and `NearIntentAdapter` through the public
+ * `@effectstream/batcher-sdk` package root (guarding against the exports
+ * regressing) and validates their offline batch-building logic:
+ * batch payload construction, max-batch-size capping, fee estimation,
+ * and adapter metadata.
+ *
+ * Full service integration is still TODO and should verify:
  * 1. Start the batcher service with a NearAdapter targeting the sandbox
  * 2. Submit a signed input to the batcher HTTP API
  * 3. Verify the batcher submits a FunctionCall transaction to the sandbox
@@ -15,31 +21,124 @@
  * 7. Verify the intent adapter interacts with the Solver Bus (mock required)
  * 8. Verify settlement is monitored
  *
- * Requires:
+ * Requires (for the full integration):
  * - Batcher service running with NearAdapter configured
  * - A game contract on sandbox that accepts batched inputs
  * - For intents: a mock Solver Bus or test Solver Bus endpoint
  */
 import { assert } from "@e2e/engine";
+import {
+  NearAdapter,
+  NearIntentAdapter,
+  type DefaultBatcherInput,
+} from "@effectstream/batcher-sdk";
+import { AddressType } from "@effectstream/utils";
+
+const DEFAULT_GAS = "300000000000000"; // 300 TGas, adapter default
+
+function makeInputs(count: number): DefaultBatcherInput[] {
+  return Array.from({ length: count }, (_, i) => ({
+    addressType: AddressType.NEAR,
+    address: `player-${i}.test.near`,
+    input: JSON.stringify({ action: "move", x: i, y: i + 1 }),
+    signature: `sig-${i}`,
+    timestamp: new Date(0).toISOString(),
+    target: "near",
+  }));
+}
 
 export async function runBatcherTest(): Promise<void> {
-  // TODO: Start batcher service with NearAdapter
-  // TODO: Submit signed input via HTTP POST to batcher
-  // TODO: Verify transaction lands on-chain
-
-  await assert("NEAR Batcher — submits transaction to sandbox", async () => {
-    // const res = await fetch("http://localhost:3334/send-input", {
-    //   method: "POST",
-    //   headers: { "Content-Type": "application/json" },
-    //   body: JSON.stringify({
-    //     address: "player.test.near",
-    //     input: JSON.stringify({ action: "move", x: 1, y: 2 }),
-    //     signature: "...",
-    //     timestamp: new Date().toISOString(),
-    //     target: "near",
-    //   }),
-    // });
-    // return res.ok;
-    return true; // STUB: passes unconditionally
+  const adapter = new NearAdapter({
+    rpcUrl: "http://127.0.0.1:3030",
+    networkId: "sandbox",
+    batcherAccountId: "batcher.test.near",
+    batcherPrivateKey: "ed25519:unused-offline",
+    contractAccountId: "game.test.near",
+    contractMethod: "submitGameInputs",
+    syncProtocolName: "parallelNearRPC",
+    maxBatchSize: 2,
   });
+
+  await assert("NEAR Batcher — adapter metadata", async () => {
+    return (
+      adapter.getChainName() === "near-sandbox" &&
+      adapter.getAccountAddress() === "batcher.test.near" &&
+      adapter.getSyncProtocolName() === "parallelNearRPC" &&
+      adapter.isReady()
+    );
+  });
+
+  await assert("NEAR Batcher — buildBatchData builds FunctionCall payload", async () => {
+    const result = adapter.buildBatchData(makeInputs(1));
+    if (result == null) return false;
+    const { data, selectedInputs } = result;
+    const batch = data.args["batch"] as Array<Record<string, unknown>>;
+    return (
+      selectedInputs.length === 1 &&
+      data.contractAccountId === "game.test.near" &&
+      data.methodName === "submitGameInputs" &&
+      data.gas === DEFAULT_GAS &&
+      data.deposit === "0" &&
+      batch.length === 1 &&
+      batch[0]!["address"] === "player-0.test.near"
+    );
+  });
+
+  await assert("NEAR Batcher — buildBatchData caps at maxBatchSize", async () => {
+    const result = adapter.buildBatchData(makeInputs(5));
+    return result != null && result.selectedInputs.length === 2;
+  });
+
+  await assert("NEAR Batcher — buildBatchData returns null for empty input", async () => {
+    return adapter.buildBatchData([]) == null;
+  });
+
+  await assert("NEAR Batcher — estimateBatchFee returns attached gas", async () => {
+    const result = adapter.buildBatchData(makeInputs(1));
+    return result != null && adapter.estimateBatchFee(result.data) === DEFAULT_GAS;
+  });
+
+  const intentAdapter = new NearIntentAdapter({
+    rpcUrl: "http://127.0.0.1:3030",
+    networkId: "sandbox",
+    batcherAccountId: "solver.test.near",
+    batcherPrivateKey: "ed25519:unused-offline",
+    syncProtocolName: "parallelNearRPC",
+  });
+
+  await assert("NEAR Intent Batcher — adapter metadata", async () => {
+    return (
+      intentAdapter.getChainName() === "near-intents-sandbox" &&
+      intentAdapter.getAccountAddress() === "solver.test.near" &&
+      intentAdapter.estimateBatchFee({ intents: [], signerAccountId: "" }) === "0"
+    );
+  });
+
+  await assert("NEAR Intent Batcher — buildBatchData builds intent messages", async () => {
+    const inputs: DefaultBatcherInput[] = [
+      {
+        addressType: AddressType.NEAR,
+        address: "player.test.near",
+        input: JSON.stringify({
+          send: [{ tokenId: "usdc.test.near", amount: "100" }],
+          receive: [{ tokenId: "wnear.test.near", minAmount: "1" }],
+        }),
+        timestamp: new Date(0).toISOString(),
+        target: "near",
+      },
+    ];
+    const result = intentAdapter.buildBatchData(inputs);
+    if (result == null) return false;
+    const intent = result.data.intents[0]!;
+    return (
+      result.data.signerAccountId === "solver.test.near" &&
+      intent.signerId === "player.test.near" &&
+      intent.send.length === 1 &&
+      intent.receive.length === 1 &&
+      BigInt(intent.expirationNs) > 0n
+    );
+  });
+
+  // TODO: full integration — start batcher service with NearAdapter, submit a
+  // signed input via HTTP POST, and verify the transaction lands on the sandbox.
 }

--- a/packages/batcher/mod.ts
+++ b/packages/batcher/mod.ts
@@ -61,6 +61,18 @@ export type {
   SolanaBatchPayload,
 } from "./adapters/solana-adapter.ts";
 
+export { NearAdapter } from "./adapters/near-adapter.ts";
+export type {
+  NearAdapterConfig,
+  NearBatchPayload,
+} from "./adapters/near-adapter.ts";
+
+export { NearIntentAdapter } from "./adapters/near-intent-adapter.ts";
+export type {
+  NearIntentAdapterConfig,
+  NearIntentBatch,
+} from "./adapters/near-intent-adapter.ts";
+
 
 // Rate limiting
 export type {


### PR DESCRIPTION
## Summary

`NearAdapter` and `NearIntentAdapter` were implemented and re-exported from `adapters/mod.ts`, but never from the package root `mod.ts`. Since `package.json` `exports` only exposes the root entrypoint, there was no way to import them from `@effectstream/batcher-sdk` at all.

- Export `NearAdapter`, `NearIntentAdapter`, and their config/payload types (`NearAdapterConfig`, `NearBatchPayload`, `NearIntentAdapterConfig`, `NearIntentBatch`) from `packages/batcher/mod.ts`, following the existing Celestia/Solana pattern
- Fix the two import lines in `docs/site/docs/home/200-chains/210-near.md` to import from the package root instead of the unresolvable `@effectstream/batcher-sdk/adapters` subpath
- Replace the always-passing `e2e/near/sync/batcher.test.ts` stub with offline adapter-logic tests that import through the package root (so the exports can't silently regress again), and wire `runBatcherTest` into the NEAR e2e runner — it was previously never invoked

Full batcher-service integration for the NEAR e2e suite (batcher HTTP service + game contract on sandbox, like the midnight/solana/evm suites have) is left as a TODO in the test file.

## Test plan

- [x] New NEAR batcher adapter tests pass standalone (7/7 assertions)
- [x] `bun test ./packages/batcher` — 48 pass, 0 fail
- [x] `tsc` over edited files shows no new type errors