### PR TITLE
fix(batcher): harden midnight-balancing pipeline against the dust doom loop

### DIFF
--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -79,12 +79,31 @@ export interface MidnightBalancingAdapterConfig {
   // Maximum number of worker slots (concurrent txs) per wallet. Defaults to 1.
   // Regardless of how many dust UTXOs a wallet has, at most this many will be used in parallel.
   maxSlotsPerWallet?: number;
+  // How long to wait for a spendable dust coin before letting the balance
+  // attempt proceed (and likely fail + re-queue). Defaults to 60s.
+  dustWaitTimeoutMs?: number;
+  // A dust coin only counts as spendable when its GENERATED value covers the
+  // wallet's fee + per-coin overhead margin. Defaults to 1.5 × the 0.3 DUST
+  // overhead (coins exist with ~0 generated value right after creation — a
+  // bare `availableCoins.length > 0` check passes while balancing is doomed).
+  minSpendableDustPerCoin?: bigint;
+  // Reject inputs whose serialized payload exceeds this many characters at
+  // intake (pre-queue). Defaults to 500k chars (~250 KB of tx bytes) — well
+  // above any legitimate balanced+padded tx, well below abuse territory.
+  maxInputChars?: number;
 }
 
 const TTL_DURATION_MS = 60 * 60 * 1000;
 const SUBMIT_TX_TIMEOUT_MS = 90 * 1000;
 const SPECKS_PER_DUST = 1_000_000_000_000_000n; // 1 DUST = 10^15 Specks
 const DUST_REGISTRATION_PRECHECK_TIMEOUT_MS = 60_000;
+// Wallet-side per-coin fee margin (additionalFeeOverhead) is 0.3 DUST; a coin
+// below that generated value cannot be selected by the SDK's balancer.
+const DUST_FEE_OVERHEAD_SPECKS = 300_000_000_000_000n;
+const DEFAULT_MIN_SPENDABLE_DUST = (DUST_FEE_OVERHEAD_SPECKS * 3n) / 2n;
+const DEFAULT_MAX_INPUT_CHARS = 500_000;
+/** Throttle for background dust-state refreshes triggered by capacity checks. */
+const DUST_REFRESH_THROTTLE_MS = 5_000;
 const createTtl = (): Date => new Date(Date.now() + TTL_DURATION_MS);
 
 function formatDust(specks: bigint): string {
@@ -141,6 +160,12 @@ interface DelegatedBatchData {
   traceInfos: TxTraceInfo[];
   /** Batch sequence number. */
   batchId: number;
+  /** Inputs whose payload failed to deserialize. They are included in
+   *  selectedInputs (reserved) and spliced out at submit time so the
+   *  processor's failure path increments their retry counts — a poison input
+   *  is retried a bounded number of times and then dropped WITH a log,
+   *  instead of being skipped-but-kept forever. */
+  invalidInputs: DefaultBatcherInput[];
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +197,10 @@ export class MidnightBalancingAdapter
   private availableDustUtxoCounts: (number | null)[];
   /** Tracks wallets that recently failed due to missing dust. Cleared when dust is confirmed available. */
   private walletDustExhausted: boolean[];
+  /** Timestamp of the last background dust-state refresh (throttling). */
+  private lastDustRefreshAt = 0;
+  /** True while a background dust refresh is in flight. */
+  private dustRefreshInFlight = false;
 
   /** Worker pool — initialized with 0 slots, updated per wallet after init. */
   private readonly pool: WorkerPool;
@@ -503,7 +532,76 @@ export class MidnightBalancingAdapter
 
   hasAvailableCapacity(): boolean {
     if (!this.isReady()) return false;
-    return this.pool.hasAvailableWorker();
+    if (!this.pool.hasAvailableWorker()) return false;
+    // Dust-aware gate: when every initialized wallet is known to be out of
+    // spendable dust, report no capacity so the poll loop SKIPS the target —
+    // inputs stay queued (no retry burn, no doomed 60s waits). A throttled
+    // background refresh flips the flags back as coins regain value.
+    const allExhausted = this.walletInitialized.every(
+      (ok, i) => !ok || this.walletDustExhausted[i],
+    );
+    if (allExhausted) {
+      this.maybeRefreshDustState();
+      return false;
+    }
+    return true;
+  }
+
+  /** Throttled background re-read of every wallet's dust state. */
+  private maybeRefreshDustState(): void {
+    const now = Date.now();
+    if (this.dustRefreshInFlight || now - this.lastDustRefreshAt < DUST_REFRESH_THROTTLE_MS) {
+      return;
+    }
+    this.dustRefreshInFlight = true;
+    this.lastDustRefreshAt = now;
+    void (async () => {
+      try {
+        for (let i = 0; i < this.walletSeeds.length; i++) {
+          if (!this.walletInitialized[i]) continue;
+          const info = await this.getSpendableDustInfo(i);
+          const wasExhausted = this.walletDustExhausted[i];
+          this.availableDustUtxoCounts[i] = info.total;
+          this.walletDustExhausted[i] = info.spendable === 0;
+          if (wasExhausted && info.spendable > 0) {
+            this.log.log(
+              `Wallet ${i + 1}/${this.walletSeeds.length}: dust recovered ` +
+                `(${info.spendable}/${info.total} spendable coins) — resuming`,
+            );
+          }
+        }
+      } catch {
+        // ignore — next capacity check retries
+      } finally {
+        this.dustRefreshInFlight = false;
+      }
+    })();
+  }
+
+  /**
+   * Count dust coins whose GENERATED value can actually pay a fee. The SDK's
+   * balancer selects coins by value ≥ fee + overhead margin; a freshly created
+   * coin exists with ~0 generated value, so a bare count is NOT a readiness
+   * signal (grand-e2e root cause: gate passed on count, balance failed on value).
+   */
+  private async getSpendableDustInfo(
+    walletIndex: number,
+  ): Promise<{ total: number; spendable: number; values: bigint[] }> {
+    const wr = this.walletResults[walletIndex];
+    if (!wr) return { total: 0, spendable: 0, values: [] };
+    const minValue = this.config.minSpendableDustPerCoin ?? DEFAULT_MIN_SPENDABLE_DUST;
+    const dustState = await getInitialDustState(
+      wr.wallet.dust as { state: Rx.Observable<unknown> },
+      { timeoutMs: 30_000 },
+    );
+    const coins = (dustState as { availableCoins?: Array<{ generatedNow?: bigint | string }> })
+      .availableCoins ?? [];
+    const values = coins.map((c) => BigInt(c.generatedNow ?? 0));
+    return {
+      total: coins.length,
+      spendable: values.filter((v) => v >= minValue).length,
+      values,
+    };
   }
 
   isFullyIdle(): boolean {
@@ -654,24 +752,33 @@ export class MidnightBalancingAdapter
     const selectedInputs: DefaultBatcherInput[] = [];
     const workerAssignments: { walletIdx: number; slotIdx: number }[] = [];
     const traceInfos: TxTraceInfo[] = [];
+    const invalidInputs: DefaultBatcherInput[] = [];
 
-    // Prefer wallets that are known to have dust. Falls back to exhausted
-    // wallets if all are exhausted (the pipeline will wait for regeneration).
+    // Only assign workers from wallets known to have spendable dust.
+    // (No fallback to exhausted wallets — hasAvailableCapacity() gates the
+    // all-exhausted case, so inputs simply stay queued until dust recovers.)
     const dustFilter = (walletIdx: number): boolean =>
       !this.walletDustExhausted[walletIdx];
 
     for (const input of availableInputs) {
-      const worker = this.pool.acquireWorker(dustFilter);
-      if (!worker) break; // no free workers
-
+      // Deserialize BEFORE acquiring a worker. Failures are selected as
+      // invalid (no worker) so the processor increments their retries and
+      // eventually drops them with a log — never skipped-but-kept forever.
       let entry: DelegatedTxEntry;
       try {
         entry = this.deserializeTxEntry(input);
       } catch (error) {
-        this.pool.releaseWorker(worker.walletIdx, worker.slotIdx);
-        this.log.error(`Deserialize failed for ${input.target}: ${error}`);
-        continue; // skip bad input, try next
+        this.log.warn(
+          `Deserialize failed for #${inputContentHash(input.input)} ` +
+            `(retry=${input.retryCount ?? 0}) — marking failed: ${error}`,
+        );
+        invalidInputs.push(input);
+        selectedInputs.push(input);
+        continue;
       }
+
+      const worker = this.pool.acquireWorker(dustFilter);
+      if (!worker) break; // no free workers
 
       const txIdx = txs.length + 1;
       txs.push(entry);
@@ -687,7 +794,7 @@ export class MidnightBalancingAdapter
       });
     }
 
-    if (txs.length === 0) return null;
+    if (txs.length === 0 && invalidInputs.length === 0) return null;
 
     // Mark inputs as in-flight and snapshot the keys (synchronous)
     const reservedInputKeys: string[] = [];
@@ -703,11 +810,13 @@ export class MidnightBalancingAdapter
       return `${t.label}/W${wa.walletIdx + 1}:s${wa.slotIdx} #${t.contentHash}${retry}`;
     }).join(", ");
     this.log.log(
-      `Built batch B${String(batchId).padStart(2, "0")}: ${txs.length} tx(s) [${assignments}] [pool: ${this.pool.getStatus()}]`,
+      `Built batch B${String(batchId).padStart(2, "0")}: ${txs.length} tx(s) [${assignments}]` +
+        (invalidInputs.length > 0 ? ` + ${invalidInputs.length} invalid input(s)` : "") +
+        ` [pool: ${this.pool.getStatus()}]`,
     );
     return {
       selectedInputs,
-      data: { txs, selectedInputs, workerAssignments, reservedInputKeys, traceInfos, batchId },
+      data: { txs, selectedInputs, workerAssignments, reservedInputKeys, traceInfos, batchId, invalidInputs },
     };
   }
 
@@ -728,36 +837,39 @@ export class MidnightBalancingAdapter
    */
   private async waitForDustAvailability(
     walletIndex: number,
-    timeoutMs: number = 60_000,
+    timeoutMs?: number,
   ): Promise<void> {
+    const effectiveTimeoutMs = timeoutMs ?? this.config.dustWaitTimeoutMs ?? 60_000;
     const walletResult = this.walletResults[walletIndex];
     if (!walletResult) return;
     const label = `${walletIndex + 1}/${this.walletSeeds.length}`;
 
+    // Value-aware gate: a coin only counts when its generated value covers
+    // fee + overhead — never a bare availableCoins.length check.
     try {
-      const dustState = await getInitialDustState(walletResult.wallet.dust);
-      if ((dustState.availableCoins?.length ?? 0) > 0) {
+      const info = await this.getSpendableDustInfo(walletIndex);
+      if (info.spendable > 0) {
         this.walletDustExhausted[walletIndex] = false;
         return;
       }
+      this.log.log(
+        `Wallet ${label}: no SPENDABLE dust (${info.total} coins, values=[${
+          info.values.map(formatDust).join(", ")
+        }] DUST), waiting up to ${effectiveTimeoutMs}ms...`,
+      );
     } catch {
       return;
     }
 
-    this.log.log(
-      `Wallet ${label}: no dust UTXOs yet, waiting up to ${timeoutMs}ms for regeneration...`,
-    );
     const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
+    while (Date.now() - start < effectiveTimeoutMs) {
       await new Promise((r) => setTimeout(r, 1_000));
       try {
-        const dustState = await getInitialDustState(
-          walletResult.wallet.dust as { state: Rx.Observable<unknown> },
-          { timeoutMs: 30_000 },
-        );
-        if (((dustState as { availableCoins?: unknown[] }).availableCoins?.length ?? 0) > 0) {
+        const info = await this.getSpendableDustInfo(walletIndex);
+        if (info.spendable > 0) {
           this.log.log(
-            `Wallet ${label}: dust available after ${Date.now() - start}ms`,
+            `Wallet ${label}: spendable dust available after ${Date.now() - start}ms ` +
+              `(${info.spendable}/${info.total} coins)`,
           );
           this.walletDustExhausted[walletIndex] = false;
           return;
@@ -768,7 +880,7 @@ export class MidnightBalancingAdapter
     }
     this.walletDustExhausted[walletIndex] = true;
     this.log.warn(
-      `Wallet ${label}: dust still unavailable after ${timeoutMs}ms, proceeding to balance (will likely fail and re-queue)`,
+      `Wallet ${label}: dust still unavailable after ${effectiveTimeoutMs}ms, proceeding to balance (will likely fail and re-queue)`,
     );
   }
 
@@ -782,9 +894,10 @@ export class MidnightBalancingAdapter
   ): Promise<BalancingRecipe> {
     const walletResult = this.walletResults[walletIndex]!;
 
-    await Rx.firstValueFrom(
-      walletResult.wallet.state().pipe(Rx.timeout(10_000)),
-    ).catch(() => {});
+    // NOTE: no facade wallet.state() read here — under dust-only sync the aux
+    // sub-wallets are suspended, so the combined observable never emits and a
+    // timeout-guarded read silently burned its full timeout on EVERY balance.
+    // waitForDustAvailability reads the dust sub-wallet state directly.
     await this.waitForDustAvailability(walletIndex);
 
     const keys = {
@@ -960,12 +1073,25 @@ export class MidnightBalancingAdapter
     this.log.log(`[${tag}] Balanced (${balanceMs}ms) — dust cost: ${formatDust(dustCost)} DUST`);
 
     // --- Phase 2: Sign + Finalize (no lock — concurrent safe) ---
+    // signRecipe failures are NOT auto-reverted by the facade (finalizeRecipe
+    // and submitTransaction are) — without an explicit revert, the dust coin
+    // booked by balanceEntry is stranded in pendingDust until the 3h grace
+    // period, permanently shrinking the fee-lane pool (grand-e2e root cause).
     const proveStart = performance.now();
-    const signedRecipe = await walletResult.wallet.signRecipe(
-      recipe,
-      (payload: Uint8Array) =>
-        walletResult.unshieldedKeystore.signData(payload),
-    );
+    let signedRecipe;
+    try {
+      signedRecipe = await walletResult.wallet.signRecipe(
+        recipe,
+        (payload: Uint8Array) =>
+          walletResult.unshieldedKeystore.signData(payload),
+      );
+    } catch (error) {
+      this.log.warn(`[${tag}] signRecipe failed — reverting booked dust: ${error}`);
+      await walletResult.wallet.revert(recipe).catch((e) =>
+        this.log.warn(`[${tag}] revert after signRecipe failure also failed: ${e}`)
+      );
+      throw error;
+    }
     const finalized = await walletResult.wallet.finalizeRecipe(signedRecipe);
     const proveMs = Math.round(performance.now() - proveStart);
     this.log.log(`[${tag}] Proved (${proveMs}ms)`);
@@ -1008,9 +1134,22 @@ export class MidnightBalancingAdapter
     this.log.log(`[${tag}] Submitting (hash: ${txHash})...`);
     const submitStart = performance.now();
 
+    // Keep a handle on the real submit promise: when the race times out we
+    // proceed optimistically (tx may still land), but if the underlying
+    // submit ultimately REJECTS, its booked dust must be reverted — otherwise
+    // the coin is stranded until the grace period.
+    const submitPromise = walletResult.wallet.submitTransaction(finalized);
+    let timedOut = false;
+    submitPromise.catch((err) => {
+      if (!timedOut) return; // non-timeout failures are handled below / by the facade
+      this.log.warn(
+        `[${tag}] submit ultimately failed after timeout — reverting booked dust: ${err}`,
+      );
+      void walletResult.wallet.revertTransaction(finalized).catch(() => {});
+    });
     try {
       await Promise.race([
-        walletResult.wallet.submitTransaction(finalized),
+        submitPromise,
         new Promise<never>((_, reject) =>
           setTimeout(
             () => reject(new Error("submitTransaction timed out")),
@@ -1084,6 +1223,26 @@ export class MidnightBalancingAdapter
   ): Promise<BlockchainHash> {
     const { txs, workerAssignments, traceInfos, batchId } = batchData;
     const bTag = `B${String(batchId).padStart(2, "0")}`;
+
+    // Fail invalid (undeserializable) inputs up front: splicing them out of
+    // selectedInputs makes the processor's diff path increment their retry
+    // counts, so they are bounded-retried and then dropped WITH a log.
+    if (batchData.invalidInputs.length > 0) {
+      const invalidSet = new Set(batchData.invalidInputs);
+      for (let i = batchData.selectedInputs.length - 1; i >= 0; i--) {
+        if (invalidSet.has(batchData.selectedInputs[i])) {
+          batchData.selectedInputs.splice(i, 1);
+        }
+      }
+      this.log.warn(
+        `[${bTag}] ${batchData.invalidInputs.length} invalid input(s) marked failed (deserialize)`,
+      );
+      if (txs.length === 0) {
+        throw new Error(
+          `All ${batchData.invalidInputs.length} inputs failed to deserialize (invalid input)`,
+        );
+      }
+    }
 
     this.log.log(
       `[${bTag}] Processing ${txs.length} tx(s) [pool: ${this.pool.getStatus()}]`,
@@ -1248,12 +1407,27 @@ export class MidnightBalancingAdapter
     return true;
   }
 
+  /**
+   * Reject oversized or undeserializable payloads at /send-input time,
+   * BEFORE they enter the queue. A hex-shape check is not enough: valid hex
+   * that is not a serialized Midnight transaction would be accepted, fail
+   * deserialization on every poll tick, and (pre-hardening) sit in the queue
+   * forever. Running the real deserializer here makes intake authoritative.
+   */
   validateInput(input: DefaultBatcherInput): ValidationResult {
+    const maxChars = this.config.maxInputChars ?? DEFAULT_MAX_INPUT_CHARS;
+    if (input.input.length > maxChars) {
+      return {
+        valid: false,
+        error: `Input too large (${input.input.length} chars, max ${maxChars})`,
+      };
+    }
     try {
       const { hex } = this.parseHexInput(input.input);
       if (!/^[0-9a-fA-F]+$/.test(hex)) {
         return { valid: false, error: "Input is not valid hex" };
       }
+      this.deserializeTxEntry(input);
       return { valid: true };
     } catch (e) {
       return {

--- a/packages/batcher/adapters/worker-pool.ts
+++ b/packages/batcher/adapters/worker-pool.ts
@@ -147,18 +147,19 @@ export class WorkerPool {
    *
    * @param walletFilter Optional predicate to exclude wallets (e.g. those
    *   without available dust). Workers whose wallet is rejected by the filter
-   *   are skipped. If all free workers are filtered out, falls back to the
-   *   unfiltered set so callers never stall permanently.
+   *   are skipped. When every free worker is filtered out, returns null —
+   *   inputs stay queued and the adapter's capacity gate decides when to
+   *   resume (deliberately no fallback: assigning a worker from a wallet
+   *   known to lack dust guarantees a doomed balance attempt).
    */
   acquireWorker(walletFilter?: (walletIdx: number) => boolean): WorkerSlot | null {
     const free = this.workers.filter((w) => !w.busy);
     if (free.length === 0) return null;
 
-    // Apply wallet filter if provided, but fall back to unfiltered set to avoid stalling.
-    let candidates = walletFilter
+    const candidates = walletFilter
       ? free.filter((w) => walletFilter(w.walletIdx))
       : free;
-    if (candidates.length === 0) candidates = free;
+    if (candidates.length === 0) return null;
 
     // Count busy workers per wallet (across ALL workers, not just free ones)
     const busyPerWallet = new Map<number, number>();

--- a/packages/batcher/core/batch-processor.ts
+++ b/packages/batcher/core/batch-processor.ts
@@ -47,8 +47,23 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         timeout: number,
       ) => Promise<{ latestBlock: number; rollup: number } | null>;
       getCallbackKey: (input: T) => string;
+      getRetryPolicy: () => { maxRetries: number; retryDelayMs: number };
+      setTargetCooldown: (target: string, ms: number) => void;
     },
   ) {}
+
+  /**
+   * Classify a batch-wide failure. INFRASTRUCTURE failures (no spendable
+   * dust, unreachable node/indexer/prover, timeouts) are conditions of the
+   * batcher's environment, not of the inputs — retrying the same inputs
+   * later will succeed, so their retry budgets must NOT be charged.
+   * Everything else is treated as an input failure.
+   */
+  static isInfraFailure(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /could not balance dust|Insufficient Funds|Unable to connect|fetch failed|ECONNREFUSED|ECONNRESET|ENOTFOUND|ETIMEDOUT|socket|network|timed? ?out|Service Unavailable|Bad Gateway|502|503|pool timed out/i
+      .test(message);
+  }
 
   async processBatchForTarget(
     adapter: BlockchainAdapter<any>,
@@ -105,16 +120,33 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       // so we need the original list to know which inputs actually failed.
       const inputsSnapshot = [...selectedInputs];
 
+      const { maxRetries, retryDelayMs } = this.batcher.getRetryPolicy();
+
       let hash: string;
       try {
         hash = await adapter.submitBatch(data, estimatedFee);
       } catch (error) {
-        // All inputs failed — increment retry counts; storage drops those that hit the limit
+        if (BatchProcessor.isInfraFailure(error)) {
+          // PARK, don't drop: the environment failed, not the inputs. Leave
+          // retry counts untouched and pause the target so the poll loop
+          // doesn't burn worker slots on a known-bad environment.
+          const cooldownMs = Math.max(retryDelayMs, 1000);
+          console.warn(
+            `[BatchProcessor] Infra failure for target ${target} — parking ` +
+              `${inputsSnapshot.length} input(s) untouched, cooldown ${cooldownMs}ms: ${
+                error instanceof Error ? error.message : error
+              }`,
+          );
+          this.batcher.setTargetCooldown(target, cooldownMs);
+          throw error;
+        }
+        // Input failure — increment retry counts; storage drops (with a
+        // warning) those that hit the configured limit.
         debugLog(
-          `[BatchProcessor] submitBatch threw for target ${target}, incrementing retry counts for ${inputsSnapshot.length} inputs`,
+          `[BatchProcessor] submitBatch threw for target ${target}, incrementing retry counts for ${inputsSnapshot.length} inputs (maxRetries=${maxRetries})`,
         );
         await this.batcher.storage
-          .incrementRetryCount(inputsSnapshot, target, 3)
+          .incrementRetryCount(inputsSnapshot, target, maxRetries)
           .catch((e) =>
             debugLog(`[BatchProcessor] Failed to increment retry counts: ${e}`)
           );
@@ -145,10 +177,10 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         const failedInputs = inputsSnapshot.filter((i) => !finalSet.has(i));
         if (failedInputs.length > 0) {
           debugLog(
-            `[BatchProcessor] Incrementing retry count for ${failedInputs.length} failed inputs`,
+            `[BatchProcessor] Incrementing retry count for ${failedInputs.length} failed inputs (maxRetries=${maxRetries})`,
           );
           await this.batcher.storage
-            .incrementRetryCount(failedInputs, target, 3)
+            .incrementRetryCount(failedInputs, target, maxRetries)
             .catch((e) =>
               debugLog(
                 `[BatchProcessor] Failed to increment retry counts: ${e}`,

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -206,6 +206,12 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
         receipt: BlockchainTransactionReceipt,
         timeout: number,
       ) => this.waitForEffectStreamProcessed(target, receipt, timeout),
+      getRetryPolicy: () => ({
+        maxRetries: this.config.maxRetries ?? 3,
+        retryDelayMs: this.config.retryDelayMs ?? 1000,
+      }),
+      setTargetCooldown: (target: string, ms: number) =>
+        this.setTargetCooldown(target, ms),
     });
     this.shutdownManager = new ShutdownManager<T>(
       {
@@ -743,11 +749,26 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
   /**
    * Check if a specific target is ready for batching based on its configured criteria
    */
+  /** Targets on an infra-failure cooldown are skipped until the deadline. */
+  private readonly targetCooldownUntil = new Map<string, number>();
+
+  /**
+   * Pause batching for a target (inputs stay queued, retry counts untouched).
+   * Used by the processor when a batch fails for INFRASTRUCTURE reasons —
+   * charging an outage against per-input retry budgets deletes user inputs.
+   */
+  setTargetCooldown(target: string, ms: number): void {
+    this.targetCooldownUntil.set(target, Date.now() + ms);
+  }
+
   private async isTargetReadyForBatching(target: string): Promise<boolean> {
     if (!this.defaultTarget) {
       // This shouldn't happen after init(), but handle gracefully
       return false;
     }
+
+    const cooldownUntil = this.targetCooldownUntil.get(target) ?? 0;
+    if (cooldownUntil > Date.now()) return false;
 
     const adapter = this.adapters[target];
 

--- a/packages/batcher/core/storage.ts
+++ b/packages/batcher/core/storage.ts
@@ -303,8 +303,10 @@ export class FileStorage<T extends DefaultBatcherInput = DefaultBatcherInput>
           }
           const newRetryCount = (input.retryCount ?? 0) + 1;
           if (newRetryCount >= maxRetries) {
-            debugLog(
-              `[Storage] Dropping input after ${newRetryCount} failed retries: ${key.substring(0, 100)}...`,
+            // Always-visible: deleting a user's input must never be silent.
+            console.warn(
+              `[Storage] DROPPING input after ${newRetryCount} failed retries ` +
+                `(address=${input.address}, target=${target}): ${key.substring(0, 100)}...`,
             );
             continue; // drop it from storage
           }

--- a/packages/batcher/test/hardening.test.ts
+++ b/packages/batcher/test/hardening.test.ts
@@ -1,0 +1,98 @@
+// Unit tests for the dust-doom-loop hardening (see templates/midnight-batcher/TESTING.md):
+//  - worker pool must NOT hand out workers from dust-exhausted wallets
+//  - infra failures must be classified (park) vs input failures (retry-charge)
+//  - storage must retry-charge and then DROP with a visible warning at the
+//    CONFIGURED limit (previously hardcoded to 3)
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { WorkerPool } from "../adapters/worker-pool.ts";
+import { BatchProcessor } from "../core/batch-processor.ts";
+import { FileStorage } from "../core/storage.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+
+describe("WorkerPool exhaustion filter", () => {
+  test("returns null when every free worker's wallet is filtered out (no fallback)", () => {
+    const pool = new WorkerPool([2, 2]); // 2 wallets × 2 slots
+    const worker = pool.acquireWorker(() => false);
+    expect(worker).toBeNull();
+  });
+
+  test("only assigns workers from wallets passing the filter", () => {
+    const pool = new WorkerPool([1, 1]);
+    const worker = pool.acquireWorker((walletIdx) => walletIdx === 1);
+    expect(worker).not.toBeNull();
+    expect(worker!.walletIdx).toBe(1);
+  });
+
+  test("still assigns freely without a filter", () => {
+    const pool = new WorkerPool([1]);
+    expect(pool.acquireWorker()).not.toBeNull();
+  });
+});
+
+describe("BatchProcessor.isInfraFailure", () => {
+  const infra = [
+    "All 5 transactions failed. First error: Insufficient Funds: could not balance dust",
+    "Unable to connect. Is the computer able to access the url?",
+    "fetch failed",
+    "connect ECONNREFUSED 127.0.0.1:8088",
+    "submitTransaction timed out",
+    "Request failed: 503 Service Unavailable",
+    "index_wallets_task failed: pool timed out while waiting for an open connection",
+  ];
+  for (const message of infra) {
+    test(`infra: ${message.slice(0, 50)}`, () => {
+      expect(BatchProcessor.isInfraFailure(new Error(message))).toBe(true);
+    });
+  }
+
+  const input = [
+    "All 1 transactions failed. First error: Invalid Transaction: Custom error: 103",
+    "Transaction failed to deserialize: unexpected byte",
+    "All 2 inputs failed to deserialize (invalid input)",
+    "txStage must be 'unproven', 'unbound', or 'finalized'",
+  ];
+  for (const message of input) {
+    test(`input: ${message.slice(0, 50)}`, () => {
+      expect(BatchProcessor.isInfraFailure(new Error(message))).toBe(false);
+    });
+  }
+});
+
+describe("FileStorage retry-then-drop honors the configured limit", () => {
+  const makeInput = (n: number): DefaultBatcherInput => ({
+    address: `addr-${n}`,
+    addressType: 5,
+    input: JSON.stringify({ tx: "aa".repeat(8) }),
+    timestamp: String(1000 + n),
+    target: "midnight-balancer",
+  } as DefaultBatcherInput);
+
+  test("input survives below maxRetries and is dropped at the limit", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "batcher-hardening-"));
+    try {
+      const storage = new FileStorage(dir);
+      await storage.init?.();
+      const input = makeInput(1);
+      await storage.addInput(input);
+
+      // maxRetries=5: four increments keep it, the fifth drops it.
+      for (let i = 0; i < 4; i++) {
+        const [current] = await storage.getAllInputs();
+        await storage.incrementRetryCount([current], "midnight-balancer", 5);
+        const remaining = await storage.getAllInputs();
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].retryCount).toBe(i + 1);
+      }
+      const [current] = await storage.getAllInputs();
+      await storage.incrementRetryCount([current], "midnight-balancer", 5);
+      expect((await storage.getAllInputs()).length).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Grand-e2e runs showed ~1000 occurrences of `Insufficient Funds: could not balance dust` from the `midnight-balancer` target: 60s wait → doomed balance attempt → re-queue → **silent input deletion after 3 retries**.

Root-caused with a Dockerized adversarial harness (13-test suite; lands separately as `templates/midnight-batcher`): **the loop never starts from load alone** — on a healthy chain a booked dust coin returns within ~1 block, and even slots==coins bursts at 3–4× overload drain cleanly. It needs a *seed*: an infrastructure failure or misprovisioning that empties the spendable pool, after which the old loop mechanics turn a transient condition into permanent input loss. We reproduced that seed live: an indexer crash (session-pool starvation) during which the unfixed batcher silently deleted 12 user inputs because the outage was charged against per-input retry budgets.

## Fixes

**Intake (`MidnightBalancingAdapter.validateInput`)**
- Size cap (`maxInputChars`, default 500k chars) + **authoritative deserialization** at `/send-input` — poison/oversized payloads get a 400 and never enter the queue. Previously a garbage-hex input was accepted, then failed deserialization on every poll tick and sat in the queue forever (observed: 82 failures in 42s, phantom pending count).

**Dust readiness**
- Value-aware gate: a coin only counts when `generatedNow ≥ minSpendableDustPerCoin` (default 1.5 × the 0.3 DUST wallet overhead; `dustWaitTimeoutMs` configurable). The old `availableCoins.length > 0` check passes on fresh ~0-value coins while balancing is guaranteed to fail.
- `hasAvailableCapacity()` is dust-aware: all wallets exhausted ⇒ target reports no capacity, inputs park with retry budgets untouched; a throttled background refresh resumes processing when coins recover.
- Worker pool no longer falls back to dust-exhausted wallets (the fallback guaranteed doomed balance attempts).

**Failure handling (`BatchProcessor`)**
- Batch-wide failures are classified: **infra** causes (dust exhaustion, unreachable node/indexer/prover, timeouts, 5xx, pool exhaustion) park inputs and put the target on a cooldown (`retryDelayMs`); only genuine input failures charge retries.
- The `maxRetries` / `retryDelayMs` config fields are now actually honored — both existed but were never read (retry limit was hardcoded to 3).
- In-queue undeserializable inputs are bounded-retried and dropped **with a visible warning**; storage drops always `console.warn` with address/target (never silent).

**Dust-leak reverts**
- `signRecipe` failure reverts the booked balancing recipe (the one pipeline step the facade does not auto-revert — a stranded coin is locked into `pendingDust` for the 3h grace period, permanently shrinking the fee-lane pool).
- The 90s submit-timeout path attaches a continuation that reverts if the underlying submit ultimately rejects.

**Performance**
- Removed a swallowed 10s `wallet.state()` read on **every** balance: under `dust-only` sync the aux sub-wallets are suspended, so the combined observable never emits and the timeout was burned each time.

## Verification

- `bun test packages/batcher/test/hardening.test.ts` — 15 new unit tests (pool filter honesty, infra-vs-input classification against real error strings, configured retry-then-drop).
- Full adversarial suite (T1–T13) against a Dockerized Midnight stack (node 1.0.0 / indexer 4.3.2 / 3× proof servers), 20 dust lanes / 20 worker slots (the exact grand-e2e slots==coins geometry), on-chain ground truth (commutative counter delta + sink wallet balance):
  - all 13 green post-fix; zero `could not balance dust`, zero silent drops
  - poison input: accepted-and-stuck → rejected 400, queue clean
  - 1MB blob: accepted → rejected 400
  - node outage recovery 699s → 92s; restart-with-queue drain 944s → 63s; duplicate handling 365s → 165s (exactly-once preserved)
  - prover-kill and submit-timeout fault injection: dust pool returns to 20/20
  - memory (docker stats per run): no regression — batcher container peak 672 MiB before vs 537–588 MiB after under the same loads

The harness (compose stack, funding bootstrap, workload generators, T1–T13 runner, memory sampling) follows in a separate PR as `templates/midnight-batcher`.