### PR TITLE
fix(templates): repair broken dev launch and silently-dropped batched inputs

### DIFF
--- a/templates/batcher-validations/bun.lock
+++ b/templates/batcher-validations/bun.lock
@@ -76,6 +76,7 @@
         "typescript": "^5.5.0",
         "vite": "^6.2.0",
         "vite-plugin-node-stdlib-browser": "^0.2.1",
+        "vite-plugin-wasm": "^3.5.0",
       },
     },
     "packages/node": {
@@ -2093,6 +2094,8 @@
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-plugin-node-stdlib-browser": ["vite-plugin-node-stdlib-browser@0.2.1", "", { "dependencies": { "@rollup/plugin-inject": "^5.0.3" }, "peerDependencies": { "node-stdlib-browser": "^1.2.0", "vite": "^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-6u2i613Dkqj5KaTNIrnZvE6y3/awWAp0S5TjucTvGxdhetftB1Mgvblc+nwYzlw6sntPlac8UOC7ttXNh+LZKA=="],
+
+    "vite-plugin-wasm": ["vite-plugin-wasm@3.6.0", "", { "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw=="],
 
     "vlq": ["vlq@2.0.4", "", {}, "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="],
 

--- a/templates/batcher-validations/packages/batcher/batcher.dev.ts
+++ b/templates/batcher-validations/packages/batcher/batcher.dev.ts
@@ -21,7 +21,10 @@ const config: BatcherConfig = {
   pollingIntervalMs: batchIntervalMs,
   adapters: { paimaL2 },
   defaultTarget: "paimaL2",
-  namespace: "",
+  // Must match the node's setSecurityNamespace(...) and the frontend's
+  // EffectstreamConfig namespace — the sync-side L2 primitive re-verifies
+  // batched signatures against only the configured namespace.
+  namespace: "batcher-validations",
   batchingCriteria: {
     paimaL2: { criteriaType: "time", timeWindowMs: batchIntervalMs },
   },

--- a/templates/batcher-validations/packages/frontend/client/src/config.ts
+++ b/templates/batcher-validations/packages/frontend/client/src/config.ts
@@ -2,7 +2,12 @@ import { EffectstreamConfig } from "@effectstream/wallets";
 import { hardhat } from "viem/chains";
 
 export const paimaConfig = new EffectstreamConfig(
-  "",
+  // Must match BOTH the batcher's `namespace` and the node's
+  // setSecurityNamespace(...). The sync-side L2 primitive re-verifies batched
+  // signatures with getReadNamespaces(securityNamespace), which returns ONLY
+  // the configured namespace — an empty value here makes every batched input
+  // fail verification and get silently dropped.
+  "batcher-validations",
   "mainEvmRPC",
   "0x5FbDB2315678afecb367f032d93F642f64180aa3",
   hardhat,

--- a/templates/batcher-validations/packages/frontend/package.json
+++ b/templates/batcher-validations/packages/frontend/package.json
@@ -18,6 +18,7 @@
     "vite": "^6.2.0",
     "@vitejs/plugin-react": "^4.3.0",
     "vite-plugin-node-stdlib-browser": "^0.2.1",
+    "vite-plugin-wasm": "^3.5.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.5.0"

--- a/templates/batcher-validations/packages/frontend/vite.config.ts
+++ b/templates/batcher-validations/packages/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import nodePolyfills from "vite-plugin-node-stdlib-browser";
+import wasm from "vite-plugin-wasm";
 
 export default defineConfig({
   root: path.resolve(import.meta.dirname!, "client"),
@@ -61,5 +62,6 @@ export default defineConfig({
         "node:fs": "memfs",
       },
     }),
+    wasm(),
   ],
 });

--- a/templates/chess-v2/packages/batcher/batcher.dev.ts
+++ b/templates/chess-v2/packages/batcher/batcher.dev.ts
@@ -18,7 +18,10 @@ const config: BatcherConfig = {
   pollingIntervalMs: batchIntervalMs,
   adapters: { paimaL2 },
   defaultTarget: "paimaL2",
-  namespace: "",
+  // Must match the node's setSecurityNamespace(...) and the frontend's
+  // EffectstreamConfig namespace — the sync-side L2 primitive re-verifies
+  // batched signatures against only the configured namespace.
+  namespace: "chess-v2",
   batchingCriteria: {
     paimaL2: { criteriaType: "time", timeWindowMs: batchIntervalMs },
   },

--- a/templates/chess-v2/packages/frontend/client/src/PaimaEngineConfig.ts
+++ b/templates/chess-v2/packages/frontend/client/src/PaimaEngineConfig.ts
@@ -3,7 +3,12 @@ import { EffectstreamConfig } from "@effectstream/wallets";
 import { BATCHER_URL } from "./config.ts";
 
 export const paimaEngineConfig = new EffectstreamConfig(
-  "",
+  // Must match BOTH the batcher's `namespace` and the node's
+  // setSecurityNamespace(...). The sync-side L2 primitive re-verifies batched
+  // signatures with getReadNamespaces(securityNamespace), which returns ONLY
+  // the configured namespace — an empty value here makes every batched input
+  // fail verification and get silently dropped.
+  "chess-v2",
   "mainEvmRPC",
   "0x5FbDB2315678afecb367f032d93F642f64180aa3",
   hardhat,

--- a/templates/night-bitcoin-v2/packages/batcher/batcher.dev.ts
+++ b/templates/night-bitcoin-v2/packages/batcher/batcher.dev.ts
@@ -24,7 +24,11 @@ const adapter = new MidnightBalancingAdapter(walletSeed, {
 const config: BatcherConfig<DefaultBatcherInput> = {
   pollingIntervalMs: batcherConfig.pollingIntervalMs,
   enableHttpServer: true,
-  namespace: "",
+  // Must match the node's setSecurityNamespace(...) and the frontend's
+  // EffectstreamConfig namespace (both "night-bitcoin"). Batched signatures are
+  // re-verified against only the configured namespace, so a mismatch here makes
+  // every batched input fail verification and be silently dropped.
+  namespace: "night-bitcoin",
   confirmationLevel: "wait-receipt",
   enableEventSystem: false,
   port: batcherConfig.port,

--- a/templates/shinkai-v2/bun.lock
+++ b/templates/shinkai-v2/bun.lock
@@ -73,6 +73,7 @@
         "typescript": "^5.5.0",
         "vite": "^6.2.0",
         "vite-plugin-node-stdlib-browser": "^0.2.1",
+        "vite-plugin-wasm": "^3.5.0",
       },
     },
     "packages/node": {
@@ -2026,6 +2027,8 @@
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-plugin-node-stdlib-browser": ["vite-plugin-node-stdlib-browser@0.2.1", "", { "dependencies": { "@rollup/plugin-inject": "^5.0.3" }, "peerDependencies": { "node-stdlib-browser": "^1.2.0", "vite": "^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-6u2i613Dkqj5KaTNIrnZvE6y3/awWAp0S5TjucTvGxdhetftB1Mgvblc+nwYzlw6sntPlac8UOC7ttXNh+LZKA=="],
+
+    "vite-plugin-wasm": ["vite-plugin-wasm@3.6.0", "", { "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw=="],
 
     "vlq": ["vlq@2.0.4", "", {}, "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="],
 

--- a/templates/shinkai-v2/packages/batcher/batcher.dev.ts
+++ b/templates/shinkai-v2/packages/batcher/batcher.dev.ts
@@ -19,9 +19,10 @@ const config: BatcherConfig = {
   adapters: { paimaL2 },
   defaultTarget: "paimaL2",
   // Must match what the sync-side `EffectstreamL2Primitive` uses to re-verify
-  // signatures. The SDK currently hardcodes namespace = null there, so we sign
-  // and verify with an empty namespace end-to-end until the SDK exposes it.
-  namespace: "",
+  // signatures — i.e. the node's setSecurityNamespace(...) — and the frontend's
+  // NAMESPACE. getReadNamespaces() returns only the configured namespace, so a
+  // mismatch here makes every batched input fail verification and be dropped.
+  namespace: "shinkai-v2",
   batchingCriteria: {
     paimaL2: { criteriaType: "time", timeWindowMs: batchIntervalMs },
   },

--- a/templates/shinkai-v2/packages/frontend/client/src/config.ts
+++ b/templates/shinkai-v2/packages/frontend/client/src/config.ts
@@ -3,10 +3,12 @@ import { arbitrum, hardhat } from "viem/chains";
 
 const BATCHER_URL = import.meta.env.VITE_BATCHER_URL ?? "http://localhost:3334";
 const L2_ADDRESS = import.meta.env.VITE_L2_ADDRESS ?? "0x0000000000000000000000000000000000000000";
-// Empty namespace — must match the batcher and the sync-side L2 primitive,
-// which currently hardcodes namespace = null when reconstructing the signed
-// message for verification.
-const NAMESPACE = import.meta.env.VITE_NAMESPACE ?? "";
+// Must match BOTH the batcher's `namespace` and the node's
+// `setSecurityNamespace(...)`. The sync-side L2 primitive re-verifies batched
+// signatures with getReadNamespaces(securityNamespace), which returns ONLY the
+// configured namespace — an empty value here makes every batched input fail
+// verification and get silently dropped.
+const NAMESPACE = import.meta.env.VITE_NAMESPACE ?? "shinkai-v2";
 const CHAIN = import.meta.env.MODE === "mainnet" ? arbitrum : hardhat;
 
 export const SOCIAL_WALLET_URL =

--- a/templates/shinkai-v2/packages/frontend/package.json
+++ b/templates/shinkai-v2/packages/frontend/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite --mode dev",
-    "build": "NODE_OPTIONS=--max-old-space-size=1024 vite build --mode dev",
-    "build:dev": "NODE_OPTIONS=--max-old-space-size=1024 vite build --mode dev",
-    "build:mainnet": "NODE_OPTIONS=--max-old-space-size=1024 vite build --mode mainnet",
+    "build": "NODE_OPTIONS=--max-old-space-size=2048 vite build --mode dev",
+    "build:dev": "NODE_OPTIONS=--max-old-space-size=2048 vite build --mode dev",
+    "build:mainnet": "NODE_OPTIONS=--max-old-space-size=2048 vite build --mode mainnet",
     "serve": "bun run server/main.ts"
   },
   "dependencies": {
@@ -20,6 +20,7 @@
   "devDependencies": {
     "vite": "^6.2.0",
     "vite-plugin-node-stdlib-browser": "^0.2.1",
+    "vite-plugin-wasm": "^3.5.0",
     "typescript": "^5.5.0"
   }
 }

--- a/templates/shinkai-v2/packages/frontend/vite.config.ts
+++ b/templates/shinkai-v2/packages/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import path from "path";
 import nodePolyfills from "vite-plugin-node-stdlib-browser";
+import wasm from "vite-plugin-wasm";
 
 export default defineConfig({
   root: path.resolve(import.meta.dirname!, "client"),
@@ -79,5 +80,6 @@ export default defineConfig({
         "node:fs": "memfs",
       },
     }),
+    wasm(),
   ],
 });


### PR DESCRIPTION
Follow-up to #835 — these two commits were pushed after that PR merged, so they never landed.

Both bugs were found by manually browser-testing all 14 enabled templates one at a time. Neither is visible to CI, for the same underlying reason: **the template test suites never build the frontend and never exercise browser signing.** Every affected template's suite passes green.

## 1. `vite-plugin-wasm` missing — `bun run dev` completely broken

`shinkai-v2` and `batcher-validations` could not start at all. The frontend build died on `@midnight-ntwrk/ledger-v8`'s wasm and took the whole orchestrator down with it:

```
[vite:wasm-fallback] Could not load .../midnight_ledger_wasm_bg.wasm
"ESM integration proposal for Wasm" is not supported currently.
Use vite-plugin-wasm or other community plugins to handle this.
```

Same fix `chess-v2` already received in a3834d8c. ledger-v8 arrives transitively in both. Seven other templates already carry the plugin — these two were missed.

`shinkai-v2` additionally needed its Node heap cap raised **1GB → 2GB**: bundling the wasm peaks at ~2.1GB RSS. Note this is in tension with 6f3271e6, which deliberately lowered it to 1GB to avoid OOM swap on constrained servers — 2048 is the minimum that builds, and `minify` was already disabled there. If those constrained servers still matter, the alternative is externalizing ledger-v8 rather than inlining it, which is a larger change.

## 2. Batched inputs silently dropped — namespace mismatch

The nastier one. The user signs, the batcher submits, the transaction confirms on-chain with the correct contract, selector and event — and **nothing reaches the state machine**. `rollup_inputs` stays empty and nothing is logged anywhere.

`EffectstreamL2Primitive` re-verifies each batched signature against `getReadNamespaces(securityNamespace)`, which returns **only** the configured namespace. The frontend and batcher signed with `""` while the node declared a real one, so verification failed and the primitive dropped the input on its silent path — precisely what its own comment warns about.

Verified against a real on-chain signature captured from shinkai-v2:

| namespace signed with | verifies |
|---|---|
| `null` / `""` | ✅ |
| `"shinkai-v2"` | ❌ |

Comments in the frontend and batcher claimed the SDK "hardcodes namespace = null" when reconstructing the message. That is no longer true as of 0.102.0 — those comments are updated to state what actually has to match.

All three sides now agree per template:

| template | frontend | batcher | node |
|---|---|---|---|
| shinkai-v2 | `""` → `shinkai-v2` | `""` → `shinkai-v2` | `shinkai-v2` |
| batcher-validations | `""` → `batcher-validations` | `""` → `batcher-validations` | `batcher-validations` |
| chess-v2 | `""` → `chess-v2` | `""` → `chess-v2` | `chess-v2` |
| night-bitcoin-v2 | already `night-bitcoin` | `""` → `night-bitcoin` | `night-bitcoin` |

**Unaffected, and checked rather than assumed:** `hex-battle` and `world-map-2d` pass `batcherURL: undefined, preferBatchedMode: false` and submit directly — the direct path does not re-verify against a namespace, so their `-node` suffix mismatch is harmless. `preorder` uses no batcher at all, which is exactly why it worked throughout.

## Verification

Confirmed working in a real browser for **shinkai-v2**, **batcher-validations** and **chess-v2** — three independent confirmations of the namespace fix.

> [!NOTE]
> **night-bitcoin-v2's namespace fix is by inspection only** — it launches cleanly and its wiring now matches, but it was deferred from the manual pass and has not been browser-tested.

Full manual results: 13 of 14 templates tested, 12 working, 1 deferred (night-bitcoin-v2).

## Known issues NOT addressed here

- **Midnight indexer dies ~82 min in** (reproduced twice, identical interval) inside `spo_indexer::process_next_epoch`, and the orchestrator never notices because `midnight-indexer` isn't `critical` and its readiness gate is a one-shot `wait-on tcp:8088`. Surfaces as `Wallet sync timeout after 300000ms`. Engine bug, tracked separately.
- **preorder UI**: "End campaign" shows for already-ended campaigns; "Add new product" accepts an empty name.
- **shinkai-v2 startup race** (seen once): `generate-evm-mod` ran while `deploy-evm-contracts` was still in `deploy:clean` and hit `ENOENT: ./ignition/deployments`.